### PR TITLE
Integration test the reporters

### DIFF
--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -1,0 +1,47 @@
+package cli
+
+// configFile holds all options that can be set over the config file
+type ConfigFile struct {
+	Cloud struct {
+		APIHost  string `yaml:"api-host" env:"CAPTAIN_HOST"`
+		Disabled bool
+		Insecure bool
+	}
+	Flags  map[string]any
+	Output struct {
+		Debug bool
+	}
+	TestSuites map[string]SuiteConfig `yaml:"test-suites"`
+}
+
+type SuiteConfigOutput struct {
+	PrintSummary bool `yaml:"print-summary"`
+	Reporters    map[string]string
+	Quiet        bool
+}
+
+type SuiteConfigResults struct {
+	Framework string
+	Language  string
+	Path      string
+}
+
+type SuiteConfigRetries struct {
+	Attempts                  int
+	Command                   string
+	FailFast                  bool `yaml:"fail-fast"`
+	FlakyAttempts             int  `yaml:"flaky-attempts"`
+	MaxTests                  string
+	PostRetryCommands         []string `yaml:"post-retry-commands"`
+	PreRetryCommands          []string `yaml:"pre-retry-commands"`
+	IntermediateArtifactsPath string   `yaml:"intermediate-artifacts-path"`
+}
+
+// SuiteConfig holds options that can be customized per suite
+type SuiteConfig struct {
+	Command           string
+	FailOnUploadError bool `yaml:"fail-on-upload-error"`
+	Output            SuiteConfigOutput
+	Results           SuiteConfigResults
+	Retries           SuiteConfigRetries
+}

--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Cloud Mode Integration Tests", func() {
 			env["RWX_ACCESS_TOKEN"] = os.Getenv("RWX_ACCESS_TOKEN_STAGING")
 			return env
 		}
+
 		Describe("captain run", func() {
 			Context("quarantining", func() {
 				It("succeeds when all failures quarantined", func() {

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -198,7 +198,7 @@ type envGenerator func() map[string]string
 
 type sharedTestGen func(envGenerator, string)
 
-func withCaptainConfig(cfg cli.ConfigFile, rootDir string, body func()) {
+func withCaptainConfig(cfg cli.ConfigFile, rootDir string, body func(configPath string)) {
 	// TODO set RootDir on the config file once we get that merged
 	configPath := filepath.Join(rootDir, ".captain/config.yaml")
 
@@ -216,5 +216,5 @@ func withCaptainConfig(cfg cli.ConfigFile, rootDir string, body func()) {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	body()
+	body(configPath)
 }

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -9,11 +9,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rwx-research/captain-cli/internal/cli"
 	"github.com/rwx-research/captain-cli/test/helpers"
 )
 
@@ -193,3 +197,24 @@ func withAndWithoutInheritedEnv(sharedTests sharedTestGen) {
 type envGenerator func() map[string]string
 
 type sharedTestGen func(envGenerator, string)
+
+func withCaptainConfig(cfg cli.ConfigFile, rootDir string, body func()) {
+	// TODO set RootDir on the config file once we get that merged
+	configPath := filepath.Join(rootDir, ".captain/config.yaml")
+
+	err := os.MkdirAll(filepath.Dir(configPath), 0o750)
+	Expect(err).NotTo(HaveOccurred())
+
+	configFile, err := os.Create(configPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = yaml.NewEncoder(configFile).Encode(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer func() {
+		err := os.Remove(configPath)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	body()
+}

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -298,12 +298,12 @@ var _ = Describe("OSS mode Integration Tests", func() {
 					},
 				}
 
-				withCaptainConfig(cfg, tmp, func() {
+				withCaptainConfig(cfg, tmp, func(configPath string) {
 					result := runCaptain(captainArgs{
 						args: []string{
 							"run",
 							"captain-cli-functional-tests",
-							"--config-file", filepath.Join(tmp, ".captain/config.yaml"),
+							"--config-file", configPath,
 						},
 						env: getEnvWithoutAccessToken(),
 					})
@@ -362,12 +362,12 @@ var _ = Describe("OSS mode Integration Tests", func() {
 					},
 				}
 
-				withCaptainConfig(cfg, tmp, func() {
+				withCaptainConfig(cfg, tmp, func(configPath string) {
 					result := runCaptain(captainArgs{
 						args: []string{
 							"run",
 							"captain-cli-functional-tests",
-							"--config-file", filepath.Join(tmp, ".captain/config.yaml"),
+							"--config-file", configPath,
 						},
 						env: getEnvWithoutAccessToken(),
 					})
@@ -426,12 +426,12 @@ var _ = Describe("OSS mode Integration Tests", func() {
 					},
 				}
 
-				withCaptainConfig(cfg, tmp, func() {
+				withCaptainConfig(cfg, tmp, func(configPath string) {
 					result := runCaptain(captainArgs{
 						args: []string{
 							"run",
 							"captain-cli-functional-tests",
-							"--config-file", filepath.Join(tmp, ".captain/config.yaml"),
+							"--config-file", configPath,
 						},
 						env: getEnvWithoutAccessToken(),
 					})


### PR DESCRIPTION
Adds integration tests for the reporters both with and without a config file (that they produce files, nothing about the content since that may change version to version and is itself unit tested)