### PR TITLE
Release to unstable on merges to main

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -27,6 +27,16 @@ jobs:
           DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
           REPORT: true
 
+  unstable-release:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/release.yaml
+    needs: build-and-test
+    with:
+      sha: ${{ github.sha }}
+      kind: unstable
+      version:
+    secrets: inherit
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,23 @@ on:
         description: 'Version (only for production releases)'
         required: false
         type: string
+  workflow_call:
+    inputs:
+      sha:
+        description: 'Commit SHA'
+        required: true
+        type: string
+      kind:
+        description: 'Release'
+        required: true
+        type: string
+      version:
+        description: 'Version (only for production releases)'
+        required: false
+        type: string
+    secrets:
+      CLOUDFRONT_DISTRIBUTION_ID:
+        required: true
 
 jobs:
   verify-inputs:


### PR DESCRIPTION
Adds `workflow_call` to the release workflow so we can trigger it on merges to main, and does just that (triggers it on merges)