### PR TITLE
Only production releases (and the unstable alias) are published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -226,7 +226,7 @@ jobs:
           gh release view ${{ needs.extract-version-details.outputs.aliased-version }} || \
             gh release create ${{ needs.extract-version-details.outputs.aliased-version }} \
             --latest=false \
-            --draft=${{ inputs.kind != 'production' }} \
+            --draft=${{ inputs.kind != 'production' && inputs.kind != 'unstable' }} \
             --prerelease=${{ inputs.kind != 'production' }} \
             --notes "The Captain ${{ needs.extract-version-details.outputs.aliased-version }} release and tag exist to provide an easy way to download the latest ${{ needs.extract-version-details.outputs.aliased-version }}.x.x release of Captain. For example, you can always download the latest Linux x86 ${{ needs.extract-version-details.outputs.aliased-version }} release at this URL: https://github.com/rwx-research/captain/releases/download/${{ needs.extract-version-details.outputs.aliased-version }}/captain-linux-x86_64. (Look at the assets attached to this release to find the other available downloads.) This release and its assets are updated whenever a new ${{ needs.extract-version-details.outputs.aliased-version }}.x.x version of Captain is released." \
             --title "Captain ${{ needs.extract-version-details.outputs.aliased-version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,10 +210,11 @@ jobs:
         with:
           ref: ${{ needs.extract-version-details.outputs.full-version }}
       - name: Publish the full version release
+        if: ${{ inputs.kind == 'production' }}
         run: |
           gh release edit ${{ needs.extract-version-details.outputs.full-version }} \
             --draft=false \
-            --latest=${{ inputs.kind == 'production' }}
+            --latest
       - name: Push the aliased tags
         if: ${{ needs.extract-version-details.outputs.aliased-version != '' }}
         run: |
@@ -225,6 +226,7 @@ jobs:
           gh release view ${{ needs.extract-version-details.outputs.aliased-version }} || \
             gh release create ${{ needs.extract-version-details.outputs.aliased-version }} \
             --latest=false \
+            --draft=${{ inputs.kind != 'production' }} \
             --prerelease=${{ inputs.kind != 'production' }} \
             --notes "The Captain ${{ needs.extract-version-details.outputs.aliased-version }} release and tag exist to provide an easy way to download the latest ${{ needs.extract-version-details.outputs.aliased-version }}.x.x release of Captain. For example, you can always download the latest Linux x86 ${{ needs.extract-version-details.outputs.aliased-version }} release at this URL: https://github.com/rwx-research/captain/releases/download/${{ needs.extract-version-details.outputs.aliased-version }}/captain-linux-x86_64. (Look at the assets attached to this release to find the other available downloads.) This release and its assets are updated whenever a new ${{ needs.extract-version-details.outputs.aliased-version }}.x.x version of Captain is released." \
             --title "Captain ${{ needs.extract-version-details.outputs.aliased-version }}"


### PR DESCRIPTION
Doing this has two effects:
- One, we can keep rebuilding the same SHA for testing-* and unstable-* when working on the workflow
  - We have a check that does not allow re-release of published versions
- Two, draft releases don't show up in the public releases list (https://github.com/rwx-research/captain/releases)

This leaves vX.X.X, unstable, and vX as published releases.