### PR TITLE
No-op on github-step-summary reporter when GITHUB_STEP_SUMMARY is blank

### DIFF
--- a/cmd/captain/quarantine.go
+++ b/cmd/captain/quarantine.go
@@ -44,12 +44,7 @@ func AddQuarantineFlags(rootCmd *cobra.Command, cliArgs *CliArgs) {
 					case "github-step-summary":
 						stepSummaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
 						if stepSummaryPath == "" {
-							return errors.WithDecoration(errors.NewConfigurationError(
-								"'github-step-summary' reporter misconfigured",
-								"The 'github-step-summary' reporter can only run within a GitHub Actions job where the "+
-									"'GITHUB_STEP_SUMMARY' environment variable is set.",
-								"",
-							))
+							continue
 						}
 
 						reporterFuncs[stepSummaryPath] = reporting.WriteMarkdownSummary

--- a/cmd/captain/quarantine.go
+++ b/cmd/captain/quarantine.go
@@ -32,6 +32,12 @@ func AddQuarantineFlags(rootCmd *cobra.Command, cliArgs *CliArgs) {
 			if err != nil {
 				return errors.WithStack(err)
 			}
+
+			captain, err := cli.GetService(cmd)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
 			if suiteConfig, ok := cfg.TestSuites[cliArgs.RootCliArgs.suiteID]; ok {
 				for name, path := range suiteConfig.Output.Reporters {
 					switch name {
@@ -44,6 +50,10 @@ func AddQuarantineFlags(rootCmd *cobra.Command, cliArgs *CliArgs) {
 					case "github-step-summary":
 						stepSummaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
 						if stepSummaryPath == "" {
+							captain.Log.Debug(
+								"Skipping configuration of the 'github-step-summary' reporter " +
+									"(the 'GITHUB_STEP_SUMMARY' environment variable is not set).",
+							)
 							continue
 						}
 
@@ -80,10 +90,6 @@ func AddQuarantineFlags(rootCmd *cobra.Command, cliArgs *CliArgs) {
 				UploadResults:     false,
 			}
 
-			captain, err := cli.GetService(cmd)
-			if err != nil {
-				return errors.WithStack(err)
-			}
 			err = captain.RunSuite(cmd.Context(), runConfig)
 			if _, ok := errors.AsConfigurationError(err); !ok {
 				cmd.SilenceUsage = true

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -69,12 +69,7 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 					case "github-step-summary":
 						stepSummaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
 						if stepSummaryPath == "" {
-							return errors.WithDecoration(errors.NewConfigurationError(
-								"'github-step-summary' reporter misconfigured",
-								"The 'github-step-summary' reporter can only run within a GitHub Actions job where the "+
-									"'GITHUB_STEP_SUMMARY' environment variable is set.",
-								"",
-							))
+							continue
 						}
 
 						reporterFuncs[stepSummaryPath] = reporting.WriteMarkdownSummary

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -57,6 +57,12 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 			if err != nil {
 				return errors.WithStack(err)
 			}
+
+			captain, err := cli.GetService(cmd)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
 			if suiteConfig, ok := cfg.TestSuites[cliArgs.RootCliArgs.suiteID]; ok {
 				for name, path := range suiteConfig.Output.Reporters {
 					switch name {
@@ -69,6 +75,10 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 					case "github-step-summary":
 						stepSummaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
 						if stepSummaryPath == "" {
+							captain.Log.Debug(
+								"Skipping configuration of the 'github-step-summary' reporter " +
+									"(the 'GITHUB_STEP_SUMMARY' environment variable is not set).",
+							)
 							continue
 						}
 
@@ -119,10 +129,6 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 				UploadResults:             true,
 			}
 
-			captain, err := cli.GetService(cmd)
-			if err != nil {
-				return errors.WithStack(err)
-			}
 			err = captain.RunSuite(cmd.Context(), runConfig)
 			if _, ok := errors.AsConfigurationError(err); !ok {
 				cmd.SilenceUsage = true


### PR DESCRIPTION
With the old behavior, it was a little annoying to use `github-step-summary` in the config file because running the CLI anywhere but in GitHub Actions (e.g. locally for testing) would result in an error. With this behavior, if you're not on GitHub, we just won't try to write the summary.