### PR TITLE
backwards compatibility testing

### DIFF
--- a/.captain/config.yaml
+++ b/.captain/config.yaml
@@ -8,7 +8,7 @@ test-suites:
     results:
       path: report.xml
   backwards-compatibility:
-    command: nix develop --command mage integrationTestsFromTag
+    command: nix develop --command mage integrationTest
     fail-on-upload-error: true
     output:
       reporters:

--- a/.captain/config.yaml
+++ b/.captain/config.yaml
@@ -7,7 +7,7 @@ test-suites:
         github-step-summary:
     results:
       path: report.xml
-  backwards-compatibility:
+  captain-cli-backwards-compatibility:
     command: nix develop --command mage integrationTest
     fail-on-upload-error: true
     output:

--- a/.captain/config.yaml
+++ b/.captain/config.yaml
@@ -7,3 +7,11 @@ test-suites:
         github-step-summary:
     results:
       path: report.xml
+  backwards-compatibility:
+    command: nix develop --command mage integrationTestsFromTag
+    fail-on-upload-error: true
+    output:
+      reporters:
+        github-step-summary:
+    results:
+      path: report.xml

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -99,7 +99,7 @@ jobs:
           git fetch --tags
           git checkout ${{ matrix.legacy_version }}
       - name: run integration tests from ${{ matrix.legacy_version }}
-        run: ./captain run backwards-compatibility
+        run: ./captain run captain-cli-backwards-compatibility
         env:
           RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
           RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: checkout old version
         run: |
           git fetch --tags
-          git checkout ${{ matrix.legacy_version }}
+          git checkout ${{ matrix.legacy_version }} -- ./test
       - name: run integration tests from ${{ matrix.legacy_version }}
         run: ./captain run captain-cli-backwards-compatibility
         env:

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -13,7 +13,10 @@ jobs:
           extra_nix_config: |
             keep-derivations = true
             keep-outputs = true
-      - run: CGO_ENABLED=0 LDFLAGS="-w -s" nix develop --command mage
+      - run: nix develop --command mage
+        env:
+          CGO_ENABLED: 0
+          LDFLAGS: -w -s
       - run: ./captain run captain-cli-ginkgo
         env:
           RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
@@ -85,13 +88,21 @@ jobs:
           extra_nix_config: |
             keep-derivations = true
             keep-outputs = true
-      - name: Run legacy tests against version ${{ matrix.legacy_version }}
-        run: nix develop --command mage integrationTestsFromTag
+
+      - name: build captain
+        run: nix develop --command mage
         env:
-          LEGACY_VERSION_TO_TEST: ${{ matrix.legacy_version }}
-          REPORT: true
           CGO_ENABLED: 0
           LDFLAGS: -w -s
+      - name: checkout old version
+        run: |
+          git fetch --tags
+          git checkout ${{ matrix.legacy_version }}
+      - name: run integration tests from ${{ matrix.legacy_version }}
+        run: ./captain run backwards-compatibility
+        env:
           RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
           RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
           DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+          REPORT: true
+          LEGACY_VERSION_TO_TEST: ${{ matrix.legacy_version }}

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        legacy_version: ${{ fromJSON(needs.which-tags-to-test.outputs.versions) }}
+        legacy_version: ${{ fromJSON(needs.which-versions-to-test.outputs.versions) }}
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -53,11 +53,11 @@ jobs:
       - run: nix develop --command go mod tidy
       - run: git diff-index --quiet HEAD
 
-  which-tags-to-test:
+  which-versions-to-test:
     name: Determine which tags to test for backwards compatibility
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.output-tags.outputs.tags }}
+      versions: ${{ steps.output-tags.outputs.versions }}
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
@@ -67,16 +67,17 @@ jobs:
             keep-outputs = true
       - run: |
           git fetch --tags
-          echo "tags=$(nix develop --command mage legacyTestSuiteTags)" >> "$GITHUB_OUTPUT"
+          echo "versions=$(nix develop --command mage legacyTestSuiteTags)" >> "$GITHUB_OUTPUT"
         id: output-tags
 
   backwards-compatibility-tests:
     name: Backwards compatibility tests
