### PR TITLE
partition args can be set by provider

### DIFF
--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -161,5 +161,9 @@ func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 	cfg = bindFrameworkFlags(cfg, cliArgs.frameworkParams, cliArgs.RootCliArgs.suiteID)
 	cfg = bindRunCmdFlags(cfg, cliArgs)
 
+	if err = setConfigContext(cmd, cfg); err != nil {
+		return cfg, errors.WithDecoration(err)
+	}
+
 	return cfg, nil
 }

--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -47,7 +47,8 @@ func getConfig(cmd *cobra.Command) (Config, error) {
 	return cfg, nil
 }
 
-func setConfig(cmd *cobra.Command, cfg Config) error {
+// adds config to cmd's context
+func setConfigContext(cmd *cobra.Command, cfg Config) error {
 	if _, err := getConfig(cmd); err == nil {
 		return errors.NewInternalError("Tried to set config on the command but it was already set. This should never happen!")
 	}

--- a/cmd/captain/config_test.go
+++ b/cmd/captain/config_test.go
@@ -20,9 +20,11 @@ var _ = Describe("InitConfig", func() {
 	BeforeEach(func() {
 		cliArgs = main.CliArgs{}
 		cmd = &cobra.Command{
-			Use: "mycli",
-			Run: func(cmd *cobra.Command, args []string) {}, // do nothing
+			Use:                "mycli",
+			Run:                func(cmd *cobra.Command, args []string) {}, // do nothing
+			DisableFlagParsing: true,                                       // without this we can't call Execute()
 		}
+		Expect(cmd.Execute()).ToNot(HaveOccurred()) // before Execute, cmd.Context() is nil
 		helpers.UnsetCIEnv()
 		os.Setenv("CAPTAIN_SUITE_ID", "some-suite")
 		err := captain.ConfigureRootCmd(cmd, &cliArgs)

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -77,7 +77,7 @@ func initCLIService(
 			return errors.WithDecoration(err)
 		}
 
-		if err = setConfig(cmd, cfg); err != nil {
+		if err = setConfigContext(cmd, cfg); err != nil {
 			return errors.WithDecoration(err)
 		}
 
@@ -216,7 +216,7 @@ func unsafeInitParsingOnly(cliArgs *CliArgs) func(*cobra.Command, []string) erro
 			return errors.WithStack(err)
 		}
 
-		if err := setConfig(cmd, cfg); err != nil {
+		if err := setConfigContext(cmd, cfg); err != nil {
 			return errors.WithStack(err)
 		}
 

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -76,10 +76,6 @@ func initCLIService(
 			return errors.WithDecoration(err)
 		}
 
-		if err = setConfigContext(cmd, cfg); err != nil {
-			return errors.WithDecoration(err)
-		}
-
 		logger := logging.NewProductionLogger()
 		if cfg.Output.Debug {
 			logger = logging.NewDebugLogger()
@@ -149,10 +145,6 @@ func unsafeInitParsingOnly(cliArgs *CliArgs) func(*cobra.Command, []string) erro
 		}
 		cfg, err := InitConfig(cmd, *cliArgs)
 		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		if err := setConfigContext(cmd, cfg); err != nil {
 			return errors.WithStack(err)
 		}
 

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -81,7 +81,9 @@ func initCLIService(
 	}
 }
 
-func initCliServiceWithConfig(cmd *cobra.Command, cfg Config, suiteID string, providerValidator func(providers.Provider) error) error {
+func initCliServiceWithConfig(
+	cmd *cobra.Command, cfg Config, suiteID string, providerValidator func(providers.Provider) error,
+) error {
 	if suiteID == "" {
 		return errors.NewConfigurationError("Invalid suite-id", "The suite ID is empty.", "")
 	}

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -86,6 +86,17 @@ func initCLIService(
 		}
 
 		suiteID := cliArgs.RootCliArgs.suiteID
+		if suiteID == "" {
+			return errors.NewConfigurationError("Invalid suite-id", "The suite ID is empty.", "")
+		}
+
+		if invalidSuiteIDRegexp.Match([]byte(suiteID)) {
+			return errors.NewConfigurationError(
+				"Invalid suite-id",
+				"A suite ID can only contain alphanumeric characters, `_` and `-`.",
+				"Please make sure that the ID doesn't contain any special characters.",
+			)
+		}
 
 		apiClient, err := makeAPIClient(cfg, providerValidator, logger, suiteID)
 		if err != nil {
@@ -207,10 +218,6 @@ func makeAPIClient(
 		}))
 	}
 
-	if suiteID == "" {
-		return nil, errors.NewConfigurationError("Invalid suite-id", "The suite ID is empty.", "")
-	}
-
 	if !cfg.Cloud.Disabled {
 		logger.Warnf("Unable to find RWX_ACCESS_TOKEN in the environment. Captain will default to OSS mode.")
 		logger.Warnf("You can silence this warning by setting the following in the config file:")
@@ -219,17 +226,10 @@ func makeAPIClient(
 		logger.Warnf("  disabled: true")
 		logger.Warnf("")
 	}
+
 	if cfg.Secrets.APIToken != "" {
 		logger.Warnf("Captain detected an RWX_ACCESS_TOKEN in your environment, however Cloud mode was disabled.")
 		logger.Warnf("To start using Captain Cloud, please remove the 'cloud.disabled' setting in the config file.")
-	}
-
-	if invalidSuiteIDRegexp.Match([]byte(suiteID)) {
-		return nil, errors.NewConfigurationError(
-			"Invalid suite-id",
-			"A suite ID can only contain alphanumeric characters, `_` and `-`.",
-			"Please make sure that the ID doesn't contain any special characters.",
-		)
 	}
 
 	flakesFilePath, err := findInParentDir(filepath.Join(captainDirectory, suiteID, flakesFileName))

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"github.com/rwx-research/captain-cli/internal/backend"
 	"github.com/rwx-research/captain-cli/internal/backend/local"
@@ -67,8 +68,6 @@ func initCLIService(
 	providerValidator func(providers.Provider) error,
 ) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		var apiClient backend.Client
-
 		if err := extractSuiteIDFromPositionalArgs(&cliArgs.RootCliArgs, args); err != nil {
 			return err
 		}
@@ -88,81 +87,7 @@ func initCLIService(
 
 		suiteID := cliArgs.RootCliArgs.suiteID
 
-		if cfg.Secrets.APIToken != "" && !cfg.Cloud.Disabled {
-			var provider providers.Provider
-			provider, err = cfg.ProvidersEnv.MakeProvider()
-			if err != nil {
-				return errors.WithDecoration(errors.Wrap(err, "failed to construct provider"))
-			}
-			err = providerValidator(provider)
-			if err != nil {
-				return errors.WithDecoration(err)
-			}
-
-			apiClient, err = remote.NewClient(remote.ClientConfig{
-				Debug:    cfg.Output.Debug,
-				Host:     cfg.Cloud.APIHost,
-				Insecure: cfg.Cloud.Insecure,
-				Log:      logger,
-				Token:    cfg.Secrets.APIToken,
-				Provider: provider,
-			})
-		} else {
-			var flakesFilePath, quarantinesFilePath, timingsFilePath string
-			if suiteID == "" {
-				return errors.NewConfigurationError("Invalid suite-id", "The suite ID is empty.", "")
-			}
-
-			if !cfg.Cloud.Disabled {
-				logger.Warnf("Unable to find RWX_ACCESS_TOKEN in the environment. Captain will default to OSS mode.")
-				logger.Warnf("You can silence this warning by setting the following in the config file:")
-				logger.Warnf("")
-				logger.Warnf("cloud:")
-				logger.Warnf("  disabled: true")
-				logger.Warnf("")
-			}
-			if cfg.Secrets.APIToken != "" {
-				logger.Warnf("Captain detected an RWX_ACCESS_TOKEN in your environment, however Cloud mode was disabled.")
-				logger.Warnf("To start using Captain Cloud, please remove the 'cloud.disabled' setting in the config file.")
-			}
-
-			if invalidSuiteIDRegexp.Match([]byte(suiteID)) {
-				return errors.NewConfigurationError(
-					"Invalid suite-id",
-					"A suite ID can only contain alphanumeric characters, `_` and `-`.",
-					"Please make sure that the ID doesn't contain any special characters.",
-				)
-			}
-
-			flakesFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, flakesFileName))
-			if err != nil {
-				flakesFilePath = filepath.Join(captainDirectory, suiteID, flakesFileName)
-				logger.Warnf(
-					"Unable to find existing flakes.yaml file for suite %q. Captain will create a new one at %q",
-					suiteID, flakesFilePath,
-				)
-			}
-
-			quarantinesFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, quarantinesFileName))
-			if err != nil {
-				quarantinesFilePath = filepath.Join(captainDirectory, suiteID, quarantinesFileName)
-				logger.Warnf(
-					"Unable to find existing quarantines.yaml for suite %q file. Captain will create a new one at %q",
-					suiteID, quarantinesFilePath,
-				)
-			}
-
-			timingsFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, timingsFileName))
-			if err != nil {
-				timingsFilePath = filepath.Join(captainDirectory, suiteID, timingsFileName)
-				logger.Warnf(
-					"Unable to find existing timings.yaml file. Captain will create a new one at %q",
-					timingsFilePath,
-				)
-			}
-
-			apiClient, err = local.NewClient(fs.Local{}, flakesFilePath, quarantinesFilePath, timingsFilePath)
-		}
+		apiClient, err := makeAPIClient(cfg, providerValidator, logger, suiteID)
 		if err != nil {
 			return errors.WithDecoration(errors.Wrap(err, "unable to create API client"))
 		}
@@ -254,4 +179,86 @@ func unsafeInitParsingOnly(cliArgs *CliArgs) func(*cobra.Command, []string) erro
 
 		return nil
 	}
+}
+
+func makeAPIClient(
+	cfg Config, providerValidator func(providers.Provider) error, logger *zap.SugaredLogger, suiteID string,
+) (backend.Client, error) {
+	wrapError := func(a backend.Client, b error) (backend.Client, error) {
+		return a, errors.WithDecoration(b)
+	}
+	if cfg.Secrets.APIToken != "" && !cfg.Cloud.Disabled {
+		provider, err := cfg.ProvidersEnv.MakeProvider()
+		if err != nil {
+			return nil, errors.WithDecoration(errors.Wrap(err, "failed to construct provider"))
+		}
+		err = providerValidator(provider)
+		if err != nil {
+			return nil, errors.WithDecoration(err)
+		}
+
+		return wrapError(remote.NewClient(remote.ClientConfig{
+			Debug:    cfg.Output.Debug,
+			Host:     cfg.Cloud.APIHost,
+			Insecure: cfg.Cloud.Insecure,
+			Log:      logger,
+			Token:    cfg.Secrets.APIToken,
+			Provider: provider,
+		}))
+	}
+
+	var flakesFilePath, quarantinesFilePath, timingsFilePath string
+	if suiteID == "" {
+		return nil, errors.NewConfigurationError("Invalid suite-id", "The suite ID is empty.", "")
+	}
+
+	if !cfg.Cloud.Disabled {
+		logger.Warnf("Unable to find RWX_ACCESS_TOKEN in the environment. Captain will default to OSS mode.")
+		logger.Warnf("You can silence this warning by setting the following in the config file:")
+		logger.Warnf("")
+		logger.Warnf("cloud:")
+		logger.Warnf("  disabled: true")
+		logger.Warnf("")
+	}
+	if cfg.Secrets.APIToken != "" {
+		logger.Warnf("Captain detected an RWX_ACCESS_TOKEN in your environment, however Cloud mode was disabled.")
+		logger.Warnf("To start using Captain Cloud, please remove the 'cloud.disabled' setting in the config file.")
+	}
+
+	if invalidSuiteIDRegexp.Match([]byte(suiteID)) {
+		return nil, errors.NewConfigurationError(
+			"Invalid suite-id",
+			"A suite ID can only contain alphanumeric characters, `_` and `-`.",
+			"Please make sure that the ID doesn't contain any special characters.",
+		)
+	}
+
+	flakesFilePath, err := findInParentDir(filepath.Join(captainDirectory, suiteID, flakesFileName))
+	if err != nil {
+		flakesFilePath = filepath.Join(captainDirectory, suiteID, flakesFileName)
+		logger.Warnf(
+			"Unable to find existing flakes.yaml file for suite %q. Captain will create a new one at %q",
+			suiteID, flakesFilePath,
+		)
+	}
+
+	quarantinesFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, quarantinesFileName))
+	if err != nil {
+		quarantinesFilePath = filepath.Join(captainDirectory, suiteID, quarantinesFileName)
+		logger.Warnf(
+			"Unable to find existing quarantines.yaml for suite %q file. Captain will create a new one at %q",
+			suiteID, quarantinesFilePath,
+		)
+	}
+
+	timingsFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, timingsFileName))
+	if err != nil {
+		timingsFilePath = filepath.Join(captainDirectory, suiteID, timingsFileName)
+		logger.Warnf(
+			"Unable to find existing timings.yaml file. Captain will create a new one at %q",
+			timingsFilePath,
+		)
+	}
+
+	return wrapError(local.NewClient(fs.Local{}, flakesFilePath, quarantinesFilePath, timingsFilePath))
 }

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -207,7 +207,6 @@ func makeAPIClient(
 		}))
 	}
 
