### PR TITLE
Fix a couple small release process bugs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -277,9 +277,9 @@ jobs:
 
               if [[ "$updatedPaths" == "" ]]; then
                 # shellcheck disable=SC2089
-                updatedPaths="\"/$aliasedOldPath\" \"/$aliasedNewPath\""
+                updatedPaths="/$aliasedOldPath /$aliasedNewPath"
               else
-                updatedPaths="$updatedPaths \"/$aliasedOldPath\" \"/$aliasedNewPath\""
+                updatedPaths="$updatedPaths /$aliasedOldPath /$aliasedNewPath"
               fi
             fi
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,6 +204,7 @@ jobs:
         run: |
           gh release view ${{ needs.extract-version-details.outputs.aliased-version }} || \
             gh release create ${{ needs.extract-version-details.outputs.aliased-version }} \
+            --latest=false \
             --notes "The Captain ${{ needs.extract-version-details.outputs.aliased-version }} release and tag exist to provide an easy way to download the latest ${{ needs.extract-version-details.outputs.aliased-version }}.x.x release of Captain. For example, you can always download the latest Linux x86 ${{ needs.extract-version-details.outputs.aliased-version }} release at this URL: https://github.com/rwx-research/captain/releases/download/${{ needs.extract-version-details.outputs.aliased-version }}/captain-linux-x86_64. (Look at the assets attached to this release to find the other available downloads.) This release and its assets are updated whenever a new ${{ needs.extract-version-details.outputs.aliased-version }}.x.x version of Captain is released." \
             --title "Captain ${{ needs.extract-version-details.outputs.aliased-version }}"
       - name: Push the assets from the full version release to the aliased release


### PR DESCRIPTION
**Fix bash shell expansion/quoting**

When migrating to the new process, I copied a lot of the existing behavior but made some tweaks. Previously, when accumulating the paths to invalidate, we were wrapping them in double quotes because we would set that string as a GitHub Actions output then use a GitHub Actions expression to interpolate them into the command (which would preserve the text as-is).

When using bash variable expansion instead, it was wrapping each of those quoted items in the string with an additional layer of single quotes (e.g. `create-invalidation --paths '"/some-path"' '"/other-path"'`) so we were trying to invalidate the literal path `"/some-path"` instead of `/some-path`.
 
**New aliased releases should never be the latest**

`--latest` is the default for new releases, we need to explicitly set this to `false`.