### PR TITLE
title falls back to first line of commit message

### DIFF
--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -85,11 +85,11 @@ func initCLIService(
 			logger = logging.NewDebugLogger()
 		}
 
-		providerAdapter, err := cfg.ProvidersEnv.MakeProvider()
+		provider, err := cfg.ProvidersEnv.MakeProvider()
 		if err != nil {
-			return errors.WithDecoration(errors.Wrap(err, "failed to construct provider adapter"))
+			return errors.WithDecoration(errors.Wrap(err, "failed to construct provider"))
 		}
-		err = providerValidator(providerAdapter)
+		err = providerValidator(provider)
 		if err != nil {
 			return errors.WithDecoration(err)
 		}
@@ -103,7 +103,7 @@ func initCLIService(
 				Insecure: cfg.Cloud.Insecure,
 				Log:      logger,
 				Token:    cfg.Secrets.APIToken,
-				Provider: providerAdapter,
+				Provider: provider,
 			})
 		} else {
 			var flakesFilePath, quarantinesFilePath, timingsFilePath string

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -85,7 +85,7 @@ func initCLIService(
 			logger = logging.NewDebugLogger()
 		}
 
-		providerAdapter, err := cfg.ProvidersEnv.MakeProviderAdapter()
+		providerAdapter, err := cfg.ProvidersEnv.MakeProvider()
 		if err != nil {
 			return errors.WithDecoration(errors.Wrap(err, "failed to construct provider adapter"))
 		}

--- a/internal/providers/buildkite_provider.go
+++ b/internal/providers/buildkite_provider.go
@@ -1,8 +1,6 @@
 package providers
 
 import (
-	"strings"
-
 	"github.com/rwx-research/captain-cli/internal/errors"
 )
 
@@ -43,7 +41,6 @@ func (cfg BuildkiteEnv) MakeProvider() (Provider, error) {
 		CommitSha:     cfg.Commit,
 		JobTags:       tags,
 		ProviderName:  "buildkite",
-		Title:         strings.Split(cfg.Message, "\n")[0],
 	}
 
 	return provider, nil

--- a/internal/providers/buildkite_provider.go
+++ b/internal/providers/buildkite_provider.go
@@ -27,7 +27,7 @@ type BuildkiteEnv struct {
 	RetryCount       string `env:"BUILDKITE_RETRY_COUNT"`
 }
 
-func (cfg BuildkiteEnv) MakeProvider() (Provider, error) {
+func (cfg BuildkiteEnv) makeProvider() (Provider, error) {
 	tags, validationError := buildkiteTags(cfg)
 
 	if validationError != nil {

--- a/internal/providers/buildkite_provider_test.go
+++ b/internal/providers/buildkite_provider_test.go
@@ -7,82 +7,86 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("BuildkiteEnv.MakeProvider", func() {
-	var params providers.BuildkiteEnv
+var _ = Describe("BuildkiteEnv.makeProvider", func() {
+	var env providers.Env
 
 	BeforeEach(func() {
-		params = providers.BuildkiteEnv{
-			Branch:            "main",
-			BuildCreatorEmail: "foo@bar.com",
-			BuildID:           "1234",
-			RetryCount:        "0",
-			BuildURL:          "https://buildkit.com/builds/42",
-			Message:           "fixed it\nyeah",
-			Commit:            "abc123",
-			JobID:             "build123",
-			Label:             "lint",
-			ParallelJob:       "0",
-			ParallelJobCount:  "2",
-			OrganizationSlug:  "rwx",
-			Repo:              "git@github.com/rwx-research/captain-cli",
+		env = providers.Env{
+			Buildkite: providers.BuildkiteEnv{
+				Detected:          true,
+				Branch:            "main",
+				BuildCreatorEmail: "foo@bar.com",
+				BuildID:           "1234",
+				RetryCount:        "0",
+				BuildURL:          "https://buildkit.com/builds/42",
+				Message:           "fixed it\nyeah",
+				Commit:            "abc123",
+				JobID:             "build123",
+				Label:             "lint",
+				ParallelJob:       "0",
+				ParallelJobCount:  "2",
+				OrganizationSlug:  "rwx",
+				Repo:              "git@github.com/rwx-research/captain-cli",
+			},
 		}
 	})
 
 	It("is valid", func() {
-		provider, err := params.MakeProvider()
+		provider, err := env.MakeProvider()
 		Expect(err).To(BeNil())
 		Expect(provider.AttemptedBy).To(Equal("foo@bar.com"))
 		Expect(provider.BranchName).To(Equal("main"))
 		Expect(provider.CommitSha).To(Equal("abc123"))
 		Expect(provider.CommitMessage).To(Equal("fixed it\nyeah"))
 		Expect(provider.ProviderName).To(Equal("buildkite"))
+		Expect(provider.Title).To(Equal("fixed it"))
 	})
 
 	It("requires build id", func() {
-		params.BuildID = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.BuildID = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing build ID"))
 	})
 
 	It("requires build retry count", func() {
-		params.RetryCount = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.RetryCount = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing retry count"))
 	})
 
 	It("requires build url", func() {
-		params.BuildURL = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.BuildURL = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing build URL"))
 	})
 
 	It("requires job id", func() {
-		params.JobID = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.JobID = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing job ID"))
 	})
 
 	It("requires job name", func() {
-		params.Label = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.Label = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing label"))
 	})
 
 	It("requires buildkite org slug", func() {
-		params.OrganizationSlug = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.OrganizationSlug = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing organization slug"))
 	})
 
 	It("requires repository url", func() {
-		params.Repo = ""
-		_, err := params.MakeProvider()
+		env.Buildkite.Repo = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing repository"))
 	})
@@ -90,20 +94,23 @@ var _ = Describe("BuildkiteEnv.MakeProvider", func() {
 
 var _ = Describe("BuildkiteProvider.JobTags", func() {
 	It("constructs job tags with parallel attributes", func() {
-		provider, _ := providers.BuildkiteEnv{
-			Branch:            "main",
-			BuildCreatorEmail: "foo@bar.com",
-			BuildID:           "1234",
-			RetryCount:        "0",
-			BuildURL:          "https://buildkit.com/builds/42",
-			Message:           "fixed it",
-			Commit:            "abc123",
-			JobID:             "build123",
-			Label:             "lint",
-			ParallelJob:       "0",
-			ParallelJobCount:  "2",
-			OrganizationSlug:  "rwx",
-			Repo:              "git@github.com/rwx-research/captain-cli",
+		provider, _ := providers.Env{
+			Buildkite: providers.BuildkiteEnv{
+				Detected:          true,
+				Branch:            "main",
+				BuildCreatorEmail: "foo@bar.com",
+				BuildID:           "1234",
+				RetryCount:        "0",
+				BuildURL:          "https://buildkit.com/builds/42",
+				Message:           "fixed it",
+				Commit:            "abc123",
+				JobID:             "build123",
+				Label:             "lint",
+				ParallelJob:       "0",
+				ParallelJobCount:  "2",
+				OrganizationSlug:  "rwx",
+				Repo:              "git@github.com/rwx-research/captain-cli",
+			},
 		}.MakeProvider()
 		Expect(provider.JobTags).To(Equal(map[string]any{
 			"buildkite_retry_count":        "0",
@@ -119,20 +126,23 @@ var _ = Describe("BuildkiteProvider.JobTags", func() {
 	})
 
 	It("constructs job tags without parallel attributes", func() {
-		provider, _ := providers.BuildkiteEnv{
-			Branch:            "main",
-			BuildCreatorEmail: "foo@bar.com",
-			BuildID:           "1234",
-			RetryCount:        "0",
-			BuildURL:          "https://buildkit.com/builds/42",
-			Message:           "fixed it",
-			Commit:            "abc123",
-			JobID:             "build123",
-			Label:             "lint",
-			ParallelJob:       "",
-			ParallelJobCount:  "",
-			OrganizationSlug:  "rwx",
-			Repo:              "git@github.com/rwx-research/captain-cli",
+		provider, _ := providers.Env{
+			Buildkite: providers.BuildkiteEnv{
+				Detected:          true,
+				Branch:            "main",
+				BuildCreatorEmail: "foo@bar.com",
+				BuildID:           "1234",
+				RetryCount:        "0",
+				BuildURL:          "https://buildkit.com/builds/42",
+				Message:           "fixed it",
+				Commit:            "abc123",
+				JobID:             "build123",
+				Label:             "lint",
+				ParallelJob:       "",
+				ParallelJobCount:  "",
+				OrganizationSlug:  "rwx",
+				Repo:              "git@github.com/rwx-research/captain-cli",
+			},
 		}.MakeProvider()
 		Expect(provider.JobTags).To(Equal(map[string]any{
 			"buildkite_retry_count":       "0",

--- a/internal/providers/buildkite_provider_test.go
+++ b/internal/providers/buildkite_provider_test.go
@@ -36,7 +36,6 @@ var _ = Describe("BuildkiteEnv.MakeProvider", func() {
 		Expect(provider.CommitSha).To(Equal("abc123"))
 		Expect(provider.CommitMessage).To(Equal("fixed it\nyeah"))
 		Expect(provider.ProviderName).To(Equal("buildkite"))
-		Expect(provider.Title).To(Equal("fixed it"))
 	})
 
 	It("requires build id", func() {

--- a/internal/providers/circleci_provider.go
+++ b/internal/providers/circleci_provider.go
@@ -27,7 +27,7 @@ type CircleCIEnv struct {
 	RepositoryURL   string `env:"CIRCLE_REPOSITORY_URL"`
 }
 
-func (cfg CircleCIEnv) MakeProvider() (Provider, error) {
+func (cfg CircleCIEnv) makeProvider() (Provider, error) {
 	tags, validationError := circleciTags(cfg)
 
 	if validationError != nil {

--- a/internal/providers/circleci_provider_test.go
+++ b/internal/providers/circleci_provider_test.go
@@ -7,11 +7,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("CircleCiEnv.MakeProvider", func() {
-	var params providers.CircleCIEnv
+var _ = Describe("CircleCiEnv.makeProvider", func() {
+	var env providers.Env
 
 	BeforeEach(func() {
-		params = providers.CircleCIEnv{
+		env = providers.Env{CircleCI: providers.CircleCIEnv{
+			Detected: true,
 			BuildNum: "18",
 			BuildURL: "https://circleci.com/gh/rwx-research/captain-cli/18",
 			Job:      "build",
@@ -26,11 +27,11 @@ var _ = Describe("CircleCiEnv.MakeProvider", func() {
 			Branch:   "main",
 			Sha1:     "000bd5713d35f778fb51d2b0bf034e8fff5b60b1",
 			Username: "test",
-		}
+		}}
 	})
 
 	It("is valid", func() {
-		provider, err := params.MakeProvider()
+		provider, err := env.MakeProvider()
 		Expect(err).To(BeNil())
 		Expect(provider.AttemptedBy).To(Equal("test"))
 		Expect(provider.BranchName).To(Equal("main"))
@@ -41,55 +42,55 @@ var _ = Describe("CircleCiEnv.MakeProvider", func() {
 	})
 
 	It("requires BuildNum", func() {
-		params.BuildNum = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.BuildNum = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing build number"))
 	})
 
 	It("requires BuildURL", func() {
-		params.BuildURL = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.BuildURL = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing build URL"))
 	})
 
 	It("requires JobName", func() {
-		params.Job = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.Job = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing job name"))
 	})
 
 	It("does not require NodeIndex", func() {
-		params.NodeIndex = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.NodeIndex = ""
+		_, err := env.MakeProvider()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("does not require NodeTotal", func() {
-		params.NodeTotal = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.NodeTotal = ""
+		_, err := env.MakeProvider()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("requires RepoAccountName", func() {
-		params.ProjectUsername = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.ProjectUsername = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing project username"))
 	})
 
 	It("requires RepoName", func() {
-		params.ProjectReponame = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.ProjectReponame = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing repository name"))
 	})
 
 	It("requires RepoURL", func() {
-		params.RepositoryURL = ""
-		_, err := params.MakeProvider()
+		env.CircleCI.RepositoryURL = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing repository URL"))
 	})
@@ -97,7 +98,8 @@ var _ = Describe("CircleCiEnv.MakeProvider", func() {
 
 var _ = Describe("Circleciparams.JobTags", func() {
 	It("constructs job tags with parallel attributes", func() {
-		provider, _ := providers.CircleCIEnv{
+		provider, _ := providers.Env{CircleCI: providers.CircleCIEnv{
+			Detected:  true,
 			BuildNum:  "18",
 			BuildURL:  "https://circleci.com/gh/rwx-research/captain-cli/18",
 			Job:       "build",
@@ -111,7 +113,7 @@ var _ = Describe("Circleciparams.JobTags", func() {
 			Branch:   "main",
 			Sha1:     "000bd5713d35f778fb51d2b0bf034e8fff5b60b1",
 			Username: "test",
-		}.MakeProvider()
+		}}.MakeProvider()
 
 		Expect(provider.JobTags).To(Equal(map[string]any{
 			"circle_build_num":        "18",
@@ -126,7 +128,8 @@ var _ = Describe("Circleciparams.JobTags", func() {
 	})
 
 	It("constructs job tags without parallel attributes", func() {
-		provider, _ := providers.CircleCIEnv{
+		provider, _ := providers.Env{CircleCI: providers.CircleCIEnv{
+			Detected:  true,
 			BuildNum:  "18",
 			BuildURL:  "https://circleci.com/gh/rwx-research/captain-cli/18",
 			Job:       "build",
@@ -140,7 +143,7 @@ var _ = Describe("Circleciparams.JobTags", func() {
 			Branch:   "main",
 			Sha1:     "000bd5713d35f778fb51d2b0bf034e8fff5b60b1",
 			Username: "test",
-		}.MakeProvider()
+		}}.MakeProvider()
 
 		Expect(provider.JobTags).To(Equal(map[string]any{
 			"circle_build_num":        "18",

--- a/internal/providers/github_provider.go
+++ b/internal/providers/github_provider.go
@@ -78,15 +78,15 @@ func (cfg GitHubEnv) MakeProviderWithoutCommitMessageParsing(payloadData GitHubE
 	}
 
 	commitMessage := payloadData.HeadCommit.Message
-	title := strings.Split(commitMessage, "\n")[0]
-	if title == "" {
+	var title string
+	if commitMessage == "" {
 		title = fmt.Sprintf("%s (PR #%d)", payloadData.PullRequest.Title, payloadData.PullRequest.Number)
 	}
 
 	provider := Provider{
 		AttemptedBy:   attemptedBy,
 		BranchName:    branchName,
-		CommitMessage: payloadData.HeadCommit.Message,
+		CommitMessage: commitMessage,
 		CommitSha:     cfg.CommitSha,
 		JobTags:       tags,
 		ProviderName:  "github",

--- a/internal/providers/github_provider.go
+++ b/internal/providers/github_provider.go
@@ -45,7 +45,7 @@ type GitHubEventPayloadData struct {
 	} `json:"pull_request"`
 }
 
-func (cfg GitHubEnv) MakeProvider() (Provider, error) {
+func (cfg GitHubEnv) makeProvider() (Provider, error) {
 	eventPayloadData := GitHubEventPayloadData{}
 
 	file, err := os.Open(cfg.EventPath)

--- a/internal/providers/github_provider_test.go
+++ b/internal/providers/github_provider_test.go
@@ -7,7 +7,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("GitHubEnv.MakeProvider", func() {
+var _ = Describe("GitHubEnv.makeProvider", func() {
+	// TODO: it'd be nice to have a fixture file with a real event payload. For now we test _most_ of the github provider
+	// with the MakeProviderWithoutCommitMessageParsing func which only depends on the GitHubEnv struct.
 	var params providers.GitHubEnv
 	var eventPayloadData providers.GitHubEventPayloadData
 

--- a/internal/providers/github_provider_test.go
+++ b/internal/providers/github_provider_test.go
@@ -44,7 +44,6 @@ var _ = Describe("GitHubEnv.MakeProvider", func() {
 		Expect(provider.CommitSha).To(Equal("abc123"))
 		Expect(provider.CommitMessage).To(Equal("fixed it\nyeah"))
 		Expect(provider.ProviderName).To(Equal("github"))
-		Expect(provider.Title).To(Equal("fixed it"))
 	})
 
 	It("uses the PR info for the title when the commit message is missing", func() {

--- a/internal/providers/gitlab_ci_provider.go
+++ b/internal/providers/gitlab_ci_provider.go
@@ -35,7 +35,7 @@ type GitLabEnv struct {
 	APIV4URL string `env:"CI_API_V4_URL"`
 }
 
-func (cfg GitLabEnv) MakeProvider() (Provider, error) {
+func (cfg GitLabEnv) makeProvider() (Provider, error) {
 	attemptedBy := cfg.UserLogin
 	if attemptedBy == "" {
 		// presumably if there's no attempted by, the build was triggered by pushing the commit / the commit author

--- a/internal/providers/gitlab_ci_provider.go
+++ b/internal/providers/gitlab_ci_provider.go
@@ -1,8 +1,6 @@
 package providers
 
 import (
-	"strings"
-
 	"github.com/rwx-research/captain-cli/internal/errors"
 )
 
@@ -56,7 +54,6 @@ func (cfg GitLabEnv) MakeProvider() (Provider, error) {
 		CommitSha:     cfg.CommitSHA,
 		JobTags:       tags,
 		ProviderName:  "gitlabci",
-		Title:         strings.Split(cfg.CommitMessage, "\n")[0],
 	}
 
 	return provider, nil

--- a/internal/providers/gitlab_ci_provider_test.go
+++ b/internal/providers/gitlab_ci_provider_test.go
@@ -40,6 +40,7 @@ var _ = Describe("GitLabEnv.MakeProvider", func() {
 		Expect(provider.CommitSha).To(Equal("03d68a49ef1e131cf8942d5a07a0ff008ede6a1a"))
 		Expect(provider.CommitMessage).To(Equal("this is what I did\nand here are some details"))
 		Expect(provider.ProviderName).To(Equal("gitlabci"))
+		Expect(provider.Title).To(Equal("this is what I did"))
 	})
 
 	It("falls back to commit author if attempted by is not set", func() {

--- a/internal/providers/gitlab_ci_provider_test.go
+++ b/internal/providers/gitlab_ci_provider_test.go
@@ -39,7 +39,6 @@ var _ = Describe("GitLabEnv.MakeProvider", func() {
 		Expect(provider.CommitSha).To(Equal("03d68a49ef1e131cf8942d5a07a0ff008ede6a1a"))
 		Expect(provider.CommitMessage).To(Equal("this is what I did\nand here are some details"))
 		Expect(provider.ProviderName).To(Equal("gitlabci"))
-		Expect(provider.Title).To(Equal("this is what I did"))
 	})
 
 	It("falls back to commit author if attempted by is not set", func() {

--- a/internal/providers/gitlab_ci_provider_test.go
+++ b/internal/providers/gitlab_ci_provider_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 var _ = Describe("GitLabEnv.MakeProvider", func() {
-	var params providers.GitLabEnv
+	var env providers.Env
 
 	BeforeEach(func() {
-		params = providers.GitLabEnv{
+		env = providers.Env{GitLab: providers.GitLabEnv{
+			Detected:      true,
 			JobName:       "rspec 1/2",
 			JobStage:      "test",
 			JobID:         "3889399980",
@@ -28,11 +29,11 @@ var _ = Describe("GitLabEnv.MakeProvider", func() {
 			CommitBranch:  "main",
 			CommitMessage: "this is what I did\nand here are some details",
 			APIV4URL:      "https://gitlab.com/api/v4",
-		}
+		}}
 	})
 
 	It("is valid", func() {
-		provider, err := params.MakeProvider()
+		provider, err := env.MakeProvider()
 		Expect(err).To(BeNil())
 		Expect(provider.AttemptedBy).To(Equal("michaelglass"))
 		Expect(provider.BranchName).To(Equal("main"))
@@ -42,100 +43,101 @@ var _ = Describe("GitLabEnv.MakeProvider", func() {
 	})
 
 	It("falls back to commit author if attempted by is not set", func() {
-		params.UserLogin = ""
-		provider, _ := params.MakeProvider()
+		env.GitLab.UserLogin = ""
+		provider, _ := env.MakeProvider()
 
 		Expect(provider.AttemptedBy).To(Equal("Michael Glass <me@mike.is>"))
 	})
 
 	It("requires JobName", func() {
-		params.JobName = ""
-		_, err := params.MakeProvider()
+		env.GitLab.JobName = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing job name"))
 	})
 
 	It("requires JobStage", func() {
-		params.JobStage = ""
-		_, err := params.MakeProvider()
+		env.GitLab.JobStage = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing job stage"))
 	})
 
 	It("requires JobID", func() {
-		params.JobID = ""
-		_, err := params.MakeProvider()
+		env.GitLab.JobID = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing job ID"))
 	})
 
 	It("requires PipelineID", func() {
-		params.PipelineID = ""
-		_, err := params.MakeProvider()
+		env.GitLab.PipelineID = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing pipeline ID"))
 	})
 
 	It("requires JobURL", func() {
-		params.JobURL = ""
-		_, err := params.MakeProvider()
+		env.GitLab.JobURL = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing job URL"))
 	})
 
 	It("requires PipelineURL", func() {
-		params.PipelineURL = ""
-		_, err := params.MakeProvider()
+		env.GitLab.PipelineURL = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing pipeline URL"))
 	})
 
 	It("doesn't requires AttemptedBy", func() {
-		params.UserLogin = ""
-		_, err := params.MakeProvider()
+		env.GitLab.UserLogin = ""
+		_, err := env.MakeProvider()
 
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("doesn't requires NodeIndex", func() {
-		params.NodeIndex = ""
-		_, err := params.MakeProvider()
+		env.GitLab.NodeIndex = ""
+		_, err := env.MakeProvider()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("requires NodeTotal", func() {
-		params.NodeTotal = ""
-		_, err := params.MakeProvider()
+		env.GitLab.NodeTotal = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing node total"))
 	})
 
 	It("requires project path", func() {
-		params.ProjectPath = ""
-		_, err := params.MakeProvider()
+		env.GitLab.ProjectPath = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing project path"))
 	})
 
 	It("requires ProjectURL", func() {
-		params.ProjectURL = ""
-		_, err := params.MakeProvider()
+		env.GitLab.ProjectURL = ""
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing project URL"))
 	})
 
 	It("requires API URL", func() {
-		params.APIV4URL = ""
+		env.GitLab.APIV4URL = ""
 
-		_, err := params.MakeProvider()
+		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing API URL"))
 	})
 })
 
-var _ = Describe("GitLabCIparams.JobTags", func() {
+var _ = Describe("GitLabCIenv.GitLab.JobTags", func() {
 	It("constructs job tags with parallel attributes", func() {
-		provider, _ := providers.GitLabEnv{
+		provider, _ := providers.Env{GitLab: providers.GitLabEnv{
+			Detected:      true,
 			JobName:       "rspec 1/2",
 			JobStage:      "test",
 			JobID:         "3889399980",
@@ -152,7 +154,7 @@ var _ = Describe("GitLabCIparams.JobTags", func() {
 			CommitBranch:  "main",
 			CommitMessage: "this is what I did\nand here are some details",
 			APIV4URL:      "https://gitlab.com/api/v4",
-		}.MakeProvider()
+		}}.MakeProvider()
 
 		Expect(provider.JobTags).To(Equal(map[string]any{
 			"gitlab_project_url":     "https://gitlab.com/captain-examples/rspec",
@@ -170,7 +172,8 @@ var _ = Describe("GitLabCIparams.JobTags", func() {
 	})
 
 	It("constructs job tags without parallel attributes", func() {
-		provider, _ := providers.GitLabEnv{
+		provider, _ := providers.Env{GitLab: providers.GitLabEnv{
+			Detected:      true,
 			JobName:       "rspec",
 			JobStage:      "test",
 			JobID:         "3889399980",
@@ -187,7 +190,7 @@ var _ = Describe("GitLabCIparams.JobTags", func() {
 			CommitBranch:  "main",
 			CommitMessage: "this is what I did\nand here are some details",
 			APIV4URL:      "https://gitlab.com/api/v4",
-		}.MakeProvider()
+		}}.MakeProvider()
 
 		Expect(provider.JobTags).To(Equal(map[string]any{
 			"gitlab_job_stage":       "test",

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -1,6 +1,10 @@
 package providers
 
-import "github.com/rwx-research/captain-cli/internal/errors"
+import (
+	"strings"
+
+	"github.com/rwx-research/captain-cli/internal/errors"
+)
 
 type Env struct {
 	Buildkite BuildkiteEnv
@@ -121,6 +125,13 @@ func (env Env) MakeProviderAdapter() (Provider, error) {
 		return Provider{}, err
 	}
 
+	mergedWithGeneric := Merge(detectedProvider, env.Generic.MakeProvider())
+
+	if mergedWithGeneric.Title == "" {
+		mergedWithGeneric.Title = "asdfjasdfj"
+		mergedWithGeneric.Title = strings.Split(mergedWithGeneric.CommitMessage, "\n")[0]
+	}
+
 	// merge the generic provider into the detected provider. The captain-specific flags & env vars take precedence.
-	return Merge(detectedProvider, env.Generic.MakeProvider()), nil
+	return mergedWithGeneric, nil
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -113,7 +113,7 @@ func (env Env) MakeProvider() (Provider, error) {
 		case env.GitHub.Detected:
 			return wrapError(env.GitHub.MakeProvider())
 		case env.Buildkite.Detected:
-			return wrapError(env.Buildkite.MakeProvider())
+			return wrapError(env.Buildkite.makeProvider())
 		case env.CircleCI.Detected:
 			return wrapError(env.CircleCI.MakeProvider())
 		case env.GitLab.Detected:

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -117,7 +117,7 @@ func (env Env) MakeProvider() (Provider, error) {
 		case env.CircleCI.Detected:
 			return wrapError(env.CircleCI.makeProvider())
 		case env.GitLab.Detected:
-			return wrapError(env.GitLab.MakeProvider())
+			return wrapError(env.GitLab.makeProvider())
 		}
 		return Provider{}, nil
 	}()

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -128,7 +128,6 @@ func (env Env) MakeProvider() (Provider, error) {
 	mergedWithGeneric := Merge(detectedProvider, env.Generic.MakeProvider())
 
 	if mergedWithGeneric.Title == "" {
-		mergedWithGeneric.Title = "asdfjasdfj"
 		mergedWithGeneric.Title = strings.Split(mergedWithGeneric.CommitMessage, "\n")[0]
 	}
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -103,7 +103,7 @@ func firstNonempty(strs ...string) string {
 	return ""
 }
 
-func (env Env) MakeProviderAdapter() (Provider, error) {
+func (env Env) MakeProvider() (Provider, error) {
 	// detect provider from environment if we can
 	wrapError := func(p Provider, err error) (Provider, error) {
 		return p, errors.Wrap(err, "error building detected provider")

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -111,7 +111,7 @@ func (env Env) MakeProvider() (Provider, error) {
 	detectedProvider, err := func() (Provider, error) {
 		switch {
 		case env.GitHub.Detected:
-			return wrapError(env.GitHub.MakeProvider())
+			return wrapError(env.GitHub.makeProvider())
 		case env.Buildkite.Detected:
 			return wrapError(env.Buildkite.makeProvider())
 		case env.CircleCI.Detected:

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -115,7 +115,7 @@ func (env Env) MakeProvider() (Provider, error) {
 		case env.Buildkite.Detected:
 			return wrapError(env.Buildkite.makeProvider())
 		case env.CircleCI.Detected:
-			return wrapError(env.CircleCI.MakeProvider())
+			return wrapError(env.CircleCI.makeProvider())
 		case env.GitLab.Detected:
 			return wrapError(env.GitLab.MakeProvider())
 		}

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -123,7 +123,7 @@ var _ = Describe("providers.Merge", func() {
 	})
 })
 
-var _ = Describe("MakeProviderAdapter", func() {
+var _ = Describe("MakeProvider", func() {
 	var env providers.Env
 
 	BeforeEach(func() {
@@ -137,7 +137,7 @@ var _ = Describe("MakeProviderAdapter", func() {
 				env.Generic.Branch = "main"
 				env.Generic.Sha = "abc123"
 
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(provider).To(Equal(
 					providers.Provider{
@@ -156,9 +156,9 @@ var _ = Describe("MakeProviderAdapter", func() {
 		Context("but with an invalid generic provider", func() {
 			It("returns the invalid generic provider", func() {
 				// different commands have different concepts of what a valid generic provider is
-				// so we can't validate that in MakeProviderAdapter
+				// so we can't validate that in MakeProvider
 				env.Generic.Who = "me"
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(provider.AttemptedBy).To(Equal("me"))
 			})
@@ -166,7 +166,7 @@ var _ = Describe("MakeProviderAdapter", func() {
 
 		It("when title is set, uses the set title", func() {
 			env.Generic.Title = "foo"
-			provider, err := env.MakeProviderAdapter()
+			provider, err := env.MakeProvider()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(provider.Title).To(Equal("foo"))
 			Expect(provider.CommitMessage).To(Equal(""))
@@ -178,14 +178,14 @@ var _ = Describe("MakeProviderAdapter", func() {
 			})
 
 			It("when title is unset, sets title to the commit message", func() {
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(provider.Title).To(Equal("fixed it"))
 				Expect(provider.CommitMessage).To(Equal("fixed it"))
 			})
 			It("when title is set, uses the set title", func() {
 				env.Generic.Title = "didn't fix it yet"
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(provider.Title).To(Equal("didn't fix it yet"))
 				Expect(provider.CommitMessage).To(Equal("fixed it"))
@@ -198,14 +198,14 @@ var _ = Describe("MakeProviderAdapter", func() {
 			})
 
 			It("when title is unset, sets title to the first line of the commit message", func() {
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(provider.Title).To(Equal("fixed it"))
 				Expect(provider.CommitMessage).To(Equal("fixed it\nit was tricky!"))
 			})
 			It("when title is set, uses the set title", func() {
 				env.Generic.Title = "didn't fix it yet"
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(provider.Title).To(Equal("didn't fix it yet"))
 				Expect(provider.CommitMessage).To(Equal("fixed it\nit was tricky!"))
@@ -233,7 +233,7 @@ var _ = Describe("MakeProviderAdapter", func() {
 			}
 		})
 		It("returns provider info", func() {
-			provider, err := env.MakeProviderAdapter()
+			provider, err := env.MakeProvider()
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(provider).To(Equal(
@@ -263,7 +263,7 @@ var _ = Describe("MakeProviderAdapter", func() {
 			It("returns the merged provider with the title from the generic provider", func() {
 				env.Generic.Sha = "qrs789"
 				env.Generic.CommitMessage = "fixed it on Tuesday\nthis commit message annotated before writing to captain"
-				provider, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProvider()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(provider).To(Equal(
 					providers.Provider{
@@ -309,7 +309,7 @@ var _ = Describe("MakeProviderAdapter", func() {
 			}
 		})
 		It("is invalid", func() {
-			provider, _ := env.MakeProviderAdapter()
+			provider, _ := env.MakeProvider()
 			err := providers.Validate(provider)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Missing branch name"))
@@ -318,7 +318,7 @@ var _ = Describe("MakeProviderAdapter", func() {
 		Context("and with a generic provider that will be valid after merge", func() {
 			It("returns the merged provider", func() {
 				env.Generic.Branch = "main"
-				provider, _ := env.MakeProviderAdapter()
+				provider, _ := env.MakeProvider()
 				err := providers.Validate(provider)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(provider.BranchName).To(Equal("main"))

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -139,10 +139,17 @@ var _ = Describe("MakeProviderAdapter", func() {
 
 				provider, err := env.MakeProviderAdapter()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(provider.ProviderName).To(Equal("generic"))
-				Expect(provider.CommitSha).To(Equal("abc123"))
-				Expect(provider.BranchName).To(Equal("main"))
-				Expect(provider.AttemptedBy).To(Equal("me"))
+				Expect(provider).To(Equal(
+					providers.Provider{
+						ProviderName:  "generic",
+						CommitSha:     "abc123",
+						BranchName:    "main",
+						AttemptedBy:   "me",
+						CommitMessage: "",
+						Title:         "",
+						JobTags:       map[string]any{"captain_build_url": ""},
+					},
+				))
 			})
 		})
 
@@ -178,11 +185,29 @@ var _ = Describe("MakeProviderAdapter", func() {
 		})
 		It("returns provider info", func() {
 			provider, err := env.MakeProviderAdapter()
+
 			Expect(err).NotTo(HaveOccurred())
-			Expect(provider.ProviderName).To(Equal("buildkite"))
-			Expect(provider.CommitSha).To(Equal("abc123"))
-			Expect(provider.BranchName).To(Equal("main"))
-			Expect(provider.AttemptedBy).To(Equal("foo@bar.com"))
+			Expect(provider).To(Equal(
+				providers.Provider{
+					ProviderName:  "buildkite",
+					CommitSha:     "abc123",
+					BranchName:    "main",
+					AttemptedBy:   "foo@bar.com",
+					CommitMessage: "fixed it",
+					Title:         "fixed it",
+					JobTags: map[string]any{
+						"buildkite_retry_count":        "0",
+						"buildkite_parallel_job_count": "2",
+						"buildkite_build_id":           "1234",
+						"buildkite_build_url":          "https://buildkit.com/builds/42",
+						"buildkite_job_id":             "build123",
+						"buildkite_label":              "lint",
+						"buildkite_repo":               "git@github.com/rwx-research/captain-cli",
+						"buildkite_organization_slug":  "rwx",
+						"buildkite_parallel_job":       "0",
+					},
+				},
+			))
 		})
 
 		Context("and with a generic provider", func() {
@@ -190,10 +215,27 @@ var _ = Describe("MakeProviderAdapter", func() {
 				env.Generic.Sha = "qrs789"
 				provider, err := env.MakeProviderAdapter()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(provider.ProviderName).To(Equal("buildkite"))
-				Expect(provider.CommitSha).To(Equal("qrs789"))
-				Expect(provider.BranchName).To(Equal("main"))
-				Expect(provider.AttemptedBy).To(Equal("foo@bar.com"))
+				Expect(provider).To(Equal(
+					providers.Provider{
+						ProviderName:  "buildkite",
+						CommitSha:     "qrs789",
+						BranchName:    "main",
+						AttemptedBy:   "foo@bar.com",
+						CommitMessage: "fixed it",
+						Title:         "fixed it",
+						JobTags: map[string]any{
+							"buildkite_retry_count":        "0",
+							"buildkite_parallel_job_count": "2",
+							"buildkite_build_id":           "1234",
+							"buildkite_build_url":          "https://buildkit.com/builds/42",
+							"buildkite_job_id":             "build123",
+							"buildkite_label":              "lint",
+							"buildkite_repo":               "git@github.com/rwx-research/captain-cli",
+							"buildkite_organization_slug":  "rwx",
+							"buildkite_parallel_job":       "0",
+						},
+					},
+				))
 			})
 		})
 	})

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -260,8 +260,9 @@ var _ = Describe("MakeProviderAdapter", func() {
 		})
 
 		Context("and with a generic provider", func() {
-			It("returns the merged provider", func() {
+			It("returns the merged provider with the title from the generic provider", func() {
 				env.Generic.Sha = "qrs789"
+				env.Generic.CommitMessage = "fixed it on Tuesday\nthis commit message annotated before writing to captain"
 				provider, err := env.MakeProviderAdapter()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(provider).To(Equal(
@@ -270,8 +271,8 @@ var _ = Describe("MakeProviderAdapter", func() {
 						CommitSha:     "qrs789",
 						BranchName:    "main",
 						AttemptedBy:   "foo@bar.com",
-						CommitMessage: "fixed it",
-						Title:         "fixed it",
+						CommitMessage: "fixed it on Tuesday\nthis commit message annotated before writing to captain",
+						Title:         "fixed it on Tuesday",
 						JobTags: map[string]any{
 							"buildkite_retry_count":        "0",
 							"buildkite_parallel_job_count": "2",

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -158,8 +158,57 @@ var _ = Describe("MakeProviderAdapter", func() {
 				// different commands have different concepts of what a valid generic provider is
 				// so we can't validate that in MakeProviderAdapter
 				env.Generic.Who = "me"
-				_, err := env.MakeProviderAdapter()
+				provider, err := env.MakeProviderAdapter()
 				Expect(err).ToNot(HaveOccurred())
+				Expect(provider.AttemptedBy).To(Equal("me"))
+			})
+		})
+
+		It("when title is set, uses the set title", func() {
+			env.Generic.Title = "foo"
+			provider, err := env.MakeProviderAdapter()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(provider.Title).To(Equal("foo"))
+			Expect(provider.CommitMessage).To(Equal(""))
+		})
+
+		Context("When commit message has a single line", func() {
+			BeforeEach(func() {
+				env.Generic.CommitMessage = "fixed it"
+			})
+
+			It("when title is unset, sets title to the commit message", func() {
+				provider, err := env.MakeProviderAdapter()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(provider.Title).To(Equal("fixed it"))
+				Expect(provider.CommitMessage).To(Equal("fixed it"))
+			})
+			It("when title is set, uses the set title", func() {
+				env.Generic.Title = "didn't fix it yet"
+				provider, err := env.MakeProviderAdapter()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(provider.Title).To(Equal("didn't fix it yet"))
+				Expect(provider.CommitMessage).To(Equal("fixed it"))
+			})
+		})
+
+		Context("When commit message has a multiple lines line", func() {
+			BeforeEach(func() {
+				env.Generic.CommitMessage = "fixed it\nit was tricky!"
+			})
+
+			It("when title is unset, sets title to the first line of the commit message", func() {
+				provider, err := env.MakeProviderAdapter()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(provider.Title).To(Equal("fixed it"))
+				Expect(provider.CommitMessage).To(Equal("fixed it\nit was tricky!"))
+			})
+			It("when title is set, uses the set title", func() {
+				env.Generic.Title = "didn't fix it yet"
+				provider, err := env.MakeProviderAdapter()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(provider.Title).To(Equal("didn't fix it yet"))
+				Expect(provider.CommitMessage).To(Equal("fixed it\nit was tricky!"))
 			})
 		})
 	})


### PR DESCRIPTION
if title isn't set but commit message is, all providers falls back to commit message 

previously most providers were doing this. This PR
- ensures it happens for the generic provider
- ensures it happens late -- if the commit message is overridden somehow, the title is pulled from the latest commit message

additionally, it makes all of the provider-specific `MakeProvider` methods private