### PR TITLE
If no reporters are set in the suite config, make a new config map

### DIFF
--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -326,6 +326,9 @@ func bindRunCmdFlags(cfg Config, cliArgs CliArgs) Config {
 
 		if len(cliArgs.reporters) > 0 {
 			reporterConfig := suiteConfig.Output.Reporters
+			if reporterConfig == nil {
+				reporterConfig = make(map[string]string)
+			}
 
 			for _, r := range cliArgs.reporters {
 				name, path, _ := strings.Cut(r, "=")


### PR DESCRIPTION
The changes in #16 introduced new problems with reporter configurations. `map[string]string` in Go defaults to `nil`, not an empty map 😞 Right now, if you _don't_ specify config file reporters but _do_ try to specify a reporter via CLI flag, you get a nil pointer error. 

This fixes that. I'll get tests in place ASAP (how we discussed them in Slack), but this'll fix the bug (tested by hand locally with config file only, flags only, and both).