### PR TITLE
set delimeter from env

### DIFF
--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -103,7 +103,8 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 	}
 
 	partitionCmd.Flags().StringVar(&pArgs.delimiter, "delimiter", defaultDelimiter,
-		"the delimiter used to separate partitioned files."+"It can also be set using the env var CAPTAIN_DELIMITER.")
+		"the delimiter used to separate partitioned files.\n"+
+			"It can also be set using the env var CAPTAIN_DELIMITER.")
 
 	rootCmd.AddCommand(partitionCmd)
 	return nil

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -45,8 +45,8 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		Long: "'captain partition' can be used to split up your test suite by test file, leveraging test file timings " +
 			"recorded in captain.",
 		Example: "" +
-			"  bundle exec rspec $(captain partition --suide-id your-project-rspec --index 0 --total 2 spec/**/*_spec.rb)\n" +
-			"  bundle exec rspec $(captain partition --suide-id your-project-rspec --index 1 --total 2 spec/**/*_spec.rb)",
+			"  bundle exec rspec $(captain partition your-project-rspec --index 0 --total 2 spec/**/*_spec.rb)\n" +
+			"  bundle exec rspec $(captain partition your-project-rspec --index 1 --total 2 spec/**/*_spec.rb)",
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,
 		PreRunE: initCLIService(cliArgs, func(p providers.Provider) error {

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -97,7 +97,13 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 	// it's a smell that we're using cliArgs here but I believe it's a major refactor to stop doing that.
 	addShaFlag(partitionCmd, &cliArgs.GenericProvider.Sha)
 
-	partitionCmd.Flags().StringVar(&pArgs.delimiter, "delimiter", " ", "the delimiter used to separate partitioned files")
+	defaultDelimiter := os.Getenv("CAPTAIN_DELIMITER")
+	if defaultDelimiter == "" {
+		defaultDelimiter = " "
+	}
+
+	partitionCmd.Flags().StringVar(&pArgs.delimiter, "delimiter", defaultDelimiter,
+		"the delimiter used to separate partitioned files."+"It can also be set using the env var CAPTAIN_DELIMITER.")
 
 	rootCmd.AddCommand(partitionCmd)
 	return nil

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -48,6 +48,49 @@ var _ = Describe("OSS mode Integration Tests", func() {
 
 		Describe("captain partition", func() {
 			Context("without timings", func() {
+				Context("with a delimiter", func() {
+					It("sets partition 1 correctly", func() {
+						result := runCaptain(captainArgs{
+							args: []string{
+								"partition",
+								"captain-cli-functional-tests",
+								"fixtures/integration-tests/partition/x.rb",
+								"fixtures/integration-tests/partition/y.rb",
+								"fixtures/integration-tests/partition/z.rb",
+								"--index", "0",
+								"--total", "2",
+								"--delimiter", ",",
+							},
+							env: getEnvWithoutAccessToken(),
+						})
+
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
+						Expect(result.exitCode).To(Equal(0))
+					})
+
+				It("sets partition 1 correctly when delimiter is set via env var", func() {
+						env := getEnvWithoutAccessToken()
+						env["CAPTAIN_DELIMITER"] = ","
+
+						result := runCaptain(captainArgs{
+							args: []string{
+								"partition",
+								"captain-cli-functional-tests",
+								"fixtures/integration-tests/partition/x.rb",
+								"fixtures/integration-tests/partition/y.rb",
+								"fixtures/integration-tests/partition/z.rb",
+								"--index", "0",
+								"--total", "2",
+							},
+							env: env,
+						})
+
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
+						Expect(result.exitCode).To(Equal(0))
+					})
+				})
 				It("sets partition 1 correctly", func() {
 					result := runCaptain(captainArgs{
 						args: []string{


### PR DESCRIPTION
in line with other params, delimiter also accepts params from env

maybe we want to have this more automatic? E.g. a helper function that also sets the env var.