-    needs: which-tags-to-test
+    needs: which-versions-to-test
+    if: ${{ needs.which-versions-to-test.outputs.versions != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: ${{ fromJSON(needs.which-tags-to-test.outputs.tags) }}
+        legacy_version: ${{ fromJSON(needs.which-tags-to-test.outputs.versions) }}
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
@@ -84,10 +85,10 @@ jobs:
           extra_nix_config: |
             keep-derivations = true
             keep-outputs = true
-      - name: Run legacy tests against version ${{ matrix.tag }}
+      - name: Run legacy tests against version ${{ matrix.legacy_version }}
         run: nix develop --command mage integrationTestsFromTag
         env:
-          tag: ${{ matrix.tag }}
+          LEGACY_VERSION_TO_TEST: ${{ matrix.legacy_version }}
           REPORT: true
           CGO_ENABLED: 0
           LDFLAGS: -w -s

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -52,3 +52,45 @@ jobs:
             keep-outputs = true
       - run: nix develop --command go mod tidy
       - run: git diff-index --quiet HEAD
+
+  which-tags-to-test:
+    name: Determine which tags to test for backwards compatibility
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.output-tags.outputs.tags }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            keep-derivations = true
+            keep-outputs = true
+      - run: |
+          git fetch --tags
+          echo "tags=$(nix develop --command mage legacyTestSuiteTags)" >> "$GITHUB_OUTPUT"
+        id: output-tags
+
+  backwards-compatibility-tests:
+    name: Backwards compatibility tests
+    needs: which-tags-to-test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tag: ${{ fromJSON(needs.which-tags-to-test.outputs.tags) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            keep-derivations = true
+            keep-outputs = true
+      - name: Run legacy tests against version ${{ matrix.tag }}
+        run: nix develop --command mage integrationTestsFromTag
+        env:
+          tag: ${{ matrix.tag }}
+          REPORT: true
+          CGO_ENABLED: 0
+          LDFLAGS: -w -s
+          RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+          RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
+          DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require github.com/mileusna/useragent v1.2.1
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+	github.com/blang/semver/v4 v4.0.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 )
 
@@ -27,12 +28,12 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	golang.org/x/tools v0.7.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
 require (
 	github.com/caarlos0/env/v7 v7.1.0
 	github.com/kr/pretty v0.3.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
 github.com/caarlos0/env/v7 v7.1.0 h1:9lzTF5amyQeWHZzuZeKlCb5FWSUxpG1js43mhbY8ozg=
@@ -30,6 +32,7 @@ github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -84,8 +87,9 @@ golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/magefile.go
+++ b/magefile.go
@@ -148,14 +148,15 @@ func findTagsWithChangesInTest() ([]string, error) {
 		return nil, err
 	}
 
-	minimumVersion := semver.Version{Major: 1, Minor: 9, Patch: 4}
+	// versions AFTER this will be included in tags to test
+	oneBeforeMinimumVersion := semver.Version{Major: 1, Minor: 10, Patch: 1}
 
 	var versionTags []semver.Version
 
 	for _, tag := range strings.Split(string(out), "\n") {
 		tagVersion, err := semver.ParseTolerant(tag)
 		// ignore error, filter out version < 1.9.5
-		if err == nil && tagVersion.GTE(minimumVersion) {
+		if err == nil && tagVersion.GTE(oneBeforeMinimumVersion) {
 			versionTags = append(versionTags, tagVersion)
 		}
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -156,7 +156,10 @@ func findTagsWithChangesInTest() ([]string, error) {
 	for _, tag := range strings.Split(string(out), "\n") {
 		tagVersion, err := semver.ParseTolerant(tag)
 		// ignore error, filter out version < 1.9.5
-		if err == nil && tagVersion.GTE(oneBeforeMinimumVersion) {
+		if err == nil &&
+			len(tagVersion.Pre) == 0 && // not pre-release
+			tagVersion.GTE(oneBeforeMinimumVersion) {
+
 			versionTags = append(versionTags, tagVersion)
 		}
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -100,15 +100,11 @@ func UnitTest(ctx context.Context) error {
 
 // Test executes the test-suite for the Captain-CLI.
 func IntegrationTest(ctx context.Context) error {
-	mg.Deps(Build)
-
-	// if LEGACY_VERSION_TO_TEST is set, checkout that version and then run integration tests
-	// perhaps in the future we'll archive the test binaries but for now we just checkout the rev.
-	if os.Getenv("LEGACY_VERSION_TO_TEST") != "" {
-		err := sh.RunV("git", "checkout", os.Getenv("LEGACY_VERSION_TO_TEST"))
-		if err != nil {
-			return err
-		}
+	if os.Getenv("LEGACY_VERSION_TO_TEST") == "" {
+		// only build captain if we're running tests against the latest captain version
+		// so that we can build against the active, branch, then run integration tests from a previous commit against that
+		// binary
+		mg.Deps(Build)
 	}
 
 	return (makeTestTask("-tags", "integration", "./test/"))(ctx)

--- a/magefile.go
+++ b/magefile.go
@@ -129,6 +129,7 @@ func makeTestTask(args ...string) func(ctx context.Context) error {
 	}
 }
 
+// this prints out a json-formatted list of tags where the ./test directory has changed
 func LegacyTestSuiteTags(ctx context.Context) error {
 	tagsWithChanges, err := findTagsWithChangesInTest()
 	if err != nil {

--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -38,7 +38,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(BeEmpty())
+					withoutBackwardsCompatibility(func() {
+						// stderr may start showing deprecation warnings
+						Expect(result.stderr).To(BeEmpty())
+					})
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -54,7 +57,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
+					})
 					Expect(result.exitCode).To(Equal(123))
 				})
 			})
@@ -95,7 +100,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(BeEmpty())
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(BeEmpty())
+					})
 					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -114,7 +121,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
+					})
 					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'"))
 					Expect(result.exitCode).To(Equal(123))
 				})
@@ -133,7 +142,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 					env: getEnvWithAccessToken(),
 				})
 
-				Expect(result.stderr).To(BeEmpty())
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(BeEmpty())
+				})
 				Expect(result.exitCode).To(Equal(0))
 			})
 
@@ -148,7 +159,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 					env: getEnvWithAccessToken(),
 				})
 
-				Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
+				})
 				Expect(result.exitCode).To(Equal(123))
 			})
 		})
@@ -169,7 +182,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+					})
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -188,7 +203,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+					})
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/y.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -219,7 +236,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(BeEmpty())
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(BeEmpty())
+					})
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/d_spec.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -236,7 +255,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					Expect(result.stderr).To(BeEmpty())
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(BeEmpty())
+					})
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/c_spec.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -254,8 +275,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 					env: getEnvWithAccessToken(),
 				})
 
-				Expect(result.stderr).To(BeEmpty())
-				Expect(result.stdout).To(BeEmpty())
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(BeEmpty())
+					Expect(result.stdout).To(BeEmpty())
+				})
 				Expect(result.exitCode).To(Equal(0))
 			})
 		})