-	var flakesFilePath, quarantinesFilePath, timingsFilePath string
 	if suiteID == "" {
 		return nil, errors.NewConfigurationError("Invalid suite-id", "The suite ID is empty.", "")
 	}
@@ -242,7 +241,7 @@ func makeAPIClient(
 		)
 	}
 
-	quarantinesFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, quarantinesFileName))
+	quarantinesFilePath, err := findInParentDir(filepath.Join(captainDirectory, suiteID, quarantinesFileName))
 	if err != nil {
 		quarantinesFilePath = filepath.Join(captainDirectory, suiteID, quarantinesFileName)
 		logger.Warnf(
@@ -251,7 +250,7 @@ func makeAPIClient(
 		)
 	}
 
-	timingsFilePath, err = findInParentDir(filepath.Join(captainDirectory, suiteID, timingsFileName))
+	timingsFilePath, err := findInParentDir(filepath.Join(captainDirectory, suiteID, timingsFileName))
 	if err != nil {
 		timingsFilePath = filepath.Join(captainDirectory, suiteID, timingsFileName)
 		logger.Warnf(

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -33,11 +33,6 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		return i, true, nil
 	}
 
-	defaultPartitionIndex, gotDefaultFromEnv, err := getEnvAsInt("CAPTAIN_PARTITION_INDEX")
-	if err != nil {
-		return err
-	}
-
 	partitionCmd := &cobra.Command{
 		Use: "partition [--help] [--config-file=<path>] [--delimiter=<delim>] [--sha=<sha>] --suite-id=<suite> --index=<i> " +
 			"--total=<total> <args>",
@@ -74,9 +69,16 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 			return errors.WithStack(err)
 		},
 	}
+
+	defaultPartitionIndex, gotDefaultFromEnv, err := getEnvAsInt("CAPTAIN_PARTITION_INDEX")
+	if err != nil {
+		return err
+	}
+
 	partitionCmd.Flags().IntVar(
 		&pArgs.nodes.Index, "index", defaultPartitionIndex, "the 0-indexed index of a particular partition",
 	)
+
 	if !gotDefaultFromEnv {
 		if err := partitionCmd.MarkFlagRequired("index"); err != nil {
 			return errors.WithStack(err)

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -125,11 +125,6 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		return err
 	}
 	partitionCmd.Flags().IntVar(&pArgs.nodes.Total, "total", defaultPartitionTotal, "the total number of partitions")
-	// if !ok || defaultPartitionTotal < 1 {
-	// 	if err := partitionCmd.MarkFlagRequired("total"); err != nil {
-	// 		return errors.WithStack(err)
-	// 	}
-	// }
 
 	// it's a smell that we're using cliArgs here but I believe it's a major refactor to stop doing that.
 	addShaFlag(partitionCmd, &cliArgs.GenericProvider.Sha)

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -7,12 +7,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rwx-research/captain-cli/internal/cli"
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 	"github.com/rwx-research/captain-cli/internal/providers"
 )
 
 type partitionArgs struct {
-	nodes     cli.PartitionNodes
+	nodes     config.PartitionNodes
 	delimiter string
 }
 

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -19,19 +19,20 @@ type partitionArgs struct {
 
 func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 	var pArgs partitionArgs
-	getEnvAsInt := func(name string) (int, bool, error) {
+	// returns a negative value if the environmental variable is not set
+	getEnvAsInt := func(name string) (int, error) {
 		value := os.Getenv(name)
 		if value == "" {
-			return 0, false, nil
+			return -1, nil
 		}
 
 		i, err := strconv.Atoi(value)
 		if err != nil {
-			return 0, false,
+			return -1,
 				errors.NewInputError("value for environmental variable %s=%s can't be parsed into an integer", name, value)
 		}
 
-		return i, true, nil
+		return i, nil
 	}
 
 	partitionCmd := &cobra.Command{
@@ -45,16 +46,55 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 			"  bundle exec rspec $(captain partition your-project-rspec --index 1 --total 2 spec/**/*_spec.rb)",
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,
-		PreRunE: initCLIService(cliArgs, func(p providers.Provider) error {
-			if p.CommitSha == "" {
-				return errors.NewConfigurationError(
-					"Missing commit SHA",
-					"Captain requires a commit SHA in order to track test runs correctly.",
-					"You can specify the SHA by using the --sha flag or the CAPTAIN_SHA environment variable",
-				)
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := extractSuiteIDFromPositionalArgs(&cliArgs.RootCliArgs, args); err != nil {
+				return err
 			}
-			return nil
-		}),
+
+			cfg, err := InitConfig(cmd, *cliArgs)
+			if err != nil {
+				return errors.WithDecoration(err)
+			}
+
+			provider, err := cfg.ProvidersEnv.MakeProvider()
+			if err != nil {
+				return errors.WithDecoration(errors.Wrap(err, "failed to construct provider"))
+			}
+
+			if pArgs.nodes.Index < 0 {
+				if provider.PartitionNodes.Index < 0 {
+					return errors.NewConfigurationError(
+						"Partition index invalid.",
+						"Partition index must be 0 or greater.",
+						"You can set the partition index by using the --index flag or the CAPTAIN_PARTITION_INDEX environment variable.",
+					)
+				}
+				pArgs.nodes.Index = provider.PartitionNodes.Index
+			}
+
+			if pArgs.nodes.Total < 0 {
+				if provider.PartitionNodes.Total < 1 {
+					return errors.NewConfigurationError(
+						"Partition total invalid.",
+						"Partition total must be 1 or greater.",
+						"You can set the partition index by using the --total flag or the CAPTAIN_PARTITION_TOTAL environment variable.",
+					)
+				}
+				pArgs.nodes.Total = provider.PartitionNodes.Total
+			}
+
+			return initCliServiceWithConfig(cmd, cfg, cliArgs.RootCliArgs.suiteID, func(p providers.Provider) error {
+				if p.CommitSha == "" {
+					return errors.NewConfigurationError(
+						"Missing commit SHA",
+						"Captain requires a commit SHA in order to track test runs correctly.",
+						"You can specify the SHA by using the --sha flag or the CAPTAIN_SHA environment variable",
+					)
+				}
+				return nil
+			})
+		},
+
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			args := cliArgs.RootCliArgs.positionalArgs
 			captain, err := cli.GetService(cmd)
@@ -71,7 +111,7 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		},
 	}
 
-	defaultPartitionIndex, gotDefaultFromEnv, err := getEnvAsInt("CAPTAIN_PARTITION_INDEX")
+	defaultPartitionIndex, err := getEnvAsInt("CAPTAIN_PARTITION_INDEX")
 	if err != nil {
 		return err
 	}
@@ -80,22 +120,16 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		&pArgs.nodes.Index, "index", defaultPartitionIndex, "the 0-indexed index of a particular partition",
 	)
 
-	if !gotDefaultFromEnv {
-		if err := partitionCmd.MarkFlagRequired("index"); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-
-	defaultPartitionTotal, ok, err := getEnvAsInt("CAPTAIN_PARTITION_TOTAL")
+	defaultPartitionTotal, err := getEnvAsInt("CAPTAIN_PARTITION_TOTAL")
 	if err != nil {
 		return err
 	}
 	partitionCmd.Flags().IntVar(&pArgs.nodes.Total, "total", defaultPartitionTotal, "the total number of partitions")
-	if !ok || defaultPartitionTotal < 1 {
-		if err := partitionCmd.MarkFlagRequired("total"); err != nil {
-			return errors.WithStack(err)
-		}
-	}
+	// if !ok || defaultPartitionTotal < 1 {
+	// 	if err := partitionCmd.MarkFlagRequired("total"); err != nil {
+	// 		return errors.WithStack(err)
+	// 	}
+	// }
 
 	// it's a smell that we're using cliArgs here but I believe it's a major refactor to stop doing that.
 	addShaFlag(partitionCmd, &cliArgs.GenericProvider.Sha)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 	"github.com/rwx-research/captain-cli/internal/targetedretries"
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
@@ -115,16 +116,11 @@ func (rc RunConfig) MaxTestsToRetryPercentage() (*float64, error) {
 	return &percentage, nil
 }
 
-type PartitionNodes struct {
-	Total int
-	Index int
-}
-
 type PartitionConfig struct {
 	SuiteID        string
 	TestFilePaths  []string
 	Delimiter      string
-	PartitionNodes PartitionNodes
+	PartitionNodes config.PartitionNodes
 }
 
 func (pc PartitionConfig) Validate() error {

--- a/internal/cli/partition_test.go
+++ b/internal/cli/partition_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/rwx-research/captain-cli/internal/cli"
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 	"github.com/rwx-research/captain-cli/internal/mocks"
 	"github.com/rwx-research/captain-cli/internal/parsing"
@@ -22,7 +23,7 @@ import (
 func cfgWithArgs(index int, total int, args []string, delimiter string) cli.PartitionConfig {
 	return cli.PartitionConfig{
 		TestFilePaths: args,
-		PartitionNodes: cli.PartitionNodes{
+		PartitionNodes: config.PartitionNodes{
 			Index: index,
 			Total: total,
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+type PartitionNodes struct {
+	Total int
+	Index int
+}

--- a/internal/providers/buildkite_provider.go
+++ b/internal/providers/buildkite_provider.go
@@ -1,6 +1,9 @@
 package providers
 
 import (
+	"strconv"
+
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 )
 
@@ -34,6 +37,16 @@ func (cfg BuildkiteEnv) makeProvider() (Provider, error) {
 		return Provider{}, validationError
 	}
 
+	index, err := strconv.Atoi(cfg.ParallelJob)
+	if err != nil {
+		index = -1
+	}
+
+	total, err := strconv.Atoi(cfg.ParallelJobCount)
+	if err != nil {
+		total = -1
+	}
+
 	provider := Provider{
 		AttemptedBy:   cfg.BuildCreatorEmail,
 		BranchName:    cfg.Branch,
@@ -41,6 +54,10 @@ func (cfg BuildkiteEnv) makeProvider() (Provider, error) {
 		CommitSha:     cfg.Commit,
 		JobTags:       tags,
 		ProviderName:  "buildkite",
+		PartitionNodes: config.PartitionNodes{
+			Index: index,
+			Total: total,
+		},
 	}
 
 	return provider, nil

--- a/internal/providers/buildkite_provider_test.go
+++ b/internal/providers/buildkite_provider_test.go
@@ -1,6 +1,7 @@
 package providers_test
 
 import (
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/providers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,6 +41,7 @@ var _ = Describe("BuildkiteEnv.makeProvider", func() {
 		Expect(provider.CommitMessage).To(Equal("fixed it\nyeah"))
 		Expect(provider.ProviderName).To(Equal("buildkite"))
 		Expect(provider.Title).To(Equal("fixed it"))
+		Expect(provider.PartitionNodes).To(Equal(config.PartitionNodes{Index: 0, Total: 2}))
 	})
 
 	It("requires build id", func() {
@@ -89,6 +91,20 @@ var _ = Describe("BuildkiteEnv.makeProvider", func() {
 		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing repository"))
+	})
+
+	It("doesn't require node index", func() {
+		env.Buildkite.ParallelJob = ""
+		provider, err := env.MakeProvider()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider.PartitionNodes.Index).To(Equal(-1))
+	})
+
+	It("doesn't require node total", func() {
+		env.Buildkite.ParallelJobCount = ""
+		provider, err := env.MakeProvider()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider.PartitionNodes.Total).To(Equal(-1))
 	})
 })
 

--- a/internal/providers/circleci_provider.go
+++ b/internal/providers/circleci_provider.go
@@ -2,7 +2,9 @@ package providers
 
 import (
 	"fmt"
+	"strconv"
 
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 )
 
@@ -36,6 +38,16 @@ func (cfg CircleCIEnv) makeProvider() (Provider, error) {
 
 	title := fmt.Sprintf("%s (%s)", cfg.Job, cfg.BuildNum)
 
+	index, err := strconv.Atoi(cfg.NodeIndex)
+	if err != nil {
+		index = -1
+	}
+
+	total, err := strconv.Atoi(cfg.NodeTotal)
+	if err != nil {
+		total = -1
+	}
+
 	provider := Provider{
 		AttemptedBy:   cfg.Username,
 		BranchName:    cfg.Branch,
@@ -44,6 +56,10 @@ func (cfg CircleCIEnv) makeProvider() (Provider, error) {
 		JobTags:       tags,
 		ProviderName:  "circleci",
 		Title:         title,
+		PartitionNodes: config.PartitionNodes{
+			Index: index,
+			Total: total,
+		},
 	}
 
 	return provider, nil

--- a/internal/providers/circleci_provider_test.go
+++ b/internal/providers/circleci_provider_test.go
@@ -1,6 +1,7 @@
 package providers_test
 
 import (
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/providers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -39,6 +40,7 @@ var _ = Describe("CircleCiEnv.makeProvider", func() {
 		Expect(provider.CommitMessage).To(Equal(""))
 		Expect(provider.ProviderName).To(Equal("circleci"))
 		Expect(provider.Title).To(Equal("build (18)"))
+		Expect(provider.PartitionNodes).To(Equal(config.PartitionNodes{Index: 0, Total: 2}))
 	})
 
 	It("requires BuildNum", func() {
@@ -93,6 +95,20 @@ var _ = Describe("CircleCiEnv.makeProvider", func() {
 		_, err := env.MakeProvider()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Missing repository URL"))
+	})
+
+	It("doesn't require node index", func() {
+		env.CircleCI.NodeIndex = ""
+		provider, err := env.MakeProvider()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider.PartitionNodes.Index).To(Equal(-1))
+	})
+
+	It("doesn't require node total", func() {
+		env.CircleCI.NodeTotal = ""
+		provider, err := env.MakeProvider()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider.PartitionNodes.Total).To(Equal(-1))
 	})
 })
 

--- a/internal/providers/gitlab_ci_provider.go
+++ b/internal/providers/gitlab_ci_provider.go
@@ -1,6 +1,9 @@
 package providers
 
 import (
+	"strconv"
+
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 )
 
@@ -47,13 +50,24 @@ func (cfg GitLabEnv) makeProvider() (Provider, error) {
 		return Provider{}, validationError
 	}
 
+	index, err := strconv.Atoi(cfg.NodeIndex)
+	if err != nil {
+		index = 0
+	}
+
+	total, err := strconv.Atoi(cfg.NodeTotal)
+	if err != nil {
+		total = -1
+	}
+
 	provider := Provider{
-		AttemptedBy:   attemptedBy,
-		BranchName:    cfg.CommitBranch,
-		CommitMessage: cfg.CommitMessage,
-		CommitSha:     cfg.CommitSHA,
-		JobTags:       tags,
-		ProviderName:  "gitlabci",
+		AttemptedBy:    attemptedBy,
+		BranchName:     cfg.CommitBranch,
+		CommitMessage:  cfg.CommitMessage,
+		CommitSha:      cfg.CommitSHA,
+		JobTags:        tags,
+		ProviderName:   "gitlabci",
+		PartitionNodes: config.PartitionNodes{Index: index - 1, Total: total}, // gitlab indexes from 1
 	}
 
 	return provider, nil

--- a/internal/providers/gitlab_ci_provider_test.go
+++ b/internal/providers/gitlab_ci_provider_test.go
@@ -1,6 +1,7 @@
 package providers_test
 
 import (
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/providers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,6 +42,7 @@ var _ = Describe("GitLabEnv.MakeProvider", func() {
 		Expect(provider.CommitMessage).To(Equal("this is what I did\nand here are some details"))
 		Expect(provider.ProviderName).To(Equal("gitlabci"))
 		Expect(provider.Title).To(Equal("this is what I did"))
+		Expect(provider.PartitionNodes).To(Equal(config.PartitionNodes{Index: 0, Total: 2}))
 	})
 
 	It("falls back to commit author if attempted by is not set", func() {
@@ -101,8 +103,9 @@ var _ = Describe("GitLabEnv.MakeProvider", func() {
 
 	It("doesn't requires NodeIndex", func() {
 		env.GitLab.NodeIndex = ""
-		_, err := env.MakeProvider()
+		provider, err := env.MakeProvider()
 		Expect(err).ToNot(HaveOccurred())
+		Expect(provider.PartitionNodes.Index).To(Equal(-1))
 	})
 
 	It("requires NodeTotal", func() {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"strings"
 
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/errors"
 )
 
@@ -15,13 +16,14 @@ type Env struct {
 }
 
 type Provider struct {
-	AttemptedBy   string
-	BranchName    string
-	CommitMessage string
-	CommitSha     string
-	JobTags       map[string]any
-	ProviderName  string
-	Title         string
+	AttemptedBy    string
+	BranchName     string
+	CommitMessage  string
+	CommitSha      string
+	JobTags        map[string]any
+	ProviderName   string
+	Title          string
+	PartitionNodes config.PartitionNodes
 }
 
 func Validate(p Provider) error {

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -1,6 +1,7 @@
 package providers_test
 
 import (
+	"github.com/rwx-research/captain-cli/internal/config"
 	"github.com/rwx-research/captain-cli/internal/providers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -238,12 +239,13 @@ var _ = Describe("MakeProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(provider).To(Equal(
 				providers.Provider{
-					ProviderName:  "buildkite",
-					CommitSha:     "abc123",
-					BranchName:    "main",
-					AttemptedBy:   "foo@bar.com",
-					CommitMessage: "fixed it",
-					Title:         "fixed it",
+					ProviderName:   "buildkite",
+					CommitSha:      "abc123",
+					BranchName:     "main",
+					AttemptedBy:    "foo@bar.com",
+					CommitMessage:  "fixed it",
+					Title:          "fixed it",
+					PartitionNodes: config.PartitionNodes{Index: 0, Total: 2},
 					JobTags: map[string]any{
 						"buildkite_retry_count":        "0",
 						"buildkite_parallel_job_count": "2",
@@ -267,12 +269,13 @@ var _ = Describe("MakeProvider", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(provider).To(Equal(
 					providers.Provider{
-						ProviderName:  "buildkite",
-						CommitSha:     "qrs789",
-						BranchName:    "main",
-						AttemptedBy:   "foo@bar.com",
-						CommitMessage: "fixed it on Tuesday\nthis commit message annotated before writing to captain",
-						Title:         "fixed it on Tuesday",
+						ProviderName:   "buildkite",
+						CommitSha:      "qrs789",
+						BranchName:     "main",
+						AttemptedBy:    "foo@bar.com",
+						CommitMessage:  "fixed it on Tuesday\nthis commit message annotated before writing to captain",
+						Title:          "fixed it on Tuesday",
+						PartitionNodes: config.PartitionNodes{Total: 2, Index: 0},
 						JobTags: map[string]any{
 							"buildkite_retry_count":        "0",
 							"buildkite_parallel_job_count": "2",

--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -269,8 +269,8 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 				result := runCaptain(captainArgs{
 					args: []string{
 						"upload", "results",
-						"nonexistingfile.json",
 						"captain-cli-functional-tests",
+						"nonexistingfile.json",
 					},
 					env: getEnvWithAccessToken(),
 				})

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -187,6 +187,12 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 			})
 
 			Context("with provider-provided node total & index", func() {
+				var env map[string]string
+
+				BeforeEach(func() {
+					env = helpers.ReadEnvFromFile(".env.buildkite")
+				})
+
 				It("sets partition 2 correctly", func() {
 					result := runCaptain(captainArgs{
 						args: []string{
@@ -194,10 +200,43 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 							suiteId,
 							"fixtures/integration-tests/partition/*_spec.rb",
 						},
-						env: helpers.ReadEnvFromFile(".env.buildkite"),
+						env: env,
 					})
 
 					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/c_spec.rb"))
+					Expect(result.exitCode).To(Equal(0))
+				})
+
+				It("prefers flag --index 0 to provider-sourced index 1", func() {
+					result := runCaptain(captainArgs{
+						args: []string{
+							"partition",
+							suiteId,
+							"fixtures/integration-tests/partition/*_spec.rb",
+							"--index", "0",
+						},
+						env: env,
+					})
+
+					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/d_spec.rb"))
+					Expect(result.exitCode).To(Equal(0))
+				})
+
+				It("prefers env var CAPTAIN_PARTITION_INDEX 0 to provider-sourced index 1", func() {
+					env["CAPTAIN_PARTITION_INDEX"] = "0"
+
+					env := helpers.ReadEnvFromFile(".env.buildkite")
+					result := runCaptain(captainArgs{
+						args: []string{
+							"partition",
+							suiteId,
+							"fixtures/integration-tests/partition/*_spec.rb",
+							"--index", "0",
+						},
+						env: env,
+					})
+
+					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/d_spec.rb"))
 					Expect(result.exitCode).To(Equal(0))
 				})
 			})

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rwx-research/captain-cli"
+	"github.com/rwx-research/captain-cli/test/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -183,6 +184,22 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 
 				Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/c_spec.rb"))
 				Expect(result.exitCode).To(Equal(0))
+			})
+
+			Context("with provider-provided node total & index", func() {
+				It("sets partition 2 correctly", func() {
+					result := runCaptain(captainArgs{
+						args: []string{
+							"partition",
+							suiteId,
+							"fixtures/integration-tests/partition/*_spec.rb",
+						},
+						env: helpers.ReadEnvFromFile(".env.buildkite"),
+					})
+
+					Expect(result.stdout).To(Equal("fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/c_spec.rb"))
+					Expect(result.exitCode).To(Equal(0))
+				})
 			})
 		})
 


### PR DESCRIPTION
@tonywok let's chat to make sure these changes get into your work with `captain run` supporting partition

This PR allows `captain partition` to be run without `--index` and `--total` on CI providers that provide parallelization information

## to the reviewer:
probably easiest to review this one commit-by-commit. I cleaned some things up as I was writing this (in part to understand what was going on!)