### PR TITLE
Fixes a few markdown summary issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require github.com/mileusna/useragent v1.2.1
 require github.com/mitchellh/go-wordwrap v1.0.1
 
 require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,10 +18,12 @@ require github.com/mattn/go-shellwords v1.0.12
 
 require github.com/mileusna/useragent v1.2.1
 
-require github.com/mitchellh/go-wordwrap v1.0.1
+require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+	github.com/mitchellh/go-wordwrap v1.0.1
+)
 
 require (
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is disabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is disabled
@@ -1,6 +1,6 @@
 # `some-suite-id` Summary
 
-6 tests, 1 flaky, 2 failed, 1 timed out, 1 skipped, 2 retries
+8 tests, 1 flaky, 2 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 
 ## 🔁 Flaky
 
@@ -65,6 +65,32 @@ file/path/three.rb:4</pre>
 
 
 <dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb:12'</code></dd>
+
+</dl>
+</details>
+
+## 🏥 Quarantined
+
+<details>
+<summary><strong>quarantined test</strong></summary>
+
+<dl>
+
+
+
+
+</dl>
+</details>
+
+## 🚫 Canceled
+
+<details>
+<summary><strong>canceled test</strong></summary>
+
+<dl>
+
+
+<dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb:14'</code></dd>
 
 </dl>
 </details>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is disabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is disabled
@@ -75,7 +75,7 @@ file/path/three.rb:4</pre>
 </dl>
 </details>
 <details>
-<summary><strong>failed test message only</strong></summary>
+<summary><strong>failed test message only w/ ansi</strong></summary>
 
 <dl>
 
@@ -86,7 +86,12 @@ file/path/three.rb:4</pre>
 <details>
 <summary>Failure Details</summary><br />
 
-<pre>expected true to equal false</pre>
+<pre>Failure/Error: expect(thanos).to eq("inevitable")
+
+  expected: "inevitable"
+       got: "evitable"
+
+  (compared using ==)</pre>
 
 </details>
 </dd>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is disabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is disabled
@@ -1,6 +1,6 @@
 # `some-suite-id` Summary
 
-8 tests, 1 flaky, 2 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
+9 tests, 1 flaky, 3 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 
 ## 🔁 Flaky
 
@@ -13,12 +13,16 @@
 
 
 <dd>
-	<details>
-		<summary><code>expected true to equal false</code></summary> <br />
-		<pre>file/path/one.rb:4
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false
+
+file/path/one.rb:4
 file/path/two.rb:4
 file/path/three.rb:4</pre>
-	</details>
+
+</details>
 </dd>
 
 </dl>
@@ -35,23 +39,57 @@ file/path/three.rb:4</pre>
 <dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb[4:5:6]'</code></dd>
 
 <dd>
-	<details>
-		<summary><code>expected true to equal false</code></summary> <br />
-		<pre>file/path/one.rb:4
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false
+
+file/path/one.rb:4
 file/path/two.rb:4
 file/path/three.rb:4</pre>
-	</details>
+
+</details>
 </dd>
 
 </dl>
 </details>
 <details>
-<summary><strong>other failed test</strong></summary>
+<summary><strong>failed test backtrace only</strong></summary>
 
 <dl>
 
 <dd>Defined at <code>some/path/to/file.rb</code></dd>
 <dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb[7:8:9]'</code></dd>
+
+<dd>
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>file/path/one.rb:4
+file/path/two.rb:4
+file/path/three.rb:4</pre>
+
+</details>
+</dd>
+
+</dl>
+</details>
+<details>
+<summary><strong>failed test message only</strong></summary>
+
+<dl>
+
+
+<dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb:15'</code></dd>
+
+<dd>
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false</pre>
+
+</details>
+</dd>
 
 </dl>
 </details>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
@@ -2,7 +2,7 @@
 
 [🔗 View in Captain Cloud](https://example.com/deep_link/test_suite_summaries/some-suite-id/some/branch/abcdef113131)
 
-8 tests, 1 flaky, 2 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
+9 tests, 1 flaky, 3 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 
 ## 🔁 Flaky
 
@@ -15,12 +15,16 @@
 
 
 <dd>
-	<details>
-		<summary><code>expected true to equal false</code></summary> <br />
-		<pre>file/path/one.rb:4
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false
+
+file/path/one.rb:4
 file/path/two.rb:4
 file/path/three.rb:4</pre>
-	</details>
+
+</details>
 </dd>
 
 </dl>
@@ -37,23 +41,57 @@ file/path/three.rb:4</pre>
 <dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb[4:5:6]'</code></dd>
 
 <dd>
-	<details>
-		<summary><code>expected true to equal false</code></summary> <br />
-		<pre>file/path/one.rb:4
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false
+
+file/path/one.rb:4
 file/path/two.rb:4
 file/path/three.rb:4</pre>
-	</details>
+
+</details>
 </dd>
 
 </dl>
 </details>
 <details>
-<summary><strong>other failed test</strong></summary>
+<summary><strong>failed test backtrace only</strong></summary>
 
 <dl>
 
 <dd>Defined at <code>some/path/to/file.rb</code></dd>
 <dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb[7:8:9]'</code></dd>
+
+<dd>
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>file/path/one.rb:4
+file/path/two.rb:4
+file/path/three.rb:4</pre>
+
+</details>
+</dd>
+
+</dl>
+</details>
+<details>
+<summary><strong>failed test message only</strong></summary>
+
+<dl>
+
+
+<dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb:15'</code></dd>
+
+<dd>
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false</pre>
+
+</details>
+</dd>
 
 </dl>
 </details>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
@@ -2,7 +2,7 @@
 
 [🔗 View in Captain Cloud](https://example.com/deep_link/test_suite_summaries/some-suite-id/some/branch/abcdef113131)
 
-6 tests, 1 flaky, 2 failed, 1 timed out, 1 skipped, 2 retries
+8 tests, 1 flaky, 2 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 
 ## 🔁 Flaky
 
@@ -67,6 +67,32 @@ file/path/three.rb:4</pre>
 
 
 <dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb:12'</code></dd>
+
+</dl>
+</details>
+
+## 🏥 Quarantined
+
+<details>
+<summary><strong>quarantined test</strong></summary>
+
+<dl>
+
+
+
+
+</dl>
+</details>
+
+## 🚫 Canceled
+
+<details>
+<summary><strong>canceled test</strong></summary>
+
+<dl>
+
+
+<dd>Retry with <code>bundle exec rspec './spec/foo/bar.rb:14'</code></dd>
 
 </dl>
 </details>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
@@ -77,7 +77,7 @@ file/path/three.rb:4</pre>
 </dl>
 </details>
 <details>
-<summary><strong>failed test message only</strong></summary>
+<summary><strong>failed test message only w/ ansi</strong></summary>
 
 <dl>
 
@@ -88,7 +88,12 @@ file/path/three.rb:4</pre>
 <details>
 <summary>Failure Details</summary><br />
 
-<pre>expected true to equal false</pre>
+<pre>Failure/Error: expect(thanos).to eq("inevitable")
+
+  expected: "inevitable"
+       got: "evitable"
+
+  (compared using ==)</pre>
 
 </details>
 </dd>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary with a custom retry template
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary with a custom retry template
@@ -1,6 +1,6 @@
 # `some-suite-id` Summary
 
-8 tests, 1 flaky, 2 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
+9 tests, 1 flaky, 3 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 
 ## 🔁 Flaky
 
@@ -13,12 +13,16 @@
 
 
 <dd>
-	<details>
-		<summary><code>expected true to equal false</code></summary> <br />
-		<pre>file/path/one.rb:4
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false
+
+file/path/one.rb:4
 file/path/two.rb:4
 file/path/three.rb:4</pre>
-	</details>
+
+</details>
 </dd>
 
 </dl>
@@ -35,23 +39,57 @@ file/path/three.rb:4</pre>
 <dd>Retry with <code>bin/rspec './spec/foo/bar.rb[4:5:6]'</code></dd>
 
 <dd>
-	<details>
-		<summary><code>expected true to equal false</code></summary> <br />
-		<pre>file/path/one.rb:4
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false
+
+file/path/one.rb:4
 file/path/two.rb:4
 file/path/three.rb:4</pre>
-	</details>
+
+</details>
 </dd>
 
 </dl>
 </details>
 <details>
-<summary><strong>other failed test</strong></summary>
+<summary><strong>failed test backtrace only</strong></summary>
 
 <dl>
 
 <dd>Defined at <code>some/path/to/file.rb</code></dd>
 <dd>Retry with <code>bin/rspec './spec/foo/bar.rb[7:8:9]'</code></dd>
+
+<dd>
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>file/path/one.rb:4
+file/path/two.rb:4
+file/path/three.rb:4</pre>
+
+</details>
+</dd>
+
+</dl>
+</details>
+<details>
+<summary><strong>failed test message only</strong></summary>
+
+<dl>
+
+
+<dd>Retry with <code>bin/rspec './spec/foo/bar.rb:15'</code></dd>
+
+<dd>
+<details>
+<summary>Failure Details</summary><br />
+
+<pre>expected true to equal false</pre>
+
+</details>
+</dd>
 
 </dl>
 </details>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary with a custom retry template
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary with a custom retry template
@@ -1,6 +1,6 @@
 # `some-suite-id` Summary
 
-6 tests, 1 flaky, 2 failed, 1 timed out, 1 skipped, 2 retries
+8 tests, 1 flaky, 2 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 
 ## 🔁 Flaky
 
@@ -65,6 +65,32 @@ file/path/three.rb:4</pre>
 
 
 <dd>Retry with <code>bin/rspec './spec/foo/bar.rb:12'</code></dd>
+
+</dl>
+</details>
+
+## 🏥 Quarantined
+
+<details>
+<summary><strong>quarantined test</strong></summary>
+
+<dl>
+
+
+
+
+</dl>
+</details>
+
+## 🚫 Canceled
+
+<details>
+<summary><strong>canceled test</strong></summary>
+
+<dl>
+
+
+<dd>Retry with <code>bin/rspec './spec/foo/bar.rb:14'</code></dd>
 
 </dl>
 </details>

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary with a custom retry template
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary with a custom retry template
@@ -75,7 +75,7 @@ file/path/three.rb:4</pre>
 </dl>
 </details>
 <details>
-<summary><strong>failed test message only</strong></summary>
+<summary><strong>failed test message only w/ ansi</strong></summary>
 
 <dl>
 
@@ -86,7 +86,12 @@ file/path/three.rb:4</pre>
 <details>
 <summary>Failure Details</summary><br />
 
-<pre>expected true to equal false</pre>
+<pre>Failure/Error: expect(thanos).to eq("inevitable")
+
+  expected: "inevitable"
+       got: "evitable"
+
+  (compared using ==)</pre>
 
 </details>
 </dd>

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/acarl005/stripansi"
+
 	"github.com/rwx-research/captain-cli/internal/errors"
 	"github.com/rwx-research/captain-cli/internal/fs"
 	"github.com/rwx-research/captain-cli/internal/targetedretries"

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -40,12 +40,18 @@ const (
 {{ if .Retries }}<dd>Retried {{ .Retries}} time{{ if ne .Retries 1 }}s{{end}}</dd>{{ end }}
 {{ if .Location }}<dd>Defined at <code>{{ .Location }}</code></dd>{{ end }}
 {{ if .Command }}<dd>Retry with <code>{{ .Command }}</code></dd>{{ end }}
-{{ if .Message }}
+{{ if or .Message .Backtrace }}
 <dd>
-	<details>
-		<summary><code>{{ .Message }}</code></summary> <br />
-		{{ if .Backtrace }}<pre>{{ .Backtrace}}</pre>{{ end }}
-	</details>
+<details>
+<summary>Failure Details</summary><br />
+{{ if and .Message .Backtrace }}
+<pre>{{ .Message}}
+
+{{ .Backtrace }}</pre>
+{{ else }}
+<pre>{{ or .Message .Backtrace }}</pre>
+{{ end }}
+</details>
 </dd>
 {{ end }}
 </dl>

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -306,7 +306,7 @@ func writeMarkdownQuarantinedSection(
 ) (bool, error) {
 	return writeMarkdownSection(
 		markdown,
-		timedOutSection,
+		quarantinedSection,
 		framework,
 		tests,
 		func(test v1.Test) *v1.TestStatus {
@@ -324,7 +324,7 @@ func writeMarkdownCanceledSection(
 ) (bool, error) {
 	return writeMarkdownSection(
 		markdown,
-		timedOutSection,
+		canceledSection,
 		framework,
 		tests,
 		func(test v1.Test) *v1.TestStatus {

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/acarl005/stripansi"
 	"github.com/rwx-research/captain-cli/internal/errors"
 	"github.com/rwx-research/captain-cli/internal/fs"
 	"github.com/rwx-research/captain-cli/internal/targetedretries"
@@ -389,8 +390,11 @@ func writeMarkdownSection(
 			Retries:  len(test.PastAttempts),
 		}
 		if failedStatus != nil {
-			markdownTest.Message = failedStatus.Message
-			markdownTest.Backtrace = strings.Join(failedStatus.Backtrace, "\n")
+			markdownTest.Backtrace = stripansi.Strip(strings.Join(failedStatus.Backtrace, "\n"))
+			if failedStatus.Message != nil {
+				strippedMessage := stripansi.Strip(*failedStatus.Message)
+				markdownTest.Message = &strippedMessage
+			}
 		}
 
 		testMarkdown := new(strings.Builder)

--- a/internal/reporting/markdown_test.go
+++ b/internal/reporting/markdown_test.go
@@ -31,6 +31,8 @@ var _ = Describe("Markdown Report", func() {
 		id4 := "./spec/foo/bar.rb:12"
 		id5 := "./spec/foo/bar.rb:11"
 		id6 := "./spec/foo/bar.rb:12"
+		id7 := "./spec/foo/bar.rb:13"
+		id8 := "./spec/foo/bar.rb:14"
 		message := "expected true to equal false"
 		fifteen := 15
 		testResults = *v1.NewTestResults(
@@ -87,6 +89,16 @@ var _ = Describe("Markdown Report", func() {
 					ID:      &id6,
 					Name:    "timed out test",
 					Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+				},
+				{
+					ID:      &id7,
+					Name:    "quarantined test",
+					Attempt: v1.TestAttempt{Status: v1.NewQuarantinedTestStatus(v1.NewTimedOutTestStatus())},
+				},
+				{
+					ID:      &id8,
+					Name:    "canceled test",
+					Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()},
 				},
 			},
 			nil,

--- a/internal/reporting/markdown_test.go
+++ b/internal/reporting/markdown_test.go
@@ -35,6 +35,12 @@ var _ = Describe("Markdown Report", func() {
 		id8 := "./spec/foo/bar.rb:14"
 		id9 := "./spec/foo/bar.rb:15"
 		message := "expected true to equal false"
+		messageWithAnsi := `[31mFailure/Error: [0m[32mexpect[0m(thanos).to eq([31m[1;31m"[0m[31minevitable[1;31m"[0m[31m[0m)[0m
+[31m[0m
+[31m  expected: "inevitable"[0m
+[31m       got: "evitable"[0m
+[31m[0m
+[31m  (compared using ==)[0m`
 		fifteen := 15
 		testResults = *v1.NewTestResults(
 			v1.RubyRSpecFramework,
@@ -109,10 +115,10 @@ var _ = Describe("Markdown Report", func() {
 				},
 				{
 					ID:   &id9,
-					Name: "failed test message only",
+					Name: "failed test message only w/ ansi",
 					Attempt: v1.TestAttempt{
 						Status: v1.NewFailedTestStatus(
-							&message,
+							&messageWithAnsi,
 							nil,
 							nil,
 						),

--- a/internal/reporting/markdown_test.go
+++ b/internal/reporting/markdown_test.go
@@ -35,7 +35,8 @@ var _ = Describe("Markdown Report", func() {
 		id8 := "./spec/foo/bar.rb:14"
 		id9 := "./spec/foo/bar.rb:15"
 		message := "expected true to equal false"
-		messageWithAnsi := `[31mFailure/Error: [0m[32mexpect[0m(thanos).to eq([31m[1;31m"[0m[31minevitable[1;31m"[0m[31m[0m)[0m
+		messageWithAnsi := `[31mFailure/Error: [0m[32mexpect[0m(thanos).to ` +
+			`eq([31m[1;31m"[0m[31minevitable[1;31m"[0m[31m[0m)[0m
 [31m[0m
 [31m  expected: "inevitable"[0m
 [31m       got: "evitable"[0m

--- a/internal/reporting/markdown_test.go
+++ b/internal/reporting/markdown_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Markdown Report", func() {
 		id6 := "./spec/foo/bar.rb:12"
 		id7 := "./spec/foo/bar.rb:13"
 		id8 := "./spec/foo/bar.rb:14"
+		id9 := "./spec/foo/bar.rb:15"
 		message := "expected true to equal false"
 		fifteen := 15
 		testResults = *v1.NewTestResults(
@@ -61,9 +62,15 @@ var _ = Describe("Markdown Report", func() {
 				},
 				{
 					ID:       &id3,
-					Name:     "other failed test",
+					Name:     "failed test backtrace only",
 					Location: &v1.Location{File: "some/path/to/file.rb"},
-					Attempt:  v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)},
+					Attempt: v1.TestAttempt{
+						Status: v1.NewFailedTestStatus(
+							nil,
+							nil,
+							[]string{"file/path/one.rb:4", "file/path/two.rb:4", "file/path/three.rb:4"},
+						),
+					},
 				},
 				{
 					ID:       &id4,
@@ -99,6 +106,17 @@ var _ = Describe("Markdown Report", func() {
 					ID:      &id8,
 					Name:    "canceled test",
 					Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()},
+				},
+				{
+					ID:   &id9,
+					Name: "failed test message only",
+					Attempt: v1.TestAttempt{
+						Status: v1.NewFailedTestStatus(
+							&message,
+							nil,
+							nil,
+						),
+					},
 				},
 			},
 			nil,


### PR DESCRIPTION
- Ensure quarantined and canceled tests end up in the right section
- Combine message and backtrace to better handle multiline message
- Strip ANSI escape codes in the markdown summary
