### PR TITLE
Use the PR title and number for the commit message when GHA event is pull_request

### DIFF
--- a/internal/providers/github_provider.go
+++ b/internal/providers/github_provider.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -39,6 +40,10 @@ func (cfg GitHubEnv) MakeProvider() (Provider, error) {
 		HeadCommit struct {
 			Message string `json:"message"`
 		} `json:"head_commit"`
+		PullRequest struct {
+			Number int `json:"number"`
+			Title string `json:"title"`
+		} `json:"pull_request"`
 	}{}
 
 	file, err := os.Open(cfg.EventPath)
@@ -50,7 +55,12 @@ func (cfg GitHubEnv) MakeProvider() (Provider, error) {
 		}
 	}
 
-	return cfg.MakeProviderWithoutCommitMessageParsing(eventPayloadData.HeadCommit.Message)
+	commitMessage := eventPayloadData.HeadCommit.Message
+	if cfg.EventName == "pull_request" {
+		commitMessage = fmt.Sprintf("%s (#%d)", eventPayloadData.PullRequest.Title, eventPayloadData.PullRequest.Number)
+	}
+
+	return cfg.MakeProviderWithoutCommitMessageParsing(commitMessage)
 }
 
 // this function is only here to make the provider easier to test without writing the event file to disk

--- a/internal/providers/github_provider.go
+++ b/internal/providers/github_provider.go
@@ -41,8 +41,8 @@ func (cfg GitHubEnv) MakeProvider() (Provider, error) {
 			Message string `json:"message"`
 		} `json:"head_commit"`
 		PullRequest struct {
-			Number int `json:"number"`
-			Title string `json:"title"`
+			Number int    `json:"number"`
+			Title  string `json:"title"`
 		} `json:"pull_request"`
 	}{}
 


### PR DESCRIPTION
Right now, for builds triggered from pull_request events, we don't collect a commit message and we just show N/A. This is not a trivial problem to solve, because GH does everything they can to hide the commit message from us in this case (they check out a specific ref that is different than the  head commit from the PR). There are lots of things we can do to fix this, but I think the easiest immediate UX improvement is to show the PR name and PR number as the commit message. It's a bit unfortunate that this isn't a real commit message, but given how we actually use this field in the UI that won't be problematic for now.

Push test run: https://captain.build/rwx/test_suite_summaries/390a902d-5fee-4098-bb81-6983d028a682
PR test run: https://captain.build/rwx/test_suite_summaries/ae9589cd-de37-427d-914f-8ee9cf7e517c