### PR TITLE
Thread more configuration through to the reporters

### DIFF
--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rwx-research/captain-cli/internal/providers"
 	"github.com/rwx-research/captain-cli/internal/reporting"
 	"github.com/rwx-research/captain-cli/internal/targetedretries"
-	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
 type CliArgs struct {
@@ -35,23 +34,6 @@ type CliArgs struct {
 	GenericProvider           providers.GenericEnv
 	frameworkParams           frameworkParams
 	RootCliArgs               rootCliArgs
-}
-
-var substitutionsByFramework = map[v1.Framework]targetedretries.Substitution{
-	v1.DotNetxUnitFramework:          new(targetedretries.DotNetxUnitSubstitution),
-	v1.ElixirExUnitFramework:         new(targetedretries.ElixirExUnitSubstitution),
-	v1.GoGinkgoFramework:             new(targetedretries.GoGinkgoSubstitution),
-	v1.GoTestFramework:               new(targetedretries.GoTestSubstitution),
-	v1.JavaScriptCypressFramework:    new(targetedretries.JavaScriptCypressSubstitution),
-	v1.JavaScriptJestFramework:       new(targetedretries.JavaScriptJestSubstitution),
-	v1.JavaScriptMochaFramework:      new(targetedretries.JavaScriptMochaSubstitution),
-	v1.JavaScriptPlaywrightFramework: new(targetedretries.JavaScriptPlaywrightSubstitution),
-	v1.PHPUnitFramework:              new(targetedretries.PHPUnitSubstitution),
-	v1.PythonPytestFramework:         new(targetedretries.PythonPytestSubstitution),
-	v1.PythonUnitTestFramework:       new(targetedretries.PythonUnitTestSubstitution),
-	v1.RubyCucumberFramework:         new(targetedretries.RubyCucumberSubstitution),
-	v1.RubyMinitestFramework:         new(targetedretries.RubyMinitestSubstitution),
-	v1.RubyRSpecFramework:            new(targetedretries.RubyRSpecSubstitution),
 }
 
 func createRunCmd(cliArgs *CliArgs) *cobra.Command {
@@ -121,7 +103,7 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 				Reporters:                 reporterFuncs,
 				Retries:                   retries,
 				RetryCommandTemplate:      retryCommand,
-				SubstitutionsByFramework:  substitutionsByFramework,
+				SubstitutionsByFramework:  targetedretries.SubstitutionsByFramework,
 				SuiteID:                   cliArgs.RootCliArgs.suiteID,
 				TestResultsFileGlob:       testResultsPath,
 				UpdateStoredResults:       cliArgs.updateStoredResults,
@@ -247,9 +229,9 @@ func AddFlags(runCmd *cobra.Command, cliArgs *CliArgs) error {
 		return errors.WithStack(err)
 	}
 
-	formattedSubstitutionExamples := make([]string, len(substitutionsByFramework))
+	formattedSubstitutionExamples := make([]string, len(targetedretries.SubstitutionsByFramework))
 	i := 0
-	for framework, substitution := range substitutionsByFramework {
+	for framework, substitution := range targetedretries.SubstitutionsByFramework {
 		formattedSubstitutionExamples[i] = fmt.Sprintf("  %v: --retry-command \"%v\"", framework, substitution.Example())
 		i++
 	}

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/rwx-research/captain-cli/internal/exec"
 	"github.com/rwx-research/captain-cli/internal/fs"
+	"github.com/rwx-research/captain-cli/internal/reporting"
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
 // Reporter is a function that writes test results to a file. Different reporters implement different encodings.
-type Reporter func(fs.File, v1.TestResults) error
+type Reporter func(fs.File, v1.TestResults, reporting.Configuration) error
 
 // TaskRunner is an abstraction over various task-runners / execution environments.
 // They are expected to implement the `taskRunner.Command` interface in turn, which is mapped to the Command type from

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -617,7 +617,7 @@ func (s Service) reportTestResults(
 	for outputPath, writeReport := range cfg.Reporters {
 		file, err := s.FileSystem.Create(outputPath)
 		if err == nil {
-			err = writeReport(file, testResults)
+			err = writeReport(file, testResults, reporting.Configuration{})
 		}
 		if err != nil {
 			s.Log.Warnf("Unable to write report to %s: %s", outputPath, err.Error())
@@ -625,7 +625,7 @@ func (s Service) reportTestResults(
 	}
 
 	if cfg.PrintSummary {
-		if err := reporting.WriteTextSummary(os.Stdout, testResults); err != nil {
+		if err := reporting.WriteTextSummary(os.Stdout, testResults, reporting.Configuration{}); err != nil {
 			s.Log.Warnf("Unable to write text summary to stdout: %s", err.Error())
 		} else {
 			// Append an empty line to make output more readable

--- a/internal/reporting/configuration.go
+++ b/internal/reporting/configuration.go
@@ -1,0 +1,10 @@
+package reporting
+
+import "github.com/rwx-research/captain-cli/internal/providers"
+
+type Configuration struct {
+	CloudEnabled bool
+	CloudHost    string
+	SuiteID      string
+	Provider     providers.Provider
+}

--- a/internal/reporting/junit.go
+++ b/internal/reporting/junit.go
@@ -10,7 +10,7 @@ import (
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
-func WriteJUnitSummary(file fs.File, testResults v1.TestResults) error {
+func WriteJUnitSummary(file fs.File, testResults v1.TestResults, _ Configuration) error {
 	result := parsing.JUnitTestResults{
 		TestSuites: make([]parsing.JUnitTestSuite, 0),
 	}

--- a/internal/reporting/junit_test.go
+++ b/internal/reporting/junit_test.go
@@ -57,7 +57,7 @@ var _ = Describe("JUnit Report", func() {
 	It("produces a parsable JUnit file", func() {
 		var result parsing.JUnitTestResults
 
-		Expect(reporting.WriteJUnitSummary(mockFile, testResults)).To(Succeed())
+		Expect(reporting.WriteJUnitSummary(mockFile, testResults, reporting.Configuration{})).To(Succeed())
 		Expect(xml.Unmarshal([]byte(mockFile.Builder.String()), &result)).To(Succeed())
 		Expect(result.TestSuites).To(HaveLen(1))
 

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -53,7 +53,7 @@ const (
 )
 
 // TODO(kkt): need suite ID, commit sha, branch
-func WriteMarkdownSummary(file fs.File, testResults v1.TestResults) error {
+func WriteMarkdownSummary(file fs.File, testResults v1.TestResults, _ Configuration) error {
 	markdown := new(strings.Builder)
 	if _, err := markdown.WriteString(fmt.Sprintf("# `%v` Summary\n\n", "TODO(kkt) suite-id")); err != nil {
 		return errors.WithStack(err)

--- a/internal/reporting/markdown_test.go
+++ b/internal/reporting/markdown_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Markdown Report", func() {
 	})
 
 	It("produces a readable summary", func() {
-		Expect(reporting.WriteMarkdownSummary(mockFile, testResults)).To(Succeed())
+		Expect(reporting.WriteMarkdownSummary(mockFile, testResults, reporting.Configuration{})).To(Succeed())
 		summary := mockFile.Builder.String()
 		cupaloy.SnapshotT(GinkgoT(), summary)
 	})
@@ -101,7 +101,11 @@ var _ = Describe("Markdown Report", func() {
 		}
 
 		Expect(
-			reporting.WriteMarkdownSummary(mockFile, *v1.NewTestResults(v1.RubyRSpecFramework, tests, nil)),
+			reporting.WriteMarkdownSummary(
+				mockFile,
+				*v1.NewTestResults(v1.RubyRSpecFramework, tests, nil),
+				reporting.Configuration{},
+			),
 		).To(Succeed())
 		summary := mockFile.Builder.String()
 		cupaloy.SnapshotT(GinkgoT(), summary)

--- a/internal/reporting/rwx.go
+++ b/internal/reporting/rwx.go
@@ -8,7 +8,7 @@ import (
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
-func WriteJSONSummary(file fs.File, testResults v1.TestResults) error {
+func WriteJSONSummary(file fs.File, testResults v1.TestResults, _ Configuration) error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 

--- a/internal/reporting/text.go
+++ b/internal/reporting/text.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
-func WriteTextSummary(file fs.File, testResults v1.TestResults) error {
+func WriteTextSummary(file fs.File, testResults v1.TestResults, _ Configuration) error {
 	statuses := make(map[v1.TestStatusKind][]string)
 	totalTests := testResults.Summary.Tests
 

--- a/internal/reporting/text_test.go
+++ b/internal/reporting/text_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Text Report", func() {
 	})
 
 	It("produces a readable summary", func() {
-		Expect(reporting.WriteTextSummary(mockFile, testResults)).To(Succeed())
+		Expect(reporting.WriteTextSummary(mockFile, testResults, reporting.Configuration{})).To(Succeed())
 		summary := mockFile.Builder.String()
 
 		Expect(summary).To(ContainSubstring("total of 4 tests"))

--- a/internal/targetedretries/substitution.go
+++ b/internal/targetedretries/substitution.go
@@ -23,6 +23,23 @@ var (
 	keywordRegexp     = regexp.MustCompile(`^{{\s?(\w+)\s?}}$`)
 )
 
+var SubstitutionsByFramework = map[v1.Framework]Substitution{
+	v1.DotNetxUnitFramework:          new(DotNetxUnitSubstitution),
+	v1.ElixirExUnitFramework:         new(ElixirExUnitSubstitution),
+	v1.GoGinkgoFramework:             new(GoGinkgoSubstitution),
+	v1.GoTestFramework:               new(GoTestSubstitution),
+	v1.JavaScriptCypressFramework:    new(JavaScriptCypressSubstitution),
+	v1.JavaScriptJestFramework:       new(JavaScriptJestSubstitution),
+	v1.JavaScriptMochaFramework:      new(JavaScriptMochaSubstitution),
+	v1.JavaScriptPlaywrightFramework: new(JavaScriptPlaywrightSubstitution),
+	v1.PHPUnitFramework:              new(PHPUnitSubstitution),
+	v1.PythonPytestFramework:         new(PythonPytestSubstitution),
+	v1.PythonUnitTestFramework:       new(PythonUnitTestSubstitution),
+	v1.RubyCucumberFramework:         new(RubyCucumberSubstitution),
+	v1.RubyMinitestFramework:         new(RubyMinitestSubstitution),
+	v1.RubyRSpecFramework:            new(RubyRSpecSubstitution),
+}
+
 type CompiledTemplate struct {
 	Template             string
 	PlaceholderToKeyword map[string]string


### PR DESCRIPTION
Follows #13. This does the small amount of refactoring work necessary to get access to the rest of the configuration we need to make the markdown report as detailed as we'd like it to be. A follow-up PR will make the final changes to the report and enable it.

- Move the framework -> substitution mapping to targeted retries
- Add a reporting configuration to the reporters interfaces
- Pass the appropriate reporting configuration to the reporters