--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests", func() {
+var _ = Describe("Cloud Mode Integration Tests", func() {
 	BeforeEach(func() {
 		Expect(os.Getenv("RWX_ACCESS_TOKEN_STAGING")).ToNot(BeEmpty(), "These integration tests require a valid RWX_ACCESS_TOKEN_STAGING")
 	})
@@ -23,7 +23,6 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 			env["RWX_ACCESS_TOKEN"] = os.Getenv("RWX_ACCESS_TOKEN_STAGING")
 			return env
 		}
-
 		Describe("captain run", func() {
 			Context("quarantining", func() {
 				It("succeeds when all failures quarantined", func() {
@@ -38,10 +37,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						// stderr may start showing deprecation warnings
-						Expect(result.stderr).To(BeEmpty())
-					})
+					Expect(result.stderr).To(BeEmpty())
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -57,9 +53,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
-					})
+					Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
 					Expect(result.exitCode).To(Equal(123))
 				})
 			})
@@ -100,9 +94,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(BeEmpty())
-					})
+					Expect(result.stderr).To(BeEmpty())
 					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -121,9 +113,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
-					})
+					Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
 					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'"))
 					Expect(result.exitCode).To(Equal(123))
 				})
@@ -142,9 +132,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 					env: getEnvWithAccessToken(),
 				})
 
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(BeEmpty())
-				})
+				Expect(result.stderr).To(BeEmpty())
 				Expect(result.exitCode).To(Equal(0))
 			})
 
@@ -159,9 +147,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 					env: getEnvWithAccessToken(),
 				})
 
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
-				})
+				Expect(result.stderr).To(Equal("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
 			})
 		})
@@ -182,9 +168,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
-					})
+					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -203,9 +187,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
-					})
+					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/y.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -236,9 +218,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(BeEmpty())
-					})
+					Expect(result.stderr).To(BeEmpty())
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/d_spec.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -255,9 +235,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 						env: getEnvWithAccessToken(),
 					})
 
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(BeEmpty())
-					})
+					Expect(result.stderr).To(BeEmpty())
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/c_spec.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
@@ -275,10 +253,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 					env: getEnvWithAccessToken(),
 				})
 
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(BeEmpty())
-					Expect(result.stdout).To(BeEmpty())
-				})
+				Expect(result.stderr).To(BeEmpty())
+				Expect(result.stdout).To(BeEmpty())
 				Expect(result.exitCode).To(Equal(0))
 			})
 		})

--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Cloud Mode Integration Tests", func() {
+var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests", func() {
 	BeforeEach(func() {
 		Expect(os.Getenv("RWX_ACCESS_TOKEN_STAGING")).ToNot(BeEmpty(), "These integration tests require a valid RWX_ACCESS_TOKEN_STAGING")
 	})

--- a/test/fixtures/integration-tests/captain-configs/junit-xml-reporter.printf-yaml
+++ b/test/fixtures/integration-tests/captain-configs/junit-xml-reporter.printf-yaml
@@ -1,0 +1,29 @@
+cloud:
+  api-host: ""
+  disabled: false
+  insecure: false
+flags: {}
+output:
+  debug: false
+test-suites:
+  captain-cli-functional-tests:
+    command: bash -c 'exit 123'
+    fail-on-upload-error: true
+    output:
+      print-summary: false
+      reporters:
+        junit-xml: %s
+      quiet: false
+    results:
+      framework: ""
+      language: ""
+      path: fixtures/integration-tests/rspec-failed-not-quarantined.json
+    retries:
+      attempts: 0
+      command: ""
+      fail-fast: false
+      flaky-attempts: 0
+      maxtests: ""
+      post-retry-commands: []
+      pre-retry-commands: []
+      intermediate-artifacts-path: ""

--- a/test/fixtures/integration-tests/captain-configs/markdown-summary-reporter.printf-yaml
+++ b/test/fixtures/integration-tests/captain-configs/markdown-summary-reporter.printf-yaml
@@ -1,0 +1,29 @@
+cloud:
+  api-host: ""
+  disabled: false
+  insecure: false
+flags: {}
+output:
+  debug: false
+test-suites:
+  captain-cli-functional-tests:
+    command: bash -c 'exit 123'
+    fail-on-upload-error: true
+    output:
+      print-summary: false
+      reporters:
+        markdown-summary: %s
+      quiet: false
+    results:
+      framework: ""
+      language: ""
+      path: fixtures/integration-tests/rspec-failed-not-quarantined.json
+    retries:
+      attempts: 0
+      command: ""
+      fail-fast: false
+      flaky-attempts: 0
+      maxtests: ""
+      post-retry-commands: []
+      pre-retry-commands: []
+      intermediate-artifacts-path: ""

