### PR TITLE
Captain v1.9.11 - Release Candidate

### DIFF
--- a/.github/workflows/continuous_delivery.yaml
+++ b/.github/workflows/continuous_delivery.yaml
@@ -1,21 +1,53 @@
 name: Continuous Delivery
-run-name: Upload CLI release to S3
+run-name: Publish Release Assets
 on:
   workflow_run:
     workflows:
-      - Release Requirements
+      - Continuous Integration
+    branches:
+      - 'releases/**'
     types:
       - completed
 
 jobs:
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+    outputs:
+      full-version: ${{ steps.tag.outputs.fullVersion }}
+      major-version: ${{ steps.tag.outputs.majorVersion }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: tag
+        run: |
+          fullVersion=$(cat version.go | grep "const Version" | awk '{print $4}' | sed 's/"//g')
+          majorVersion=$(echo "$fullVersion" | awk -F '.' '{print $1}')
+          git tag $fullVersion
+          git push --tags origin $fullVersion
+          git tag --force $majorVersion
+          git push --tags --force origin $majorVersion
+          echo "fullVersion=$fullVersion" >> "$GITHUB_OUTPUT"
+          echo "majorVersion=$majorVersion" >> "$GITHUB_OUTPUT"
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          tag_name: ${{ steps.tag.outputs.fullVersion }}
+          name: "Captain ${{ steps.tag.outputs.fullVersion }}"
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.majorVersion }}
+          name: "Captain ${{ steps.tag.outputs.majorVersion }}"
   upload:
     name: Upload artifacts
     runs-on: ubuntu-latest
+    needs: release
     environment: Production
     permissions:
-      contents: read
+      contents: write
       id-token: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -33,7 +65,9 @@ jobs:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::152560469324:role/captain-cli-cd
           role-duration-seconds: 900
-      - run: |
+      - id: build-unix
+        if: ${{ matrix.os != 'windows' }}
+        run: |
           version=$(nix develop --command go run ./cmd/captain --version)
           old_artifact_name=$(echo "captain-${{ matrix.os }}-${{ matrix.arch }}-$version" | tr '[:upper:]' '[:lower:]')
           aws s3 cp ./captain "s3://terraform-20221109133415397600000001/$old_artifact_name"
@@ -48,12 +82,19 @@ jobs:
           fi
           new_artifact_name=$(echo "$version/${{ matrix.os }}/$new_arch/captain" | tr '[:upper:]' '[:lower:]')
           aws s3 cp ./captain "s3://terraform-20221109133415397600000001/$new_artifact_name"
+
+          github_asset_name=$(echo "captain-${{ matrix.os }}-$new_arch" | tr '[:upper:]' '[:lower:]')
+          mv captain $github_asset_name
+          gh release upload ${{ needs.release.outputs.full-version }} $github_asset_name
+          gh release upload --clobber ${{ needs.release.outputs.major-version }} $github_asset_name
         env:
+          GH_TOKEN: ${{ github.token }}
           RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
-        if: ${{ matrix.os != 'windows' }}
-      - run: |
+      - id: build-windows
+        if: ${{ matrix.os == 'windows' }}
+        run: |
           version=$(nix develop --command go run ./cmd/captain --version)
-          old_artifact_name=$(echo "captain-${{ matrix.os }}-${{ matrix.arch }}-$version" | tr '[:upper:]' '[:lower:]')
+          old_artifact_name=$(echo "captain-${{ matrix.os }}-$new_arch-$version" | tr '[:upper:]' '[:lower:]')
           aws s3 cp ./captain.exe "s3://terraform-20221109133415397600000001/$old_artifact_name"
 
           if [[ "${{ matrix.arch }}" == "amd64" ]]; then
@@ -66,9 +107,14 @@ jobs:
           fi
           new_artifact_name=$(echo "$version/${{ matrix.os }}/$new_arch/captain.exe" | tr '[:upper:]' '[:lower:]')
           aws s3 cp ./captain.exe "s3://terraform-20221109133415397600000001/$new_artifact_name"
+
+          github_asset_name=$(echo "captain-${{ matrix.os }}-$new_arch.exe" | tr '[:upper:]' '[:lower:]')
+          mv captain.exe $github_asset_name
+          gh release upload ${{ needs.release.outputs.full-version }} $github_asset_name
+          gh release upload --clobber ${{ needs.release.outputs.major-version }} $github_asset_name
         env:
+          GH_TOKEN: ${{ github.token }}
           RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
-        if: ${{ matrix.os == 'windows' }}
 
   deliver-binaries:
     name: Deliver binaries

