### PR TITLE
Give update-cloudfront more permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,6 +248,7 @@ jobs:
       - extract-version-details
       - publish-release
     permissions:
+      contents: write
       id-token: write
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I couldn't test this in the PR since we block the Production environment outside the main branch. Turns out with the releases not being published, the actions job needs more permission to be able to see it (makes sense).

Fixes https://github.com/rwx-research/captain/actions/runs/4682103801/jobs/8295649569#step:4:12