--- a/test/fixtures/integration-tests/captain-configs/rwx-v1-json-reporter.printf-yaml
+++ b/test/fixtures/integration-tests/captain-configs/rwx-v1-json-reporter.printf-yaml
@@ -1,0 +1,29 @@
+cloud:
+  api-host: ""
+  disabled: false
+  insecure: false
+flags: {}
+output:
+  debug: false
+test-suites:
+  captain-cli-functional-tests:
+    command: bash -c 'exit 123'
+    fail-on-upload-error: true
+    output:
+      print-summary: false
+      reporters:
+        rwx-v1-json: %s
+      quiet: false
+    results:
+      framework: ""
+      language: ""
+      path: fixtures/integration-tests/rspec-failed-not-quarantined.json
+    retries:
+      attempts: 0
+      command: ""
+      fail-fast: false
+      flaky-attempts: 0
+      maxtests: ""
+      post-retry-commands: []
+      pre-retry-commands: []
+      intermediate-artifacts-path: ""

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -218,3 +218,30 @@ func withCaptainConfig(cfg cli.ConfigFile, rootDir string, body func(configPath 
 
 	body(configPath)
 }
+
+// Integration tests are run to ensure that captain behaves as expected as well as to ensure background compatibility
+// They're here to ensure
+// - old CLI args should work
+// - old ENV vars should work
+// - old config files should work
+// Some guidelines for writing them:
+// - avoid asserting on STDERR
+// - assertions should be as lenient as possible (e.g. avoid asserting on exact values when it's unnecessary to guarantee compatibility)
+//
+// If you want to write tighter assertions that you expect to break slightly future versions, wrap those assertions
+// (or the whole tests) in `withoutBackwardsCompatibility`
+func withoutBackwardsCompatibility(incompatibleClosure func()) {
+	if os.Getenv("LEGACY_VERSION_TO_TEST") == "" {
+		incompatibleClosure()
+	}
+}
+
+// we add a prefix to top level describes to allow quarantining (disabling) of legacy tests that become invalid / are subject to a breaking change
+func versionedPrefixForQuarantining() string {
+	version := os.Getenv("LEGACY_VERSION_TO_TEST")
+	if os.Getenv("LEGACY_VERSION_TO_TEST") == "" {
+		return ""
+	} else {
+		return version + ": "
+	}
+}

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -194,48 +193,3 @@ func withAndWithoutInheritedEnv(sharedTests sharedTestGen) {
 type envGenerator func() map[string]string
 
 type sharedTestGen func(envGenerator, string)
-
-func withCaptainConfig(cfg string, rootDir string, body func(configPath string)) {
-	// TODO set RootDir on the config file once we get that merged
-	configPath := filepath.Join(rootDir, ".captain/config.yaml")
-
-	err := os.MkdirAll(filepath.Dir(configPath), 0o750)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = os.WriteFile(configPath, []byte(cfg), 0o600)
-	Expect(err).NotTo(HaveOccurred())
-
-	defer func() {
-		err := os.Remove(configPath)
-		Expect(err).NotTo(HaveOccurred())
-	}()
-
-	body(configPath)
-}
-
-// Integration tests are run to ensure that captain behaves as expected as well as to ensure background compatibility
-// They're here to ensure
-// - old CLI args should work
-// - old ENV vars should work
-// - old config files should work
-// Some guidelines for writing them:
-// - avoid asserting on STDERR
-// - assertions should be as lenient as possible (e.g. avoid asserting on exact values when it's unnecessary to guarantee compatibility)
-//
-// If you want to write tighter assertions that you expect to break slightly future versions, wrap those assertions
-// (or the whole tests) in `withoutBackwardsCompatibility`
-func withoutBackwardsCompatibility(incompatibleClosure func()) {
-	if os.Getenv("LEGACY_VERSION_TO_TEST") == "" {
-		incompatibleClosure()
-	}
-}
-
-// we add a prefix to top level describes to allow quarantining (disabling) of legacy tests that become invalid / are subject to a breaking change
-func versionedPrefixForQuarantining() string {
-	version := os.Getenv("LEGACY_VERSION_TO_TEST")
-	if os.Getenv("LEGACY_VERSION_TO_TEST") == "" {
-		return ""
-	} else {
-		return version + ": "
-	}
-}

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -13,11 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rwx-research/captain-cli/internal/cli"
 	"github.com/rwx-research/captain-cli/test/helpers"
 )
 
@@ -198,17 +195,14 @@ type envGenerator func() map[string]string
 
 type sharedTestGen func(envGenerator, string)
 
-func withCaptainConfig(cfg cli.ConfigFile, rootDir string, body func(configPath string)) {
+func withCaptainConfig(cfg string, rootDir string, body func(configPath string)) {
 	// TODO set RootDir on the config file once we get that merged
 	configPath := filepath.Join(rootDir, ".captain/config.yaml")
 
 	err := os.MkdirAll(filepath.Dir(configPath), 0o750)
 	Expect(err).NotTo(HaveOccurred())
 
-	configFile, err := os.Create(configPath)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = yaml.NewEncoder(configFile).Encode(cfg)
+	err = os.WriteFile(configPath, []byte(cfg), 0o600)
 	Expect(err).NotTo(HaveOccurred())
 
 	defer func() {

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rwx-research/captain-cli"
-	"github.com/rwx-research/captain-cli/internal/cli"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -216,6 +215,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 		})
 
 		Describe("captain run", func() {
+			loadCaptainConfig := func(path string, substitution string) string {
+				data, err := os.ReadFile(path)
+				Expect(err).ToNot(HaveOccurred())
+				return fmt.Sprintf(string(data), substitution)
+			}
 			It("fails & passes through exit code on failure when results files is missing", func() {
 				result := runCaptain(captainArgs{
 					args: []string{
@@ -305,22 +309,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				tmp, err := os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
 
-				os.Remove(filepath.Join(tmp, "markdown.md"))
+				outputPath := filepath.Join(tmp, "markdown.md")
+				os.Remove(outputPath)
 
-				cfg := cli.ConfigFile{
-					TestSuites: map[string]cli.SuiteConfig{
-						"captain-cli-functional-tests": {
-							Command:           "bash -c 'exit 123'",
-							FailOnUploadError: true,
-							Output: cli.SuiteConfigOutput{
-								Reporters: map[string]string{"markdown-summary": filepath.Join(tmp, "markdown.md")},
-							},
-							Results: cli.SuiteConfigResults{
-								Path: "fixtures/integration-tests/rspec-failed-not-quarantined.json",
-							},
-						},
-					},
-				}
+				cfg := loadCaptainConfig("fixtures/integration-tests/captain-configs/markdown-summary-reporter.printf-yaml", outputPath)
 
 				withCaptainConfig(cfg, tmp, func(configPath string) {
 					result := runCaptain(captainArgs{
@@ -332,7 +324,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					_, err = os.Stat(filepath.Join(tmp, "markdown.md"))
+					_, err = os.Stat(outputPath)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result.exitCode).To(Equal(123))
 
@@ -374,22 +366,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				tmp, err := os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
 
-				os.Remove(filepath.Join(tmp, "rwx-v1.json"))
+				outputPath := filepath.Join(tmp, "rwx-v1.json")
+				os.Remove(outputPath)
 
-				cfg := cli.ConfigFile{
-					TestSuites: map[string]cli.SuiteConfig{
-						"captain-cli-functional-tests": {
-							Command:           "bash -c 'exit 123'",
-							FailOnUploadError: true,
-							Output: cli.SuiteConfigOutput{
-								Reporters: map[string]string{"rwx-v1-json": filepath.Join(tmp, "rwx-v1.json")},
-							},
-							Results: cli.SuiteConfigResults{
-								Path: "fixtures/integration-tests/rspec-failed-not-quarantined.json",
-							},
-						},
-					},
-				}
+				cfg := loadCaptainConfig("fixtures/integration-tests/captain-configs/rwx-v1-json-reporter.printf-yaml", outputPath)
 
 				withCaptainConfig(cfg, tmp, func(configPath string) {
 					result := runCaptain(captainArgs{
@@ -401,7 +381,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					_, err = os.Stat(filepath.Join(tmp, "rwx-v1.json"))
+					_, err = os.Stat(outputPath)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result.exitCode).To(Equal(123))
 
@@ -443,22 +423,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				tmp, err := os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
 
-				os.Remove(filepath.Join(tmp, "junit.xml"))
+				outputPath := filepath.Join(tmp, "junit.xml")
+				os.Remove(outputPath)
 
-				cfg := cli.ConfigFile{
-					TestSuites: map[string]cli.SuiteConfig{
-						"captain-cli-functional-tests": {
-							Command:           "bash -c 'exit 123'",
-							FailOnUploadError: true,
-							Output: cli.SuiteConfigOutput{
-								Reporters: map[string]string{"junit-xml": filepath.Join(tmp, "junit.xml")},
-							},
-							Results: cli.SuiteConfigResults{
-								Path: "fixtures/integration-tests/rspec-failed-not-quarantined.json",
-							},
-						},
-					},
-				}
+				cfg := loadCaptainConfig("fixtures/integration-tests/captain-configs/junit-xml-reporter.printf-yaml", outputPath)
 
 				withCaptainConfig(cfg, tmp, func(configPath string) {
 					result := runCaptain(captainArgs{
@@ -470,7 +438,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					_, err = os.Stat(filepath.Join(tmp, "junit.xml"))
+					_, err = os.Stat(outputPath)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(result.exitCode).To(Equal(123))

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", func() {
+var _ = Describe("OSS mode Integration Tests", func() {
 	randomSuiteId := func() string {
 		// create a random suite ID so that concurrent tests don't try to read / write from the same timings files
 		suiteUUID, err := uuid.NewRandom()
@@ -32,7 +32,6 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 			delete(env, "RWX_ACCESS_TOKEN")
 			return env
 		}
-
 		Describe("captain --version", func() {
 			It("renders the version I expect", func() {
 				result := runCaptain(captainArgs{
@@ -41,12 +40,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(result.exitCode).To(Equal(0))
-				Expect(result.stdout).To(MatchRegexp(`^v\d+\.\d+\.\d+-?`))
-
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stdout).To(Equal(captain.Version))
-					Expect(result.stderr).To(BeEmpty())
-				})
+				Expect(result.stdout).To(Equal(captain.Version))
+				Expect(result.stdout).To(MatchRegexp(`^v\d+\.\d+\.\d+$`))
+				Expect(result.stderr).To(BeEmpty())
 			})
 		})
 
@@ -68,15 +64,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 							env: getEnvWithoutAccessToken(),
 						})
 
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
 						Expect(result.exitCode).To(Equal(0))
-
-						withoutBackwardsCompatibility(func() {
-							Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
-						})
 					})
 
-					It("sets partition 1 correctly when delimiter is set via env var", func() {
+				It("sets partition 1 correctly when delimiter is set via env var", func() {
 						env := getEnvWithoutAccessToken()
 						env["CAPTAIN_DELIMITER"] = ","
 
@@ -93,15 +86,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 							env: env,
 						})
 
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
 						Expect(result.exitCode).To(Equal(0))
-
-						withoutBackwardsCompatibility(func() {
-							Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
-						})
 					})
 				})
-
 				It("sets partition 1 correctly", func() {
 					result := runCaptain(captainArgs{
 						args: []string{
@@ -116,12 +105,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
+					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
 					Expect(result.exitCode).To(Equal(0))
-
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
-					})
 				})
 
 				It("sets partition 2 correctly", func() {
@@ -138,12 +124,9 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
+					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/y.rb"))
 					Expect(result.exitCode).To(Equal(0))
-
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
-					})
 				})
 			})
 
@@ -215,11 +198,6 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 		})
 
 		Describe("captain run", func() {
-			loadCaptainConfig := func(path string, substitution string) string {
-				data, err := os.ReadFile(path)
-				Expect(err).ToNot(HaveOccurred())
-				return fmt.Sprintf(string(data), substitution)
-			}
 			It("fails & passes through exit code on failure when results files is missing", func() {
 				result := runCaptain(captainArgs{
 					args: []string{
@@ -230,12 +208,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					},
 					env: getEnvWithoutAccessToken(),
 				})
-				Expect(result.exitCode).To(Equal(123))
 
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-					Expect(result.stdout).To(BeEmpty())
-				})
+				// Stderr being empty isn't ideal. See: https://github.com/rwx-research/captain-cli/issues/243
+				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				Expect(result.stdout).To(BeEmpty())
+				Expect(result.exitCode).To(Equal(123))
 			})
 
 			It("fails & passes through exit code on failure", func() {
@@ -249,11 +226,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					env: getEnvWithoutAccessToken(),
 				})
 
+				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
-
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				})
 			})
 
 			It("allows using the -- command specification", func() {
@@ -267,10 +241,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					env: getEnvWithoutAccessToken(),
 				})
 
+				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				})
 			})
 
 			It("allows combining the --command specification with the -- specification", func() {
@@ -285,10 +257,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					env: getEnvWithoutAccessToken(),
 				})
 
+				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				})
 			})
 
 			It("accepts --suite-id argument", func() {
@@ -305,177 +275,6 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				Expect(result.exitCode).To(Equal(0))
 			})
 