--- a/.github/workflows/release_requirements.yaml
+++ b/.github/workflows/release_requirements.yaml
@@ -1,7 +1,7 @@
 name: Release Requirements
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches: ["releases/**"]
 jobs:
   check-version:
     name: Ensure version bump

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -45,8 +45,8 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		Long: "'captain partition' can be used to split up your test suite by test file, leveraging test file timings " +
 			"recorded in captain.",
 		Example: "" +
-			"  bundle exec rspec $(captain partition --suide-id your-project-rspec --index 0 --total 2 spec/**/*_spec.rb)\n" +
-			"  bundle exec rspec $(captain partition --suide-id your-project-rspec --index 1 --total 2 spec/**/*_spec.rb)",
+			"  bundle exec rspec $(captain partition your-project-rspec --index 0 --total 2 spec/**/*_spec.rb)\n" +
+			"  bundle exec rspec $(captain partition your-project-rspec --index 1 --total 2 spec/**/*_spec.rb)",
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,
 		PreRunE: initCLIService(cliArgs, func(p providers.Provider) error {
@@ -97,7 +97,14 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 	// it's a smell that we're using cliArgs here but I believe it's a major refactor to stop doing that.
 	addShaFlag(partitionCmd, &cliArgs.GenericProvider.Sha)
 
-	partitionCmd.Flags().StringVar(&pArgs.delimiter, "delimiter", " ", "the delimiter used to separate partitioned files")
+	defaultDelimiter := os.Getenv("CAPTAIN_DELIMITER")
+	if defaultDelimiter == "" {
+		defaultDelimiter = " "
+	}
+
+	partitionCmd.Flags().StringVar(&pArgs.delimiter, "delimiter", defaultDelimiter,
+		"the delimiter used to separate partitioned files.\n"+
+			"It can also be set using the env var CAPTAIN_DELIMITER.")
 
 	rootCmd.AddCommand(partitionCmd)
 	return nil

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -48,6 +48,49 @@ var _ = Describe("OSS mode Integration Tests", func() {
 
 		Describe("captain partition", func() {
 			Context("without timings", func() {
+				Context("with a delimiter", func() {
+					It("sets partition 1 correctly", func() {
+						result := runCaptain(captainArgs{
+							args: []string{
+								"partition",
+								"captain-cli-functional-tests",
+								"fixtures/integration-tests/partition/x.rb",
+								"fixtures/integration-tests/partition/y.rb",
+								"fixtures/integration-tests/partition/z.rb",
+								"--index", "0",
+								"--total", "2",
+								"--delimiter", ",",
+							},
+							env: getEnvWithoutAccessToken(),
+						})
+
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
+						Expect(result.exitCode).To(Equal(0))
+					})
+
+				It("sets partition 1 correctly when delimiter is set via env var", func() {
+						env := getEnvWithoutAccessToken()
+						env["CAPTAIN_DELIMITER"] = ","
+
+						result := runCaptain(captainArgs{
+							args: []string{
+								"partition",
+								"captain-cli-functional-tests",
+								"fixtures/integration-tests/partition/x.rb",
+								"fixtures/integration-tests/partition/y.rb",
+								"fixtures/integration-tests/partition/z.rb",
+								"--index", "0",
+								"--total", "2",
+							},
+							env: env,
+						})
+
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
+						Expect(result.exitCode).To(Equal(0))
+					})
+				})
 				It("sets partition 1 correctly", func() {
 					result := runCaptain(captainArgs{
 						args: []string{

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package captain
 
 // Version is the current version of this package. This needs to get bumped with every merge to 'main'.
-const Version = "v1.9.10"
+const Version = "v1.9.11"


### PR DESCRIPTION
Note: As this is our first release on `releases/v1`, the diff & commit history on this PR are not complete. To see all changes from the previous release, go to https://github.com/rwx-research/captain/compare/e14a5b9...b0f3f7d9af93c66f62a2e0b6f8546b899ec7dd75

Release notes (to be published) are below:

---

## Changelog

### Added

- Ability to explicitly disable Cloud mode through the config file.
- Additional warning messages if Captain is misconfigured.
- A fallback to the pull-request name / number if Captain can't determine a commit message in GitHub Actions.
- Ability to manually set a "title" for a test-suite execution in Captain via `CAPTAIN_TITLE` or `--title`. This can be useful if Captain is unable to derive commit messages from your environment.
- Additional options to configure the partitioning delimiter (can now be set via `CAPTAIN_DELIMITER`)

### Changed

- Some error messages were modified to be easier to understand.

