### PR TITLE
Prefer generic provider partition settings over unset detected provider

### DIFF
--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -89,10 +89,15 @@ func Merge(into Provider, from Provider) Provider {
 		into.CommitSha = firstNonempty(from.CommitSha, into.CommitSha)
 		into.CommitMessage = firstNonempty(from.CommitMessage, into.CommitMessage)
 		into.Title = firstNonempty(from.Title, into.Title)
-		if (into.PartitionNodes.Index < 0 || into.PartitionNodes.Total < 0) &&
-			(from.PartitionNodes.Index >= 0 && from.PartitionNodes.Total >= 1) {
+
+		intoPartitionImplicitlyUnset := into.PartitionNodes == config.PartitionNodes{}
+		intoPartitionExplicitlyUnset := into.PartitionNodes.Index < 0 || into.PartitionNodes.Total < 0
+		fromPartitionExplicitlySet := from.PartitionNodes.Index >= 0 && from.PartitionNodes.Total >= 1
+
+		if fromPartitionExplicitlySet && (intoPartitionExplicitlyUnset || intoPartitionImplicitlyUnset) {
 			into.PartitionNodes = from.PartitionNodes
 		}
+
 		return into
 	}
 	return from

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -129,6 +129,90 @@ var _ = Describe("providers.Merge", func() {
 		merged := providers.Merge(provider1, provider2)
 		Expect(merged.PartitionNodes).To(Equal(provider1.PartitionNodes))
 	})
+
+	It("merges partition nodes when into implicitly unset and from is explicitly set", func() {
+		genericWithNodes := providers.Provider{
+			AttemptedBy:    "me",
+			BranchName:     "main",
+			CommitSha:      "abc123",
+			CommitMessage:  "one commit message",
+			JobTags:        map[string]any{},
+			ProviderName:   "generic",
+			Title:          "some-title",
+			PartitionNodes: config.PartitionNodes{Index: 0, Total: 2},
+		}
+
+		githubWithoutNodes := providers.Provider{
+			AttemptedBy:   "you",
+			BranchName:    "test-branch",
+			CommitSha:     "qrs789",
+			CommitMessage: "another commit message",
+			JobTags:       map[string]any{},
+			ProviderName:  "GitHub",
+			Title:         "another-title",
+			// NOTE: no PartitionNodes are set
+		}
+
+		merged := providers.Merge(githubWithoutNodes, genericWithNodes)
+		Expect(merged.PartitionNodes.Index).To(Equal(0))
+		Expect(merged.PartitionNodes.Total).To(Equal(2))
+	})
+
+	It("merges partition nodes when into explicitly unset and from is explicitly set", func() {
+		genericWithNodes := providers.Provider{
+			AttemptedBy:    "me",
+			BranchName:     "main",
+			CommitSha:      "abc123",
+			CommitMessage:  "one commit message",
+			JobTags:        map[string]any{},
+			ProviderName:   "generic",
+			Title:          "some-title",
+			PartitionNodes: config.PartitionNodes{Index: 0, Total: 2},
+		}
+
+		githubWithoutNodes := providers.Provider{
+			AttemptedBy:    "you",
+			BranchName:     "test-branch",
+			CommitSha:      "qrs789",
+			CommitMessage:  "another commit message",
+			JobTags:        map[string]any{},
+			ProviderName:   "GitHub",
+			Title:          "another-title",
+			PartitionNodes: config.PartitionNodes{Index: -1, Total: -1},
+		}
+
+		merged := providers.Merge(githubWithoutNodes, genericWithNodes)
+		Expect(merged.PartitionNodes.Index).To(Equal(0))
+		Expect(merged.PartitionNodes.Total).To(Equal(2))
+	})
+
+	It("does not merge partition nodes when into explicitly set and from is explicitly set", func() {
+		genericWithNodes := providers.Provider{
+			AttemptedBy:    "me",
+			BranchName:     "main",
+			CommitSha:      "abc123",
+			CommitMessage:  "one commit message",
+			JobTags:        map[string]any{},
+			ProviderName:   "generic",
+			Title:          "some-title",
+			PartitionNodes: config.PartitionNodes{Index: 0, Total: 2},
+		}
+
+		githubWithoutNodes := providers.Provider{
+			AttemptedBy:    "you",
+			BranchName:     "test-branch",
+			CommitSha:      "qrs789",
+			CommitMessage:  "another commit message",
+			JobTags:        map[string]any{},
+			ProviderName:   "GitHub",
+			Title:          "another-title",
+			PartitionNodes: config.PartitionNodes{Index: 1, Total: 3},
+		}
+
+		merged := providers.Merge(githubWithoutNodes, genericWithNodes)
+		Expect(merged.PartitionNodes.Index).To(Equal(1))
+		Expect(merged.PartitionNodes.Total).To(Equal(3))
+	})
 })
 
 var _ = Describe("MakeProvider", func() {


### PR DESCRIPTION
Added a bit of defensiveness to merge s.t if a provider were to omit these settings, we will still prefer the generic values.

This issue was specific to github as the github provider was relying on implicitly unset partition nodes (it does not expose parallelism in the env by default).

Go was therefore using a zero value struct to satisfy the Provider interface.
As a result, it's partition node index and total were each set to 0 -- preventing the merge code from merging in the generic provider's values.