### PR TITLE
Expose the new reporter options

### DIFF
--- a/.captain/config.yaml
+++ b/.captain/config.yaml
@@ -2,5 +2,8 @@ test-suites:
   captain-cli-ginkgo:
     command: nix develop --command mage test
     fail-on-upload-error: true
+    output:
+      reporters:
+        github-step-summary:
     results:
       path: report.xml

--- a/.captain/config.yaml
+++ b/.captain/config.yaml
@@ -1,0 +1,6 @@
+test-suites:
+  captain-cli-ginkgo:
+    command: nix develop --command mage test
+    fail-on-upload-error: true
+    results:
+      path: report.xml

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -14,16 +14,12 @@ jobs:
             keep-derivations = true
             keep-outputs = true
       - run: CGO_ENABLED=0 LDFLAGS="-w -s" nix develop --command mage
-      - run: |
-          REPORT=true ./captain run \
-            --suite-id="captain-cli-ginkgo" \
-            --test-results=report.xml \
-            --fail-on-upload-error \
-            -- nix develop --command mage test
+      - run: ./captain run captain-cli-ginkgo
         env:
           RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
           RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
           DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+          REPORT: true
 
   lint:
     name: Lint

--- a/cmd/captain/quarantine.go
+++ b/cmd/captain/quarantine.go
@@ -39,10 +39,24 @@ func AddQuarantineFlags(rootCmd *cobra.Command, cliArgs *CliArgs) {
 						reporterFuncs[path] = reporting.WriteJSONSummary
 					case "junit-xml":
 						reporterFuncs[path] = reporting.WriteJUnitSummary
+					case "markdown-summary":
+						reporterFuncs[path] = reporting.WriteMarkdownSummary
+					case "github-step-summary":
+						stepSummaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
+						if stepSummaryPath == "" {
+							return errors.WithDecoration(errors.NewConfigurationError(
+								"'github-step-summary' reporter misconfigured",
+								"The 'github-step-summary' reporter can only run within a GitHub Actions job where the "+
+									"'GITHUB_STEP_SUMMARY' environment variable is set.",
+								"",
+							))
+						}
+
+						reporterFuncs[stepSummaryPath] = reporting.WriteMarkdownSummary
 					default:
 						return errors.WithDecoration(errors.NewConfigurationError(
 							fmt.Sprintf("Unknown reporter %q", name),
-							"Available reporters are 'rwx-v1-json' and 'junit-xml'.",
+							"Available reporters are 'rwx-v1-json', 'junit-xml', 'markdown-summary', and 'github-step-summary'.",
 							"",
 						))
 					}

--- a/cmd/captain/quarantine.go
+++ b/cmd/captain/quarantine.go
@@ -132,8 +132,8 @@ func AddQuarantineFlags(rootCmd *cobra.Command, cliArgs *CliArgs) {
 		&cliArgs.reporters,
 		"reporter",
 		[]string{},
-		"one or more `type=output_path` pairs to enable different reporting options. "+
-			"Available reporter types are `rwx-v1-json` and `junit-xml ",
+		"one or more `type=output_path` pairs to enable different reporting options.\n"+
+			"Available reporters are 'rwx-v1-json', 'junit-xml', 'markdown-summary', and 'github-step-summary'.",
 	)
 
 	quarantineCmd.Flags().BoolVar(

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -64,10 +64,24 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 						reporterFuncs[path] = reporting.WriteJSONSummary
 					case "junit-xml":
 						reporterFuncs[path] = reporting.WriteJUnitSummary
+					case "markdown-summary":
+						reporterFuncs[path] = reporting.WriteMarkdownSummary
+					case "github-step-summary":
+						stepSummaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
+						if stepSummaryPath == "" {
+							return errors.WithDecoration(errors.NewConfigurationError(
+								"'github-step-summary' reporter misconfigured",
+								"The 'github-step-summary' reporter can only run within a GitHub Actions job where the "+
+									"'GITHUB_STEP_SUMMARY' environment variable is set.",
+								"",
+							))
+						}
+
+						reporterFuncs[stepSummaryPath] = reporting.WriteMarkdownSummary
 					default:
 						return errors.WithDecoration(errors.NewConfigurationError(
 							fmt.Sprintf("Unknown reporter %q", name),
-							"Available reporters are 'rwx-v1-json' and 'junit-xml'.",
+							"Available reporters are 'rwx-v1-json', 'junit-xml', 'markdown-summary', and 'github-step-summary'.",
 							"",
 						))
 					}

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -324,7 +324,7 @@ func bindRunCmdFlags(cfg Config, cliArgs CliArgs) Config {
 			suiteConfig.Output.Quiet = true
 		}
 
-		if cliArgs.reporters != nil {
+		if len(cliArgs.reporters) > 0 {
 			reporterConfig := make(map[string]string)
 
 			for _, r := range cliArgs.reporters {

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -325,7 +325,7 @@ func bindRunCmdFlags(cfg Config, cliArgs CliArgs) Config {
 		}
 
 		if len(cliArgs.reporters) > 0 {
-			reporterConfig := make(map[string]string)
+			reporterConfig := suiteConfig.Output.Reporters
 
 			for _, r := range cliArgs.reporters {
 				name, path, _ := strings.Cut(r, "=")

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -193,8 +193,8 @@ func AddFlags(runCmd *cobra.Command, cliArgs *CliArgs) error {
 		&cliArgs.reporters,
 		"reporter",
 		[]string{},
-		"one or more `type=output_path` pairs to enable different reporting options. "+
-			"Available reporter types are `rwx-v1-json` and `junit-xml ",
+		"one or more `type=output_path` pairs to enable different reporting options.\n"+
+			"Available reporters are 'rwx-v1-json', 'junit-xml', 'markdown-summary', and 'github-step-summary'.",
 	)
 
 	runCmd.Flags().IntVar(

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
@@ -1,6 +1,6 @@
 # `some-suite-id` Summary
 
-[🔗 View in Captain Cloud](https://example.com/deep_link/test_suite_summaries/some-suite-id/some%2Fbranch/abcdef113131)
+[🔗 View in Captain Cloud](https://example.com/deep_link/test_suite_summaries/some-suite-id/some/branch/abcdef113131)
 
 6 tests, 1 flaky, 2 failed, 1 timed out, 1 skipped, 2 retries
 

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -2,7 +2,6 @@ package reporting
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 	"text/template"
 
@@ -65,9 +64,9 @@ func WriteMarkdownSummary(file fs.File, testResults v1.TestResults, cfg Configur
 			fmt.Sprintf(
 				"[🔗 View in Captain Cloud](https://%v/deep_link/test_suite_summaries/%v/%v/%v)\n\n",
 				cfg.CloudHost,
-				url.QueryEscape(cfg.SuiteID),
-				url.QueryEscape(cfg.Provider.BranchName),
-				url.QueryEscape(cfg.Provider.CommitSha),
+				cfg.SuiteID,
+				cfg.Provider.BranchName,
+				cfg.Provider.CommitSha,
 			),
 		); err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
This required a few bug fixes that I just lumped into this PR, but long story short:

- Uses the config file in this repo
- Fixes how the config file's reporters setting and cli flag reporters interact
- Exposes the github step summary and markdown summary reporters