-			It("produces markdown-summary reports via config file", func() {
-				tmp, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-
-				outputPath := filepath.Join(tmp, "markdown.md")
-				os.Remove(outputPath)
-
-				cfg := loadCaptainConfig("fixtures/integration-tests/captain-configs/markdown-summary-reporter.printf-yaml", outputPath)
-
-				withCaptainConfig(cfg, tmp, func(configPath string) {
-					result := runCaptain(captainArgs{
-						args: []string{
-							"run",
-							"captain-cli-functional-tests",
-							"--config-file", configPath,
-						},
-						env: getEnvWithoutAccessToken(),
-					})
-
-					_, err = os.Stat(outputPath)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result.exitCode).To(Equal(123))
-
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-					})
-				})
-			})
-
-			It("produces markdown-summary reports via CLI flag", func() {
-				tmp, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-
-				os.Remove(filepath.Join(tmp, "markdown.md"))
-
-				result := runCaptain(captainArgs{
-					args: []string{
-						"run",
-						"captain-cli-functional-tests",
-						"--test-results", "fixtures/integration-tests/rspec-failed-not-quarantined.json",
-						"--fail-on-upload-error",
-						"--reporter", fmt.Sprintf("markdown-summary=%v", filepath.Join(tmp, "markdown.md")),
-						"-c", "bash -c 'exit 123'",
-					},
-					env: getEnvWithoutAccessToken(),
-				})
-
-				_, err = os.Stat(filepath.Join(tmp, "markdown.md"))
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(result.exitCode).To(Equal(123))
-
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				})
-			})
-
-			It("produces rwx-v1-json reports via config file", func() {
-				tmp, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-
-				outputPath := filepath.Join(tmp, "rwx-v1.json")
-				os.Remove(outputPath)
-
-				cfg := loadCaptainConfig("fixtures/integration-tests/captain-configs/rwx-v1-json-reporter.printf-yaml", outputPath)
-
-				withCaptainConfig(cfg, tmp, func(configPath string) {
-					result := runCaptain(captainArgs{
-						args: []string{
-							"run",
-							"captain-cli-functional-tests",
-							"--config-file", configPath,
-						},
-						env: getEnvWithoutAccessToken(),
-					})
-
-					_, err = os.Stat(outputPath)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result.exitCode).To(Equal(123))
-
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-					})
-				})
-			})
-
-			It("produces rwx-v1-json reports via CLI flag", func() {
-				tmp, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-
-				os.Remove(filepath.Join(tmp, "rwx-v1.json"))
-
-				result := runCaptain(captainArgs{
-					args: []string{
-						"run",
-						"captain-cli-functional-tests",
-						"--test-results", "fixtures/integration-tests/rspec-failed-not-quarantined.json",
-						"--fail-on-upload-error",
-						"--reporter", fmt.Sprintf("rwx-v1-json=%v", filepath.Join(tmp, "rwx-v1.json")),
-						"-c", "bash -c 'exit 123'",
-					},
-					env: getEnvWithoutAccessToken(),
-				})
-
-				_, err = os.Stat(filepath.Join(tmp, "rwx-v1.json"))
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(result.exitCode).To(Equal(123))
-
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				})
-			})
-
-			It("produces junit-xml reports via config file", func() {
-				tmp, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-
-				outputPath := filepath.Join(tmp, "junit.xml")
-				os.Remove(outputPath)
-
-				cfg := loadCaptainConfig("fixtures/integration-tests/captain-configs/junit-xml-reporter.printf-yaml", outputPath)
-
-				withCaptainConfig(cfg, tmp, func(configPath string) {
-					result := runCaptain(captainArgs{
-						args: []string{
-							"run",
-							"captain-cli-functional-tests",
-							"--config-file", configPath,
-						},
-						env: getEnvWithoutAccessToken(),
-					})
-
-					_, err = os.Stat(outputPath)
-					Expect(err).NotTo(HaveOccurred())
-
-					Expect(result.exitCode).To(Equal(123))
-
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-					})
-				})
-			})
-
-			It("produces junit-xml reports via CLI flag", func() {
-				tmp, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-
-				os.Remove(filepath.Join(tmp, "junit.xml"))
-
-				result := runCaptain(captainArgs{
-					args: []string{
-						"run",
-						"captain-cli-functional-tests",
-						"--test-results", "fixtures/integration-tests/rspec-failed-not-quarantined.json",
-						"--fail-on-upload-error",
-						"--reporter", fmt.Sprintf("junit-xml=%v", filepath.Join(tmp, "junit.xml")),
-						"-c", "bash -c 'exit 123'",
-					},
-					env: getEnvWithoutAccessToken(),
-				})
-
-				_, err = os.Stat(filepath.Join(tmp, "junit.xml"))
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(result.exitCode).To(Equal(123))
-				withoutBackwardsCompatibility(func() {
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				})
-			})
-
 			Context("command output passthrough", func() {
 				It("passes through output of test command", func() {
 					result := runCaptain(captainArgs{
@@ -488,8 +287,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stderr).To(ContainSubstring("def")) // prefix by a bunch of warnings about captain dir not existing
-					Expect(result.stdout).To(ContainSubstring("abc\nghi"))
+					Expect(result.stderr).To(HaveSuffix("def")) // prefix by a bunch of warnings about captain dir not existing
+					Expect(result.stdout).To(HavePrefix("abc\nghi"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -560,8 +359,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.exitCode).To(Equal(0))
 					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'")) // indicative of a retry
+					Expect(result.exitCode).To(Equal(0))
 				})
 
 				It("fails & passes through exit code on failure", func() {
@@ -577,8 +376,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
+					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'"))
 					Expect(result.exitCode).To(Equal(123))
-					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'")) // indicative of a retry
 				})
 
 				It("fails & passes through exit code on failure when configured via captain config", func() {
@@ -596,6 +395,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 			})
 
+			Context("quarantining", func() {
+				// note these are tested as part of the add/remove quarantine tests
+			})
+
 			Context("with abq", func() {
 				It("runs with ABQ_SET_EXIT_CODE=false when ABQ_SET_EXIT_CODE is unset", func() {
 					result := runCaptain(captainArgs{
@@ -609,8 +412,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
+					Expect(result.stdout).To(HavePrefix("exit_code=false"))
 					Expect(result.exitCode).To(Equal(0))
-					Expect(result.stdout).To(ContainSubstring("exit_code=false"))
 				})
 
 				It("runs with ABQ_SET_EXIT_CODE=false when ABQ_SET_EXIT_CODE is already set", func() {
@@ -627,7 +430,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: env,
 					})
 
-					Expect(result.stdout).To(ContainSubstring("exit_code=false"))
+					Expect(result.stdout).To(HavePrefix("exit_code=false"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -643,7 +446,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stdout).To(ContainSubstring("state_file=/tmp/captain-abq-"))
+					Expect(result.stdout).To(HavePrefix("state_file=/tmp/captain-abq-"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -661,7 +464,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: env,
 					})
 
-					Expect(result.stdout).To(ContainSubstring("state_file=/tmp/functional-abq-1234.json"))
+					Expect(result.stdout).To(HavePrefix("state_file=/tmp/functional-abq-1234.json"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 			})
@@ -734,10 +537,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 					Expect(result.exitCode).To(Equal(123))
-					withoutBackwardsCompatibility(func() {
-						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-					})
 
 					By("removing the quarantine, tests should fail again")
 

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -334,9 +334,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 
 					_, err = os.Stat(filepath.Join(tmp, "markdown.md"))
 					Expect(err).NotTo(HaveOccurred())
-
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 					Expect(result.exitCode).To(Equal(123))
+
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+					})
 				})
 			})
 
@@ -361,8 +363,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				_, err = os.Stat(filepath.Join(tmp, "markdown.md"))
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
+
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				})
 			})
 
 			It("produces rwx-v1-json reports via config file", func() {
@@ -398,9 +403,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 
 					_, err = os.Stat(filepath.Join(tmp, "rwx-v1.json"))
 					Expect(err).NotTo(HaveOccurred())
-
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 					Expect(result.exitCode).To(Equal(123))
+
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+					})
 				})
 			})
 
