### PR TITLE
New aliased releases that are not production are also prerelease

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,6 +205,7 @@ jobs:
           gh release view ${{ needs.extract-version-details.outputs.aliased-version }} || \
             gh release create ${{ needs.extract-version-details.outputs.aliased-version }} \
             --latest=false \
+            --prerelease=${{ inputs.kind != 'production' }} \
             --notes "The Captain ${{ needs.extract-version-details.outputs.aliased-version }} release and tag exist to provide an easy way to download the latest ${{ needs.extract-version-details.outputs.aliased-version }}.x.x release of Captain. For example, you can always download the latest Linux x86 ${{ needs.extract-version-details.outputs.aliased-version }} release at this URL: https://github.com/rwx-research/captain/releases/download/${{ needs.extract-version-details.outputs.aliased-version }}/captain-linux-x86_64. (Look at the assets attached to this release to find the other available downloads.) This release and its assets are updated whenever a new ${{ needs.extract-version-details.outputs.aliased-version }}.x.x version of Captain is released." \
             --title "Captain ${{ needs.extract-version-details.outputs.aliased-version }}"
       - name: Push the assets from the full version release to the aliased release


### PR DESCRIPTION
Per title. I'll manually fix `unstable`