### PR TITLE
Determine whether a v1.Test is flaky

### DIFF
--- a/internal/testingschema/v1/test.go
+++ b/internal/testingschema/v1/test.go
@@ -119,6 +119,34 @@ func (t Test) Quarantine() Test {
 	return t
 }
 
+func (t Test) Flaky() bool {
+	if len(t.PastAttempts) == 0 {
+		return false
+	}
+
+	sawSuccess := false
+	sawPotentiallyFlaky := false
+
+	if t.Attempt.Status.Kind == TestStatusSuccessful {
+		sawSuccess = true
+	}
+	if t.Attempt.Status.PotentiallyFlaky() {
+		sawPotentiallyFlaky = true
+	}
+
+	for _, attempt := range t.PastAttempts {
+		if attempt.Status.Kind == TestStatusSuccessful {
+			sawSuccess = true
+		}
+
+		if attempt.Status.PotentiallyFlaky() {
+			sawPotentiallyFlaky = true
+		}
+	}
+
+	return sawSuccess && sawPotentiallyFlaky
+}
+
 func (t Test) Tag(key string, value any) Test {
 	if t.Attempt.Meta == nil {
 		t.Attempt.Meta = map[string]any{}

--- a/internal/testingschema/v1/test_test.go
+++ b/internal/testingschema/v1/test_test.go
@@ -176,6 +176,76 @@ var _ = Describe("Test", func() {
 		})
 	})
 
+	Describe("Flaky", func() {
+		It("is false for a test that passed", func() {
+			test := v1.Test{Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+
+		It("is false for a test that failed", func() {
+			test := v1.Test{Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+
+		It("is false for a test that timed out", func() {
+			test := v1.Test{Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+
+		It("is false for a test that was canceled", func() {
+			test := v1.Test{Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+
+		It("is true for a test that failed then passed", func() {
+			test := v1.Test{
+				Attempt:      v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()},
+				PastAttempts: []v1.TestAttempt{{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
+			}
+			Expect(test.Flaky()).To(Equal(true))
+		})
+
+		It("is true for a test that passed then failed", func() {
+			test := v1.Test{
+				Attempt:      v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)},
+				PastAttempts: []v1.TestAttempt{{Status: v1.NewSuccessfulTestStatus()}},
+			}
+			Expect(test.Flaky()).To(Equal(true))
+		})
+
+		It("is true for a test that timed out and passed", func() {
+			test := v1.Test{
+				Attempt:      v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+				PastAttempts: []v1.TestAttempt{{Status: v1.NewSuccessfulTestStatus()}},
+			}
+			Expect(test.Flaky()).To(Equal(true))
+		})
+
+		It("is false for a test that was canceled and passed", func() {
+			test := v1.Test{
+				Attempt:      v1.TestAttempt{Status: v1.NewCanceledTestStatus()},
+				PastAttempts: []v1.TestAttempt{{Status: v1.NewSuccessfulTestStatus()}},
+			}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+
+		It("is false for a test that was pended and failed", func() {
+			test := v1.Test{
+				Attempt:      v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)},
+				PastAttempts: []v1.TestAttempt{{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
+			}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+
+		It("is false for a test that was pended and passed", func() {
+			test := v1.Test{
+				Attempt:      v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)},
+				PastAttempts: []v1.TestAttempt{{Status: v1.NewSuccessfulTestStatus()}},
+			}
+			Expect(test.Flaky()).To(Equal(false))
+		})
+	})
+
 	Describe("Quarantine", func() {
 		It("quarantines a test that is not quarantined", func() {
 			originalStatus := v1.NewFailedTestStatus(nil, nil, nil)


### PR DESCRIPTION
When writing the upcoming markdown summary, we'll call out whether a test was flaky. This change takes retries into consideration within a single run of the CLI and informs whether the test is flaky or not.