### PR TITLE
add back shell escaping to captain run with partitioning

### DIFF
--- a/internal/runpartition/delimiter_substitution.go
+++ b/internal/runpartition/delimiter_substitution.go
@@ -1,6 +1,7 @@
 package runpartition
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -43,7 +44,7 @@ func (s DelimiterSubstitution) SubstitutionLookupFor(
 	escapedTestFilePaths := make([]string, 0)
 
 	for _, testFilePath := range testFilePaths {
-		escapedTestFilePaths = append(escapedTestFilePaths, templating.ShellEscape(testFilePath))
+		escapedTestFilePaths = append(escapedTestFilePaths, fmt.Sprintf("'%v'", templating.ShellEscape(testFilePath)))
 	}
 
 	return map[string]string{"testFiles": strings.Join(escapedTestFilePaths, s.Delimiter)}, nil

--- a/internal/runpartition/delimiter_substitution_test.go
+++ b/internal/runpartition/delimiter_substitution_test.go
@@ -85,7 +85,7 @@ var _ = Describe("DelimiterSubstitution", func() {
 				lookup, err := substitution.SubstitutionLookupFor(compiledTemplate, []string{"a", "b", "c"})
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(lookup["testFiles"]).To(Equal("a || b || c"))
+				Expect(lookup["testFiles"]).To(Equal("'a' || 'b' || 'c'"))
 				Expect(len(lookup)).To(Equal(1))
 			})
 		})
@@ -97,7 +97,7 @@ var _ = Describe("DelimiterSubstitution", func() {
 				lookup, err := substitution.SubstitutionLookupFor(compiledTemplate, []string{"a spec", "b spec"})
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(lookup["testFiles"]).To(Equal("a spec,b spec"))
+				Expect(lookup["testFiles"]).To(Equal("'a spec','b spec'"))
 			})
 		})
 	})

--- a/test/fixtures/integration-tests/partition-config.yaml
+++ b/test/fixtures/integration-tests/partition-config.yaml
@@ -32,8 +32,8 @@ test-suites:
       framework: RSpec
       path: ./fixtures/integration-tests/rspec-passed.json
     partition:
-      command: echo "test '{{ testFiles }}'"
-      delimiter: "' '"
+      command: echo "test {{ testFiles }}"
+      delimiter: " -hi- "
       globs:
-        - ./fixtures/integration-tests/partition/*_spec.rb
-        - ./fixtures/integration-tests/partition/*.rb
+      - ./fixtures/integration-tests/partition/*_spec.rb
+      - ./fixtures/integration-tests/partition/*.rb

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -765,7 +765,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(partitionResult0.exitCode).To(Equal(0))
-				Expect(partitionResult0.stdout).To(ContainSubstring("test fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/c_spec.rb fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
+				Expect(partitionResult0.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/a_spec.rb' 'fixtures/integration-tests/partition/c_spec.rb' 'fixtures/integration-tests/partition/x.rb' 'fixtures/integration-tests/partition/z.rb'"))
 
 				partitionResult1 := runCaptain(captainArgs{
 					args: []string{
@@ -779,7 +779,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(partitionResult1.exitCode).To(Equal(0))
-				Expect(partitionResult1.stdout).To(ContainSubstring("test fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/d_spec.rb fixtures/integration-tests/partition/y.rb"))
+				Expect(partitionResult1.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/b_spec.rb' 'fixtures/integration-tests/partition/d_spec.rb' 'fixtures/integration-tests/partition/y.rb'"))
 			})
 
 			It("accepts env vars instead of command line args", func() {
@@ -796,7 +796,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(partitionResult0.exitCode).To(Equal(0))
-				Expect(partitionResult0.stdout).To(ContainSubstring("test fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/c_spec.rb fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
+				Expect(partitionResult0.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/a_spec.rb' 'fixtures/integration-tests/partition/c_spec.rb' 'fixtures/integration-tests/partition/x.rb' 'fixtures/integration-tests/partition/z.rb'"))
 			})
 		})
 
@@ -814,7 +814,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(partitionResult0.exitCode).To(Equal(0))
-				Expect(partitionResult0.stdout).To(ContainSubstring("test fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/c_spec.rb fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
+				Expect(partitionResult0.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/a_spec.rb' 'fixtures/integration-tests/partition/c_spec.rb' 'fixtures/integration-tests/partition/x.rb' 'fixtures/integration-tests/partition/z.rb'"))
 
 				partitionResult1 := runCaptain(captainArgs{
 					args: []string{
@@ -828,7 +828,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(partitionResult1.exitCode).To(Equal(0))
-				Expect(partitionResult1.stdout).To(ContainSubstring("test fixtures/integration-tests/partition/b_spec.rb fixtures/integration-tests/partition/d_spec.rb fixtures/integration-tests/partition/y.rb"))
+				Expect(partitionResult1.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/b_spec.rb' 'fixtures/integration-tests/partition/d_spec.rb' 'fixtures/integration-tests/partition/y.rb'"))
 			})
 		})
 
@@ -846,7 +846,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				})
 
 				Expect(partitionResult0.exitCode).To(Equal(0))
-				Expect(partitionResult0.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/a_spec.rb' 'fixtures/integration-tests/partition/c_spec.rb' 'fixtures/integration-tests/partition/x.rb' 'fixtures/integration-tests/partition/z.rb'"))
+				Expect(partitionResult0.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/a_spec.rb' -hi- 'fixtures/integration-tests/partition/c_spec.rb' -hi- 'fixtures/integration-tests/partition/x.rb' -hi- 'fixtures/integration-tests/partition/z.rb'"))
 			})
 		})
 
@@ -898,7 +898,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 			})
 
 			Expect(partitionResult0.exitCode).To(Equal(0))
-			Expect(partitionResult0.stdout).To(ContainSubstring("test fixtures/integration-tests/partition/a_spec.rb fixtures/integration-tests/partition/c_spec.rb fixtures/integration-tests/partition/x.rb fixtures/integration-tests/partition/z.rb"))
+			Expect(partitionResult0.stdout).To(ContainSubstring("test 'fixtures/integration-tests/partition/a_spec.rb' 'fixtures/integration-tests/partition/c_spec.rb' 'fixtures/integration-tests/partition/x.rb' 'fixtures/integration-tests/partition/z.rb'"))
 		})
 	})
 


### PR DESCRIPTION
perhaps before we merge this: confirm there aren't weird edge cases where wrapping the test files in quotes breaks things in surprising ways

context: https://rwxhq.slack.com/archives/C04AUD3L7FU/p1681747314001059