@@ -425,8 +432,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				_, err = os.Stat(filepath.Join(tmp, "rwx-v1.json"))
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
+
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				})
 			})
 
 			It("produces junit-xml reports via config file", func() {
@@ -463,8 +473,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					_, err = os.Stat(filepath.Join(tmp, "junit.xml"))
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 					Expect(result.exitCode).To(Equal(123))
+
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+					})
 				})
 			})
 
@@ -489,8 +502,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				_, err = os.Stat(filepath.Join(tmp, "junit.xml"))
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				})
 			})
 
 			Context("command output passthrough", func() {
@@ -505,8 +520,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stderr).To(HaveSuffix("def")) // prefix by a bunch of warnings about captain dir not existing
-					Expect(result.stdout).To(HavePrefix("abc\nghi"))
+					Expect(result.stderr).To(ContainSubstring("def")) // prefix by a bunch of warnings about captain dir not existing
+					Expect(result.stdout).To(ContainSubstring("abc\nghi"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -577,8 +592,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'")) // indicative of a retry
 					Expect(result.exitCode).To(Equal(0))
+					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'")) // indicative of a retry
 				})
 
 				It("fails & passes through exit code on failure", func() {
@@ -594,8 +609,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'"))
 					Expect(result.exitCode).To(Equal(123))
+					Expect(result.stdout).To(ContainSubstring("'./x.rb[1:1]'")) // indicative of a retry
 				})
 
 				It("fails & passes through exit code on failure when configured via captain config", func() {
@@ -613,10 +628,6 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 			})
 
-			Context("quarantining", func() {
-				// note these are tested as part of the add/remove quarantine tests
-			})
-
 			Context("with abq", func() {
 				It("runs with ABQ_SET_EXIT_CODE=false when ABQ_SET_EXIT_CODE is unset", func() {
 					result := runCaptain(captainArgs{
@@ -630,8 +641,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stdout).To(HavePrefix("exit_code=false"))
 					Expect(result.exitCode).To(Equal(0))
+					Expect(result.stdout).To(ContainSubstring("exit_code=false"))
 				})
 
 				It("runs with ABQ_SET_EXIT_CODE=false when ABQ_SET_EXIT_CODE is already set", func() {
@@ -648,7 +659,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: env,
 					})
 
-					Expect(result.stdout).To(HavePrefix("exit_code=false"))
+					Expect(result.stdout).To(ContainSubstring("exit_code=false"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -664,7 +675,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stdout).To(HavePrefix("state_file=/tmp/captain-abq-"))
+					Expect(result.stdout).To(ContainSubstring("state_file=/tmp/captain-abq-"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 
@@ -682,7 +693,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: env,
 					})
 
-					Expect(result.stdout).To(HavePrefix("state_file=/tmp/functional-abq-1234.json"))
+					Expect(result.stdout).To(ContainSubstring("state_file=/tmp/functional-abq-1234.json"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 			})
@@ -755,8 +766,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 					Expect(result.exitCode).To(Equal(123))
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+					})
 
 					By("removing the quarantine, tests should fail again")
 

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rwx-research/captain-cli/internal/cli"
 )
 
-var _ = Describe("OSS mode Integration Tests", func() {
+var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", func() {
 	randomSuiteId := func() string {
 		// create a random suite ID so that concurrent tests don't try to read / write from the same timings files
 		suiteUUID, err := uuid.NewRandom()
@@ -33,6 +33,7 @@ var _ = Describe("OSS mode Integration Tests", func() {
 			delete(env, "RWX_ACCESS_TOKEN")
 			return env
 		}
+
 		Describe("captain --version", func() {
 			It("renders the version I expect", func() {
 				result := runCaptain(captainArgs{
@@ -41,9 +42,12 @@ var _ = Describe("OSS mode Integration Tests", func() {
 				})
 
 				Expect(result.exitCode).To(Equal(0))
-				Expect(result.stdout).To(Equal(captain.Version))
 				Expect(result.stdout).To(MatchRegexp(`^v\d+\.\d+\.\d+-?`))
-				Expect(result.stderr).To(BeEmpty())
+
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stdout).To(Equal(captain.Version))
+					Expect(result.stderr).To(BeEmpty())
+				})
 			})
 		})
 

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rwx-research/captain-cli"
+	"github.com/rwx-research/captain-cli/internal/cli"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rwx-research/captain-cli/internal/cli"
 )
 
 var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", func() {
@@ -69,9 +69,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 							env: getEnvWithoutAccessToken(),
 						})
 
-						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
 						Expect(result.exitCode).To(Equal(0))
+
+						withoutBackwardsCompatibility(func() {
+							Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+						})
 					})
 
 					It("sets partition 1 correctly when delimiter is set via env var", func() {
@@ -91,9 +94,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 							env: env,
 						})
 
-						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 						Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb,fixtures/integration-tests/partition/z.rb"))
 						Expect(result.exitCode).To(Equal(0))
+
+						withoutBackwardsCompatibility(func() {
+							Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+						})
 					})
 				})
 
@@ -111,9 +117,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
 					Expect(result.exitCode).To(Equal(0))
+
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+					})
 				})
 
 				It("sets partition 2 correctly", func() {
@@ -130,9 +139,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 						env: getEnvWithoutAccessToken(),
 					})
 
-					Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/y.rb"))
 					Expect(result.exitCode).To(Equal(0))
+
+					withoutBackwardsCompatibility(func() {
+						Expect(result.stderr).To(ContainSubstring("No test file timings were matched."))
+					})
 				})
 			})
 
@@ -214,11 +226,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					},
 					env: getEnvWithoutAccessToken(),
 				})
-
-				// Stderr being empty isn't ideal. See: https://github.com/rwx-research/captain-cli/issues/243
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
-				Expect(result.stdout).To(BeEmpty())
 				Expect(result.exitCode).To(Equal(123))
+
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+					Expect(result.stdout).To(BeEmpty())
+				})
 			})
 
 			It("fails & passes through exit code on failure", func() {
@@ -232,8 +245,11 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					env: getEnvWithoutAccessToken(),
 				})
 
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
+
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				})
 			})
 
 			It("allows using the -- command specification", func() {
@@ -247,8 +263,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					env: getEnvWithoutAccessToken(),
 				})
 
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				})
 			})
 
 			It("allows combining the --command specification with the -- specification", func() {
@@ -263,8 +281,10 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 					env: getEnvWithoutAccessToken(),
 				})
 
-				Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
 				Expect(result.exitCode).To(Equal(123))
+				withoutBackwardsCompatibility(func() {
+					Expect(result.stderr).To(ContainSubstring("Error: test suite exited with non-zero exit code"))
+				})
 			})
 
 			It("accepts --suite-id argument", func() {


### PR DESCRIPTION
this PR
- checks for changes in the integration test suites between all releaesed versions after 1.10.2
- for each of those, runs the integration tests
- the integration tests prefix the top level description with the version
  - and disable some over-constrained assertions within the tests
  
  
going forward, wrap tests or assertions you don't want included in the backwards compatibility tests in `withoutBackwardsCompatibility`, e.g.
				
```go
withoutBackwardsCompatibility(func() {
  Expect(something).To(Equal("something-that-will-likely-change-between-versions"))
})
```