### PR TITLE
Fix the hidden (not public) captain parse results command

### DIFF
--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -150,9 +150,11 @@ func initCliServiceWithConfig(
 func unsafeInitParsingOnly(cliArgs *CliArgs) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		err := func() error {
-			if err := extractSuiteIDFromPositionalArgs(&cliArgs.RootCliArgs, args); err != nil {
-				return err
+			cliArgs.RootCliArgs.positionalArgs = args
+			if cliArgs.RootCliArgs.suiteID == "" {
+				cliArgs.RootCliArgs.suiteID = "placeholder"
 			}
+
 			cfg, err := InitConfig(cmd, *cliArgs)
 			if err != nil {
 				return errors.WithStack(err)

--- a/cmd/captain/parse.go
+++ b/cmd/captain/parse.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/rwx-research/captain-cli/internal/cli"
+	"github.com/rwx-research/captain-cli/internal/errors"
+)
+
+func configureParseCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
+	// parseResultsCmd is the "results" sub-command of "parse".
+	parseResultsCmd := &cobra.Command{
+		Use:     "results [flags] <test-results-files>",
+		Short:   "Parses test-results files into RWX v1 JSON",
+		Long:    "'captain parse results' will parse test-results files and output RWX v1 JSON.",
+		Example: `captain parse results rspec.json`,
+		Args:    cobra.MinimumNArgs(1),
+		PreRunE: unsafeInitParsingOnly(cliArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			artifacts := cliArgs.RootCliArgs.positionalArgs
+
+			captain, err := cli.GetService(cmd)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			err = captain.Parse(cmd.Context(), artifacts)
+			return errors.WithStack(err)
+		},
+	}
+
+	addFrameworkFlags(parseResultsCmd, &cliArgs.frameworkParams)
+
+	// parseCmd represents the "parse" sub-command itself
+	parseCmd := &cobra.Command{
+		Use:   "parse",
+		Short: "Parses a specific resource in captain",
+	}
+
+	parseCmd.AddCommand(parseResultsCmd)
+	rootCmd.AddCommand(parseCmd)
+	return nil
+}

--- a/test/.snapshots/OSS mode Integration Tests captain parse results produces RWX JSON with the parsers
+++ b/test/.snapshots/OSS mode Integration Tests captain parse results produces RWX JSON with the parsers
@@ -1,0 +1,3127 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "Ruby",
+    "kind": "RSpec"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 72,
+    "otherErrors": 0,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 36,
+    "pended": 24,
+    "quarantined": 0,
+    "skipped": 0,
+    "successful": 12,
+    "timedOut": 0,
+    "todo": 0
+  },
+  "tests": [
+    {
+      "id": "./spec/examples/class_spec.rb[1:1]",
+      "name": "Tests::Case has top-level passing tests",
+      "lineage": [
+        "Tests::Case",
+        "has top-level passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 30795000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 5
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:2]",
+      "name": "Tests::Case has top-level failing tests",
+      "lineage": [
+        "Tests::Case",
+        "has top-level failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 6114000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 9
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/class_spec.rb:10:in `block (2 levels) in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:3]",
+      "name": "Tests::Case has top-level aggregated failing tests",
+      "lineage": [
+        "Tests::Case",
+        "has top-level aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3131000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 13
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/class_spec.rb:14:in `block (2 levels) in \u003ctop (required)\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/class_spec.rb:15:in `block (2 levels) in \u003ctop (required)\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:4]",
+      "name": "Tests::Case has top-level skipped tests",
+      "lineage": [
+        "Tests::Case",
+        "has top-level skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 6000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 18
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:5]",
+      "name": "Tests::Case has top-level passing pended tests",
+      "lineage": [
+        "Tests::Case",
+        "has top-level passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3167000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 23
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/class_spec.rb:23"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:6]",
+      "name": "Tests::Case has top-level failing pended tests",
+      "lineage": [
+        "Tests::Case",
+        "has top-level failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2972000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 28
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:1]",
+      "name": "Tests::Case behaves like shared examples has top-level passing tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples",
+        "has top-level passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2982000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 2
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:2]",
+      "name": "Tests::Case behaves like shared examples has top-level failing tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples",
+        "has top-level failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2971000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 6
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:7:in `block (2 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:3]",
+      "name": "Tests::Case behaves like shared examples has top-level aggregated failing tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples",
+        "has top-level aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2540000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 10
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:11:in `block (2 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:12:in `block (2 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:4]",
+      "name": "Tests::Case behaves like shared examples has top-level skipped tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples",
+        "has top-level skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 15
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:5]",
+      "name": "Tests::Case behaves like shared examples has top-level passing pended tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples",
+        "has top-level passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3049000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 20
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:20"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:6]",
+      "name": "Tests::Case behaves like shared examples has top-level failing pended tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples",
+        "has top-level failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3055000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 25
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:7:1]",
+      "name": "Tests::Case behaves like shared examples within a context has passing tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples within a context",
+        "has passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2859000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 31
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:7:2]",
+      "name": "Tests::Case behaves like shared examples within a context has failing tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples within a context",
+        "has failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2979000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 35
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:36:in `block (3 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:7:3]",
+      "name": "Tests::Case behaves like shared examples within a context has aggregated failing tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples within a context",
+        "has aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2438000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 39
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:40:in `block (3 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:41:in `block (3 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:7:4]",
+      "name": "Tests::Case behaves like shared examples within a context has skipped tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples within a context",
+        "has skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 44
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:7:5]",
+      "name": "Tests::Case behaves like shared examples within a context has passing pended tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples within a context",
+        "has passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2583000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 49
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:49"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:7:7:6]",
+      "name": "Tests::Case behaves like shared examples within a context has failing pended tests",
+      "lineage": [
+        "Tests::Case behaves like shared examples within a context",
+        "has failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3151000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 54
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:1]",
+      "name": "Tests::Case within a context has passing tests",
+      "lineage": [
+        "Tests::Case within a context",
+        "has passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2502000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 36
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:2]",
+      "name": "Tests::Case within a context has failing tests",
+      "lineage": [
+        "Tests::Case within a context",
+        "has failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3060000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 40
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/class_spec.rb:41:in `block (3 levels) in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:3]",
+      "name": "Tests::Case within a context has aggregated failing tests",
+      "lineage": [
+        "Tests::Case within a context",
+        "has aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3055000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 44
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/class_spec.rb:45:in `block (3 levels) in \u003ctop (required)\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/class_spec.rb:46:in `block (3 levels) in \u003ctop (required)\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:4]",
+      "name": "Tests::Case within a context has skipped tests",
+      "lineage": [
+        "Tests::Case within a context",
+        "has skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 49
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:5]",
+      "name": "Tests::Case within a context has passing pended tests",
+      "lineage": [
+        "Tests::Case within a context",
+        "has passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2014000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 54
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/class_spec.rb:54"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:6]",
+      "name": "Tests::Case within a context has failing pended tests",
+      "lineage": [
+        "Tests::Case within a context",
+        "has failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2398000,
+        "meta": {
+          "filePath": "./spec/examples/class_spec.rb",
+          "lineNumber": 59
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:1]",
+      "name": "Tests::Case within a context behaves like shared examples has top-level passing tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples",
+        "has top-level passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2994000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 2
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:2]",
+      "name": "Tests::Case within a context behaves like shared examples has top-level failing tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples",
+        "has top-level failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2811000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 6
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:7:in `block (2 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:3]",
+      "name": "Tests::Case within a context behaves like shared examples has top-level aggregated failing tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples",
+        "has top-level aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2654000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 10
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:11:in `block (2 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:12:in `block (2 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:4]",
+      "name": "Tests::Case within a context behaves like shared examples has top-level skipped tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples",
+        "has top-level skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 15
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:5]",
+      "name": "Tests::Case within a context behaves like shared examples has top-level passing pended tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples",
+        "has top-level passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3018000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 20
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:20"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:6]",
+      "name": "Tests::Case within a context behaves like shared examples has top-level failing pended tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples",
+        "has top-level failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2221000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 25
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:7:1]",
+      "name": "Tests::Case within a context behaves like shared examples within a context has passing tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples within a context",
+        "has passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2212000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 31
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:7:2]",
+      "name": "Tests::Case within a context behaves like shared examples within a context has failing tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples within a context",
+        "has failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2861000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 35
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:36:in `block (3 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:7:3]",
+      "name": "Tests::Case within a context behaves like shared examples within a context has aggregated failing tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples within a context",
+        "has aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3040000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 39
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:40:in `block (3 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:41:in `block (3 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:7:4]",
+      "name": "Tests::Case within a context behaves like shared examples within a context has skipped tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples within a context",
+        "has skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 44
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:7:5]",
+      "name": "Tests::Case within a context behaves like shared examples within a context has passing pended tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples within a context",
+        "has passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2672000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 49
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:49"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/class_spec.rb[1:8:7:7:6]",
+      "name": "Tests::Case within a context behaves like shared examples within a context has failing pended tests",
+      "lineage": [
+        "Tests::Case within a context behaves like shared examples within a context",
+        "has failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/class_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2959000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 54
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:1]",
+      "name": "some string has top-level passing tests",
+      "lineage": [
+        "some string",
+        "has top-level passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2110000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 4
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:2]",
+      "name": "some string has top-level failing tests",
+      "lineage": [
+        "some string",
+        "has top-level failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2240000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 8
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/string_spec.rb:9:in `block (2 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:3]",
+      "name": "some string has top-level aggregated failing tests",
+      "lineage": [
+        "some string",
+        "has top-level aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2886000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 12
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/string_spec.rb:13:in `block (2 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/string_spec.rb:14:in `block (2 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:4]",
+      "name": "some string has top-level skipped tests",
+      "lineage": [
+        "some string",
+        "has top-level skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 17
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:5]",
+      "name": "some string has top-level passing pended tests",
+      "lineage": [
+        "some string",
+        "has top-level passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2922000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 22
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/string_spec.rb:22"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:6]",
+      "name": "some string has top-level failing pended tests",
+      "lineage": [
+        "some string",
+        "has top-level failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2704000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 27
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:1]",
+      "name": "some string behaves like shared examples has top-level passing tests",
+      "lineage": [
+        "some string behaves like shared examples",
+        "has top-level passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2700000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 2
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:2]",
+      "name": "some string behaves like shared examples has top-level failing tests",
+      "lineage": [
+        "some string behaves like shared examples",
+        "has top-level failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2541000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 6
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:7:in `block (2 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:3]",
+      "name": "some string behaves like shared examples has top-level aggregated failing tests",
+      "lineage": [
+        "some string behaves like shared examples",
+        "has top-level aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2879000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 10
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:11:in `block (2 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:12:in `block (2 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:4]",
+      "name": "some string behaves like shared examples has top-level skipped tests",
+      "lineage": [
+        "some string behaves like shared examples",
+        "has top-level skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 15
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:5]",
+      "name": "some string behaves like shared examples has top-level passing pended tests",
+      "lineage": [
+        "some string behaves like shared examples",
+        "has top-level passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2721000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 20
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:20"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:6]",
+      "name": "some string behaves like shared examples has top-level failing pended tests",
+      "lineage": [
+        "some string behaves like shared examples",
+        "has top-level failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3249000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 25
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:7:1]",
+      "name": "some string behaves like shared examples within a context has passing tests",
+      "lineage": [
+        "some string behaves like shared examples within a context",
+        "has passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2793000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 31
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:7:2]",
+      "name": "some string behaves like shared examples within a context has failing tests",
+      "lineage": [
+        "some string behaves like shared examples within a context",
+        "has failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2262000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 35
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:36:in `block (3 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:7:3]",
+      "name": "some string behaves like shared examples within a context has aggregated failing tests",
+      "lineage": [
+        "some string behaves like shared examples within a context",
+        "has aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2288000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 39
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:40:in `block (3 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:41:in `block (3 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:7:4]",
+      "name": "some string behaves like shared examples within a context has skipped tests",
+      "lineage": [
+        "some string behaves like shared examples within a context",
+        "has skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 44
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:7:5]",
+      "name": "some string behaves like shared examples within a context has passing pended tests",
+      "lineage": [
+        "some string behaves like shared examples within a context",
+        "has passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2546000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 49
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:49"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:7:7:6]",
+      "name": "some string behaves like shared examples within a context has failing pended tests",
+      "lineage": [
+        "some string behaves like shared examples within a context",
+        "has failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2156000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 54
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:1]",
+      "name": "some string within a context has passing tests",
+      "lineage": [
+        "some string within a context",
+        "has passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2272000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 35
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:2]",
+      "name": "some string within a context has failing tests",
+      "lineage": [
+        "some string within a context",
+        "has failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2598000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 39
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/string_spec.rb:40:in `block (3 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:3]",
+      "name": "some string within a context has aggregated failing tests",
+      "lineage": [
+        "some string within a context",
+        "has aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2331000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 43
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/string_spec.rb:44:in `block (3 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/string_spec.rb:45:in `block (3 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:4]",
+      "name": "some string within a context has skipped tests",
+      "lineage": [
+        "some string within a context",
+        "has skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 48
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:5]",
+      "name": "some string within a context has passing pended tests",
+      "lineage": [
+        "some string within a context",
+        "has passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2118000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 53
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/string_spec.rb:53"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:6]",
+      "name": "some string within a context has failing pended tests",
+      "lineage": [
+        "some string within a context",
+        "has failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2429000,
+        "meta": {
+          "filePath": "./spec/examples/string_spec.rb",
+          "lineNumber": 58
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "name": "some string within a context behaves like shared examples has top-level passing tests",
+      "lineage": [
+        "some string within a context behaves like shared examples",
+        "has top-level passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/shared_examples.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 1960000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 2
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:2]",
+      "name": "some string within a context behaves like shared examples has top-level failing tests",
+      "lineage": [
+        "some string within a context behaves like shared examples",
+        "has top-level failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 1989000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 6
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:7:in `block (2 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:3]",
+      "name": "some string within a context behaves like shared examples has top-level aggregated failing tests",
+      "lineage": [
+        "some string within a context behaves like shared examples",
+        "has top-level aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2512000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 10
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:11:in `block (2 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:12:in `block (2 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:4]",
+      "name": "some string within a context behaves like shared examples has top-level skipped tests",
+      "lineage": [
+        "some string within a context behaves like shared examples",
+        "has top-level skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 15
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:5]",
+      "name": "some string within a context behaves like shared examples has top-level passing pended tests",
+      "lineage": [
+        "some string within a context behaves like shared examples",
+        "has top-level passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2402000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 20
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:20"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:6]",
+      "name": "some string within a context behaves like shared examples has top-level failing pended tests",
+      "lineage": [
+        "some string within a context behaves like shared examples",
+        "has top-level failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2197000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 25
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:7:1]",
+      "name": "some string within a context behaves like shared examples within a context has passing tests",
+      "lineage": [
+        "some string within a context behaves like shared examples within a context",
+        "has passing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2170000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 31
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:7:2]",
+      "name": "some string within a context behaves like shared examples within a context has failing tests",
+      "lineage": [
+        "some string within a context behaves like shared examples within a context",
+        "has failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2212000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 35
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/kylekthompson/src/rwx-research/captain/spec/examples/shared_examples.rb:36:in `block (3 levels) in \u003cmain\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-rails-6.0.0.rc1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in \u003cmodule:MinitestLifecycleAdapter\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:7:3]",
+      "name": "some string within a context behaves like shared examples within a context has aggregated failing tests",
+      "lineage": [
+        "some string within a context behaves like shared examples within a context",
+        "has aggregated failing tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3165000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 39
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Got 2 failures from failure aggregation block:\n\n  1) expected: 2\n          got: 1\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:40:in `block (3 levels) in \u003cmain\u003e'\n\n  2) expected: 3\n          got: 2\n\n     (compared using ==)\n\n     ./spec/examples/shared_examples.rb:41:in `block (3 levels) in \u003cmain\u003e'",
+          "exception": "RSpec::Expectations::MultipleExpectationsNotMetError",
+          "backtrace": [
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-support-b8e2d10b0f9a/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:85:in `notify_aggregated_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/expectations/failure_aggregator.rb:31:in `aggregate'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-expectations-d508102d72cb/lib/rspec/matchers.rb:306:in `aggregate_failures'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2251:in `block in define_built_in_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:457:in `instance_exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:390:in `execute_with'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:352:in `call'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:701:in `block in run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:697:in `run_examples'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:611:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `block in run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/example_group.rb:612:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (3 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `map'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:175:in `block (2 levels) in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:170:in `block in run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:169:in `run_specs'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:107:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rspec-core-2f753b522884/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bin/rspec:25:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in \u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `\u003ctop (required)\u003e'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'",
+            "/Users/kylekthompson/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:7:4]",
+      "name": "some string within a context behaves like shared examples within a context has skipped tests",
+      "lineage": [
+        "some string within a context behaves like shared examples within a context",
+        "has skipped tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 3000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 44
+        },
+        "status": {
+          "kind": "pended",
+          "message": "Temporarily skipped with xit"
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:7:5]",
+      "name": "some string within a context behaves like shared examples within a context has passing pended tests",
+      "lineage": [
+        "some string within a context behaves like shared examples within a context",
+        "has passing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2212000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 49
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected example to fail since it is pending, but it passed.",
+          "exception": "RSpec::Core::Pending::PendingExampleFixedError",
+          "backtrace": [
+            "./spec/examples/shared_examples.rb:49"
+          ]
+        }
+      }
+    },
+    {
+      "id": "./spec/examples/string_spec.rb[1:8:7:7:6]",
+      "name": "some string within a context behaves like shared examples within a context has failing pended tests",
+      "lineage": [
+        "some string within a context behaves like shared examples within a context",
+        "has failing pended tests"
+      ],
+      "location": {
+        "file": "./spec/examples/string_spec.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 2257000,
+        "meta": {
+          "filePath": "./spec/examples/shared_examples.rb",
+          "lineNumber": 54
+        },
+        "status": {
+          "kind": "pended",
+          "message": "for a reason"
+        }
+      }
+    }
+  ],
+  "derivedFrom": [
+    {
+      "originalFilePath": "fixtures/rspec.json",
+      "contents": "ewogICJ2ZXJzaW9uIjogIjMuMTEuMCIsCiAgImV4YW1wbGVzIjogWwogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMToxXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIHBhc3NpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBoYXMgdG9wLWxldmVsIHBhc3NpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBhc3NlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA1LAogICAgICAicnVuX3RpbWUiOiAwLjAzMDc5NSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjJdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDksCiAgICAgICJydW5fdGltZSI6IDAuMDA2MTE0LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiXG5leHBlY3RlZDogMlxuICAgICBnb3Q6IDFcblxuKGNvbXBhcmVkIHVzaW5nID09KVxuIiwKICAgICAgICAiYmFja3RyYWNlIjogWwogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTAyOmluIGBibG9jayBpbiBcdTAwM2Ntb2R1bGU6U3VwcG9ydFx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTExOmluIGBub3RpZnlfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjozODppbiBgaGFuZGxlX2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjU2OmluIGBibG9jayBpbiBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDg6aW4gYGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjY1OmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vc3JjL3J3eC1yZXNlYXJjaC9jYXB0YWluL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYjoxMDppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI2OmluIGBibG9jayBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL3JzcGVjLXJhaWxzLTYuMC4wLnJjMS9saWIvcnNwZWMvcmFpbHMvYWRhcHRlcnMucmI6NzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbW9kdWxlOk1pbml0ZXN0TGlmZWN5Y2xlQWRhcHRlclx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6M10iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBhZ2dyZWdhdGVkIGZhaWxpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBoYXMgdG9wLWxldmVsIGFnZ3JlZ2F0ZWQgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDEzLAogICAgICAicnVuX3RpbWUiOiAwLjAwMzEzMSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6Ok11bHRpcGxlRXhwZWN0YXRpb25zTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkdvdCAyIGZhaWx1cmVzIGZyb20gZmFpbHVyZSBhZ2dyZWdhdGlvbiBibG9jazpcblxuICAxKSBleHBlY3RlZDogMlxuICAgICAgICAgIGdvdDogMVxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYjoxNDppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSdcblxuICAyKSBleHBlY3RlZDogM1xuICAgICAgICAgIGdvdDogMlxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYjoxNTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjRdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIGhhcyB0b3AtbGV2ZWwgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAxOCwKICAgICAgInJ1bl90aW1lIjogNi4wZS02LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogIlRlbXBvcmFyaWx5IHNraXBwZWQgd2l0aCB4aXQiCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo1XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2UgaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDIzLAogICAgICAicnVuX3RpbWUiOiAwLjAwMzE2NywKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6Q29yZTo6UGVuZGluZzo6UGVuZGluZ0V4YW1wbGVGaXhlZEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJFeHBlY3RlZCBleGFtcGxlIHRvIGZhaWwgc2luY2UgaXQgaXMgcGVuZGluZywgYnV0IGl0IHBhc3NlZC4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiOjIzIl0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6Nl0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMjgsCiAgICAgICJydW5fdGltZSI6IDAuMDAyOTcyLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogImZvciBhIHJlYXNvbiIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjc6MV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2UgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIHBhc3NpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBhc3NlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDIsCiAgICAgICJydW5fdGltZSI6IDAuMDAyOTgyLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbAogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6NzoyXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIGZhaWxpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNiwKICAgICAgInJ1bl90aW1lIjogMC4wMDI5NzEsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpFeHBlY3RhdGlvbk5vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJcbmV4cGVjdGVkOiAyXG4gICAgIGdvdDogMVxuXG4oY29tcGFyZWQgdXNpbmcgPT0pXG4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbF93aXRoLnJiOjM1OmluIGBmYWlsX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjM4OmluIGBoYW5kbGVfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NTY6aW4gYGJsb2NrIGluIGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjoyNzppbiBgd2l0aF9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjo0ODppbiBgaGFuZGxlX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6NjU6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjEwMTppbiBgdG8nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi9zcmMvcnd4LXJlc2VhcmNoL2NhcHRhaW4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6NzppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2MjY6aW4gYGJsb2NrIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvcnNwZWMtcmFpbHMtNi4wLjAucmMxL2xpYi9yc3BlYy9yYWlscy9hZGFwdGVycy5yYjo3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2Ntb2R1bGU6TWluaXRlc3RMaWZlY3ljbGVBZGFwdGVyXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjM5MDppbiBgZXhlY3V0ZV93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjg6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyOTppbiBgcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI1OTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjcwMTppbiBgYmxvY2sgaW4gcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMyBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMDY4OmluIGB3aXRoX3N1aXRlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTcwOmluIGBibG9jayBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3JlcG9ydGVyLnJiOjc0OmluIGByZXBvcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNjk6aW4gYHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEwNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NzE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjQ1OmluIGBpbnZva2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2V4ZS9yc3BlYzo0OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBga2VybmVsX2xvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6MjM6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6NDg0OmluIGBleGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2NvbW1hbmQucmI6Mjc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9pbnZvY2F0aW9uLnJiOjEyNzppbiBgaW52b2tlX2NvbW1hbmQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IucmI6MzkyOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MzE6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2Jhc2UucmI6NDg1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MjU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTo0ODppbiBgYmxvY2sgaW4gXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvZnJpZW5kbHlfZXJyb3JzLnJiOjEwMzppbiBgd2l0aF9mcmllbmRseV9lcnJvcnMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjM2OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgXHUwMDNjbWFpblx1MDAzZSciCiAgICAgICAgXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo3OjNdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2UgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIGFnZ3JlZ2F0ZWQgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMTAsCiAgICAgICJydW5fdGltZSI6IDAuMDAyNTQsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpNdWx0aXBsZUV4cGVjdGF0aW9uc05vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJHb3QgMiBmYWlsdXJlcyBmcm9tIGZhaWx1cmUgYWdncmVnYXRpb24gYmxvY2s6XG5cbiAgMSkgZXhwZWN0ZWQ6IDJcbiAgICAgICAgICBnb3Q6IDFcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjoxMTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6MTI6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjc6NF0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBza2lwcGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2UgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIHNraXBwZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAxNSwKICAgICAgInJ1bl90aW1lIjogNC4wZS02LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogIlRlbXBvcmFyaWx5IHNraXBwZWQgd2l0aCB4aXQiCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo3OjVdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDIwLAogICAgICAicnVuX3RpbWUiOiAwLjAwMzA0OSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6Q29yZTo6UGVuZGluZzo6UGVuZGluZ0V4YW1wbGVGaXhlZEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJFeHBlY3RlZCBleGFtcGxlIHRvIGZhaWwgc2luY2UgaXQgaXMgcGVuZGluZywgYnV0IGl0IHBhc3NlZC4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6MjAiXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo3OjZdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAyNSwKICAgICAgInJ1bl90aW1lIjogMC4wMDMwNTUsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6Nzo3OjFdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBwYXNzaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2UgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyB3aXRoaW4gYSBjb250ZXh0IGhhcyBwYXNzaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJwYXNzZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAzMSwKICAgICAgInJ1bl90aW1lIjogMC4wMDI4NTksCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo3Ojc6Ml0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIGZhaWxpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIGZhaWxpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDM1LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjk3OSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6OkV4cGVjdGF0aW9uTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIlxuZXhwZWN0ZWQ6IDJcbiAgICAgZ290OiAxXG5cbihjb21wYXJlZCB1c2luZyA9PSlcbiIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjEwMjppbiBgYmxvY2sgaW4gXHUwMDNjbW9kdWxlOlN1cHBvcnRcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjExMTppbiBgbm90aWZ5X2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9mYWlsX3dpdGgucmI6MzU6aW4gYGZhaWxfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mzg6aW4gYGhhbmRsZV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjo1NjppbiBgYmxvY2sgaW4gaGFuZGxlX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjI3OmluIGB3aXRoX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjQ4OmluIGBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjo2NTppbiBgdG8nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6MTAxOmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uL3NyYy9yd3gtcmVzZWFyY2gvY2FwdGFpbi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjozNjppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2MjY6aW4gYGJsb2NrIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvcnNwZWMtcmFpbHMtNi4wLjAucmMxL2xpYi9yc3BlYy9yYWlscy9hZGFwdGVycy5yYjo3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2Ntb2R1bGU6TWluaXRlc3RMaWZlY3ljbGVBZGFwdGVyXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjM5MDppbiBgZXhlY3V0ZV93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjg6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyOTppbiBgcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI1OTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjcwMTppbiBgYmxvY2sgaW4gcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMyBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMDY4OmluIGB3aXRoX3N1aXRlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTcwOmluIGBibG9jayBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3JlcG9ydGVyLnJiOjc0OmluIGByZXBvcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNjk6aW4gYHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEwNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NzE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjQ1OmluIGBpbnZva2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2V4ZS9yc3BlYzo0OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBga2VybmVsX2xvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6MjM6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6NDg0OmluIGBleGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2NvbW1hbmQucmI6Mjc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9pbnZvY2F0aW9uLnJiOjEyNzppbiBgaW52b2tlX2NvbW1hbmQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IucmI6MzkyOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MzE6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2Jhc2UucmI6NDg1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MjU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTo0ODppbiBgYmxvY2sgaW4gXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvZnJpZW5kbHlfZXJyb3JzLnJiOjEwMzppbiBgd2l0aF9mcmllbmRseV9lcnJvcnMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjM2OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgXHUwMDNjbWFpblx1MDAzZSciCiAgICAgICAgXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo3Ojc6M10iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIGFnZ3JlZ2F0ZWQgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAzOSwKICAgICAgInJ1bl90aW1lIjogMC4wMDI0MzgsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpNdWx0aXBsZUV4cGVjdGF0aW9uc05vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJHb3QgMiBmYWlsdXJlcyBmcm9tIGZhaWx1cmUgYWdncmVnYXRpb24gYmxvY2s6XG5cbiAgMSkgZXhwZWN0ZWQ6IDJcbiAgICAgICAgICBnb3Q6IDFcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjo0MDppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6NDE6aW4gYGJsb2NrICgzIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjc6Nzo0XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDQ0LAogICAgICAicnVuX3RpbWUiOiA0LjBlLTYsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiVGVtcG9yYXJpbHkgc2tpcHBlZCB3aXRoIHhpdCIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjc6Nzo1XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA0OSwKICAgICAgInJ1bl90aW1lIjogMC4wMDI1ODMsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIiwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkNvcmU6OlBlbmRpbmc6OlBlbmRpbmdFeGFtcGxlRml4ZWRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiRXhwZWN0ZWQgZXhhbXBsZSB0byBmYWlsIHNpbmNlIGl0IGlzIHBlbmRpbmcsIGJ1dCBpdCBwYXNzZWQuIiwKICAgICAgICAiYmFja3RyYWNlIjogWyIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjQ5Il0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6Nzo3OjZdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA1NCwKICAgICAgInJ1bl90aW1lIjogMC4wMDMxNTEsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODoxXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIHdpdGhpbiBhIGNvbnRleHQgaGFzIHBhc3NpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBhc3NlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAzNiwKICAgICAgInJ1bl90aW1lIjogMC4wMDI1MDIsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmJbMTo4OjJdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2Ugd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDQwLAogICAgICAicnVuX3RpbWUiOiAwLjAwMzA2LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiXG5leHBlY3RlZDogMlxuICAgICBnb3Q6IDFcblxuKGNvbXBhcmVkIHVzaW5nID09KVxuIiwKICAgICAgICAiYmFja3RyYWNlIjogWwogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTAyOmluIGBibG9jayBpbiBcdTAwM2Ntb2R1bGU6U3VwcG9ydFx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTExOmluIGBub3RpZnlfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjozODppbiBgaGFuZGxlX2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjU2OmluIGBibG9jayBpbiBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDg6aW4gYGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjY1OmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vc3JjL3J3eC1yZXNlYXJjaC9jYXB0YWluL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYjo0MTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI2OmluIGBibG9jayBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL3JzcGVjLXJhaWxzLTYuMC4wLnJjMS9saWIvcnNwZWMvcmFpbHMvYWRhcHRlcnMucmI6NzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbW9kdWxlOk1pbml0ZXN0TGlmZWN5Y2xlQWRhcHRlclx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODozXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2Ugd2l0aGluIGEgY29udGV4dCBoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNDQsCiAgICAgICJydW5fdGltZSI6IDAuMDAzMDU1LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6TXVsdGlwbGVFeHBlY3RhdGlvbnNOb3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiR290IDIgZmFpbHVyZXMgZnJvbSBmYWlsdXJlIGFnZ3JlZ2F0aW9uIGJsb2NrOlxuXG4gIDEpIGV4cGVjdGVkOiAyXG4gICAgICAgICAgZ290OiAxXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiOjQ1OmluIGBibG9jayAoMyBsZXZlbHMpIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiOjQ2OmluIGBibG9jayAoMyBsZXZlbHMpIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjEwMjppbiBgYmxvY2sgaW4gXHUwMDNjbW9kdWxlOlN1cHBvcnRcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjExMTppbiBgbm90aWZ5X2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9mYWlsdXJlX2FnZ3JlZ2F0b3IucmI6ODU6aW4gYG5vdGlmeV9hZ2dyZWdhdGVkX2ZhaWx1cmVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjMxOmluIGBhZ2dyZWdhdGUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL21hdGNoZXJzLnJiOjMwNjppbiBgYWdncmVnYXRlX2ZhaWx1cmVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIyNTE6aW4gYGJsb2NrIGluIGRlZmluZV9idWlsdF9pbl9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo0XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIHdpdGhpbiBhIGNvbnRleHQgaGFzIHNraXBwZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNDksCiAgICAgICJydW5fdGltZSI6IDQuMGUtNiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJUZW1wb3JhcmlseSBza2lwcGVkIHdpdGggeGl0IgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo1XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGhhcyBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDU0LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjAxNCwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6Q29yZTo6UGVuZGluZzo6UGVuZGluZ0V4YW1wbGVGaXhlZEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJFeHBlY3RlZCBleGFtcGxlIHRvIGZhaWwgc2luY2UgaXQgaXMgcGVuZGluZywgYnV0IGl0IHBhc3NlZC4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiOjU0Il0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo2XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL2NsYXNzX3NwZWMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA1OSwKICAgICAgInJ1bl90aW1lIjogMC4wMDIzOTgsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3OjFdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIHBhc3NpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBhc3NlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDIsCiAgICAgICJydW5fdGltZSI6IDAuMDAyOTk0LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbAogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3OjJdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIGZhaWxpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDYsCiAgICAgICJydW5fdGltZSI6IDAuMDAyODExLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiXG5leHBlY3RlZDogMlxuICAgICBnb3Q6IDFcblxuKGNvbXBhcmVkIHVzaW5nID09KVxuIiwKICAgICAgICAiYmFja3RyYWNlIjogWwogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTAyOmluIGBibG9jayBpbiBcdTAwM2Ntb2R1bGU6U3VwcG9ydFx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTExOmluIGBub3RpZnlfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjozODppbiBgaGFuZGxlX2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjU2OmluIGBibG9jayBpbiBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDg6aW4gYGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjY1OmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vc3JjL3J3eC1yZXNlYXJjaC9jYXB0YWluL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjc6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI2OmluIGBibG9jayBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL3JzcGVjLXJhaWxzLTYuMC4wLnJjMS9saWIvcnNwZWMvcmFpbHMvYWRhcHRlcnMucmI6NzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbW9kdWxlOk1pbml0ZXN0TGlmZWN5Y2xlQWRhcHRlclx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3OjNdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2Ugd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAxMCwKICAgICAgInJ1bl90aW1lIjogMC4wMDI2NTQsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpNdWx0aXBsZUV4cGVjdGF0aW9uc05vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJHb3QgMiBmYWlsdXJlcyBmcm9tIGZhaWx1cmUgYWdncmVnYXRpb24gYmxvY2s6XG5cbiAgMSkgZXhwZWN0ZWQ6IDJcbiAgICAgICAgICBnb3Q6IDFcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjoxMTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6MTI6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjg6Nzo0XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIHNraXBwZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgaGFzIHRvcC1sZXZlbCBza2lwcGVkIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJwZW5kaW5nIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMTUsCiAgICAgICJydW5fdGltZSI6IDMuMGUtNiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJUZW1wb3JhcmlseSBza2lwcGVkIHdpdGggeGl0IgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3OjVdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMjAsCiAgICAgICJydW5fdGltZSI6IDAuMDAzMDE4LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogImZvciBhIHJlYXNvbiIsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpDb3JlOjpQZW5kaW5nOjpQZW5kaW5nRXhhbXBsZUZpeGVkRXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkV4cGVjdGVkIGV4YW1wbGUgdG8gZmFpbCBzaW5jZSBpdCBpcyBwZW5kaW5nLCBidXQgaXQgcGFzc2VkLiIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjoyMCJdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjg6Nzo2XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIGZhaWxpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAiVGVzdHM6OkNhc2Ugd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAyNSwKICAgICAgInJ1bl90aW1lIjogMC4wMDIyMjEsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3Ojc6MV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHBhc3NpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGFzc2VkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMzEsCiAgICAgICJydW5fdGltZSI6IDAuMDAyMjEyLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbAogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3Ojc6Ml0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIGZhaWxpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMzUsCiAgICAgICJydW5fdGltZSI6IDAuMDAyODYxLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiXG5leHBlY3RlZDogMlxuICAgICBnb3Q6IDFcblxuKGNvbXBhcmVkIHVzaW5nID09KVxuIiwKICAgICAgICAiYmFja3RyYWNlIjogWwogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTAyOmluIGBibG9jayBpbiBcdTAwM2Ntb2R1bGU6U3VwcG9ydFx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTExOmluIGBub3RpZnlfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjozODppbiBgaGFuZGxlX2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjU2OmluIGBibG9jayBpbiBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDg6aW4gYGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjY1OmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vc3JjL3J3eC1yZXNlYXJjaC9jYXB0YWluL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjM2OmluIGBibG9jayAoMyBsZXZlbHMpIGluIFx1MDAzY21haW5cdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyNjppbiBgYmxvY2sgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9yc3BlYy1yYWlscy02LjAuMC5yYzEvbGliL3JzcGVjL3JhaWxzL2FkYXB0ZXJzLnJiOjc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIFx1MDAzY21vZHVsZTpNaW5pdGVzdExpZmVjeWNsZUFkYXB0ZXJcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjg6Nzo3OjNdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBhZ2dyZWdhdGVkIGZhaWxpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAzOSwKICAgICAgInJ1bl90aW1lIjogMC4wMDMwNCwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6Ok11bHRpcGxlRXhwZWN0YXRpb25zTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkdvdCAyIGZhaWx1cmVzIGZyb20gZmFpbHVyZSBhZ2dyZWdhdGlvbiBibG9jazpcblxuICAxKSBleHBlY3RlZDogMlxuICAgICAgICAgIGdvdDogMVxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjQwOmluIGBibG9jayAoMyBsZXZlbHMpIGluIFx1MDAzY21haW5cdTAwM2UnXG5cbiAgMikgZXhwZWN0ZWQ6IDNcbiAgICAgICAgICBnb3Q6IDJcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjo0MTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjEwMjppbiBgYmxvY2sgaW4gXHUwMDNjbW9kdWxlOlN1cHBvcnRcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjExMTppbiBgbm90aWZ5X2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9mYWlsdXJlX2FnZ3JlZ2F0b3IucmI6ODU6aW4gYG5vdGlmeV9hZ2dyZWdhdGVkX2ZhaWx1cmVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjMxOmluIGBhZ2dyZWdhdGUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL21hdGNoZXJzLnJiOjMwNjppbiBgYWdncmVnYXRlX2ZhaWx1cmVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIyNTE6aW4gYGJsb2NrIGluIGRlZmluZV9idWlsdF9pbl9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9jbGFzc19zcGVjLnJiWzE6ODo3Ojc6NF0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHNraXBwZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJUZXN0czo6Q2FzZSB3aXRoaW4gYSBjb250ZXh0IGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDQ0LAogICAgICAicnVuX3RpbWUiOiA0LjBlLTYsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiVGVtcG9yYXJpbHkgc2tpcHBlZCB3aXRoIHhpdCIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjg6Nzo3OjVdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyB3aXRoaW4gYSBjb250ZXh0IGhhcyBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNDksCiAgICAgICJydW5fdGltZSI6IDAuMDAyNjcyLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogImZvciBhIHJlYXNvbiIsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpDb3JlOjpQZW5kaW5nOjpQZW5kaW5nRXhhbXBsZUZpeGVkRXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkV4cGVjdGVkIGV4YW1wbGUgdG8gZmFpbCBzaW5jZSBpdCBpcyBwZW5kaW5nLCBidXQgaXQgcGFzc2VkLiIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjo0OSJdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvY2xhc3Nfc3BlYy5yYlsxOjg6Nzo3OjZdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogIlRlc3RzOjpDYXNlIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyB3aXRoaW4gYSBjb250ZXh0IGhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDU0LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjk1OSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6MV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJwYXNzZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDQsCiAgICAgICJydW5fdGltZSI6IDAuMDAyMTEsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6Ml0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgaGFzIHRvcC1sZXZlbCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDgsCiAgICAgICJydW5fdGltZSI6IDAuMDAyMjQsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpFeHBlY3RhdGlvbk5vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJcbmV4cGVjdGVkOiAyXG4gICAgIGdvdDogMVxuXG4oY29tcGFyZWQgdXNpbmcgPT0pXG4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbF93aXRoLnJiOjM1OmluIGBmYWlsX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjM4OmluIGBoYW5kbGVfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NTY6aW4gYGJsb2NrIGluIGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjoyNzppbiBgd2l0aF9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjo0ODppbiBgaGFuZGxlX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6NjU6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjEwMTppbiBgdG8nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi9zcmMvcnd4LXJlc2VhcmNoL2NhcHRhaW4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYjo5OmluIGBibG9jayAoMiBsZXZlbHMpIGluIFx1MDAzY21haW5cdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyNjppbiBgYmxvY2sgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9yc3BlYy1yYWlscy02LjAuMC5yYzEvbGliL3JzcGVjL3JhaWxzL2FkYXB0ZXJzLnJiOjc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIFx1MDAzY21vZHVsZTpNaW5pdGVzdExpZmVjeWNsZUFkYXB0ZXJcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTozXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIGFnZ3JlZ2F0ZWQgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDEyLAogICAgICAicnVuX3RpbWUiOiAwLjAwMjg4NiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6Ok11bHRpcGxlRXhwZWN0YXRpb25zTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkdvdCAyIGZhaWx1cmVzIGZyb20gZmFpbHVyZSBhZ2dyZWdhdGlvbiBibG9jazpcblxuICAxKSBleHBlY3RlZDogMlxuICAgICAgICAgIGdvdDogMVxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmI6MTM6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSdcblxuICAyKSBleHBlY3RlZDogM1xuICAgICAgICAgIGdvdDogMlxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmI6MTQ6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo0XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIHNraXBwZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJzb21lIHN0cmluZyBoYXMgdG9wLWxldmVsIHNraXBwZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDE3LAogICAgICAicnVuX3RpbWUiOiA0LjBlLTYsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiVGVtcG9yYXJpbHkgc2tpcHBlZCB3aXRoIHhpdCIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo1XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAyMiwKICAgICAgInJ1bl90aW1lIjogMC4wMDI5MjIsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIiwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkNvcmU6OlBlbmRpbmc6OlBlbmRpbmdFeGFtcGxlRml4ZWRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiRXhwZWN0ZWQgZXhhbXBsZSB0byBmYWlsIHNpbmNlIGl0IGlzIHBlbmRpbmcsIGJ1dCBpdCBwYXNzZWQuIiwKICAgICAgICAiYmFja3RyYWNlIjogWyIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmI6MjIiXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6Nl0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDI3LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjcwNCwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6NzoxXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIHBhc3NpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJzb21lIHN0cmluZyBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGFzc2VkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMiwKICAgICAgInJ1bl90aW1lIjogMC4wMDI3LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbAogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjc6Ml0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIGZhaWxpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDYsCiAgICAgICJydW5fdGltZSI6IDAuMDAyNTQxLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiXG5leHBlY3RlZDogMlxuICAgICBnb3Q6IDFcblxuKGNvbXBhcmVkIHVzaW5nID09KVxuIiwKICAgICAgICAiYmFja3RyYWNlIjogWwogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTAyOmluIGBibG9jayBpbiBcdTAwM2Ntb2R1bGU6U3VwcG9ydFx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTExOmluIGBub3RpZnlfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjozODppbiBgaGFuZGxlX2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjU2OmluIGBibG9jayBpbiBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDg6aW4gYGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjY1OmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vc3JjL3J3eC1yZXNlYXJjaC9jYXB0YWluL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjc6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI2OmluIGBibG9jayBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL3JzcGVjLXJhaWxzLTYuMC4wLnJjMS9saWIvcnNwZWMvcmFpbHMvYWRhcHRlcnMucmI6NzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbW9kdWxlOk1pbml0ZXN0TGlmZWN5Y2xlQWRhcHRlclx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjc6M10iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBhZ2dyZWdhdGVkIGZhaWxpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJzb21lIHN0cmluZyBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAxMCwKICAgICAgInJ1bl90aW1lIjogMC4wMDI4NzksCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpNdWx0aXBsZUV4cGVjdGF0aW9uc05vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJHb3QgMiBmYWlsdXJlcyBmcm9tIGZhaWx1cmUgYWdncmVnYXRpb24gYmxvY2s6XG5cbiAgMSkgZXhwZWN0ZWQ6IDJcbiAgICAgICAgICBnb3Q6IDFcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjoxMTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6MTI6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo3OjRdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgaGFzIHRvcC1sZXZlbCBza2lwcGVkIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJwZW5kaW5nIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMTUsCiAgICAgICJydW5fdGltZSI6IDMuMGUtNiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJUZW1wb3JhcmlseSBza2lwcGVkIHdpdGggeGl0IgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjc6NV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMjAsCiAgICAgICJydW5fdGltZSI6IDAuMDAyNzIxLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogImZvciBhIHJlYXNvbiIsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpDb3JlOjpQZW5kaW5nOjpQZW5kaW5nRXhhbXBsZUZpeGVkRXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkV4cGVjdGVkIGV4YW1wbGUgdG8gZmFpbCBzaW5jZSBpdCBpcyBwZW5kaW5nLCBidXQgaXQgcGFzc2VkLiIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjoyMCJdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo3OjZdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJzb21lIHN0cmluZyBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAyNSwKICAgICAgInJ1bl90aW1lIjogMC4wMDMyNDksCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjc6NzoxXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGFzc2VkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMzEsCiAgICAgICJydW5fdGltZSI6IDAuMDAyNzkzLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbAogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjc6NzoyXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMzUsCiAgICAgICJydW5fdGltZSI6IDAuMDAyMjYyLAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbCwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiXG5leHBlY3RlZDogMlxuICAgICBnb3Q6IDFcblxuKGNvbXBhcmVkIHVzaW5nID09KVxuIiwKICAgICAgICAiYmFja3RyYWNlIjogWwogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTAyOmluIGBibG9jayBpbiBcdTAwM2Ntb2R1bGU6U3VwcG9ydFx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtc3VwcG9ydC1iOGUyZDEwYjBmOWEvbGliL3JzcGVjL3N1cHBvcnQucmI6MTExOmluIGBub3RpZnlfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjozODppbiBgaGFuZGxlX2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjU2OmluIGBibG9jayBpbiBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDg6aW4gYGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjY1OmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vc3JjL3J3eC1yZXNlYXJjaC9jYXB0YWluL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjM2OmluIGBibG9jayAoMyBsZXZlbHMpIGluIFx1MDAzY21haW5cdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyNjppbiBgYmxvY2sgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9yc3BlYy1yYWlscy02LjAuMC5yYzEvbGliL3JzcGVjL3JhaWxzL2FkYXB0ZXJzLnJiOjc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIFx1MDAzY21vZHVsZTpNaW5pdGVzdExpZmVjeWNsZUFkYXB0ZXJcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo3Ojc6M10iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIGFnZ3JlZ2F0ZWQgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAzOSwKICAgICAgInJ1bl90aW1lIjogMC4wMDIyODgsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpNdWx0aXBsZUV4cGVjdGF0aW9uc05vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJHb3QgMiBmYWlsdXJlcyBmcm9tIGZhaWx1cmUgYWdncmVnYXRpb24gYmxvY2s6XG5cbiAgMSkgZXhwZWN0ZWQ6IDJcbiAgICAgICAgICBnb3Q6IDFcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjo0MDppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6NDE6aW4gYGJsb2NrICgzIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo3Ojc6NF0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHNraXBwZWQgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJzb21lIHN0cmluZyBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIHNraXBwZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA0NCwKICAgICAgInJ1bl90aW1lIjogMy4wZS02LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogIlRlbXBvcmFyaWx5IHNraXBwZWQgd2l0aCB4aXQiCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6Nzo3OjVdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDQ5LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjU0NiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6Q29yZTo6UGVuZGluZzo6UGVuZGluZ0V4YW1wbGVGaXhlZEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJFeHBlY3RlZCBleGFtcGxlIHRvIGZhaWwgc2luY2UgaXQgaXMgcGVuZGluZywgYnV0IGl0IHBhc3NlZC4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6NDkiXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6Nzo3OjZdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIGJlaGF2ZXMgbGlrZSBzaGFyZWQgZXhhbXBsZXMgd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA1NCwKICAgICAgInJ1bl90aW1lIjogMC4wMDIxNTYsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6MV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHBhc3NpbmcgdGVzdHMiLAogICAgICAiZnVsbF9kZXNjcmlwdGlvbiI6ICJzb21lIHN0cmluZyB3aXRoaW4gYSBjb250ZXh0IGhhcyBwYXNzaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJwYXNzZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDM1LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjI3MiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo4OjJdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAzOSwKICAgICAgInJ1bl90aW1lIjogMC4wMDI1OTgsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpFeHBlY3RhdGlvbk5vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJcbmV4cGVjdGVkOiAyXG4gICAgIGdvdDogMVxuXG4oY29tcGFyZWQgdXNpbmcgPT0pXG4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbF93aXRoLnJiOjM1OmluIGBmYWlsX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjM4OmluIGBoYW5kbGVfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NTY6aW4gYGJsb2NrIGluIGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjoyNzppbiBgd2l0aF9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjo0ODppbiBgaGFuZGxlX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6NjU6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjEwMTppbiBgdG8nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi9zcmMvcnd4LXJlc2VhcmNoL2NhcHRhaW4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYjo0MDppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2MjY6aW4gYGJsb2NrIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvcnNwZWMtcmFpbHMtNi4wLjAucmMxL2xpYi9yc3BlYy9yYWlscy9hZGFwdGVycy5yYjo3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2Ntb2R1bGU6TWluaXRlc3RMaWZlY3ljbGVBZGFwdGVyXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjM5MDppbiBgZXhlY3V0ZV93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjg6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyOTppbiBgcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI1OTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjcwMTppbiBgYmxvY2sgaW4gcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMyBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMDY4OmluIGB3aXRoX3N1aXRlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTcwOmluIGBibG9jayBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3JlcG9ydGVyLnJiOjc0OmluIGByZXBvcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNjk6aW4gYHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEwNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NzE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjQ1OmluIGBpbnZva2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2V4ZS9yc3BlYzo0OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBga2VybmVsX2xvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6MjM6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6NDg0OmluIGBleGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2NvbW1hbmQucmI6Mjc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9pbnZvY2F0aW9uLnJiOjEyNzppbiBgaW52b2tlX2NvbW1hbmQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IucmI6MzkyOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MzE6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2Jhc2UucmI6NDg1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MjU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTo0ODppbiBgYmxvY2sgaW4gXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvZnJpZW5kbHlfZXJyb3JzLnJiOjEwMzppbiBgd2l0aF9mcmllbmRseV9lcnJvcnMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjM2OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgXHUwMDNjbWFpblx1MDAzZSciCiAgICAgICAgXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6ODozXSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBoYXMgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDQzLAogICAgICAicnVuX3RpbWUiOiAwLjAwMjMzMSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6Ok11bHRpcGxlRXhwZWN0YXRpb25zTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkdvdCAyIGZhaWx1cmVzIGZyb20gZmFpbHVyZSBhZ2dyZWdhdGlvbiBibG9jazpcblxuICAxKSBleHBlY3RlZDogMlxuICAgICAgICAgIGdvdDogMVxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmI6NDQ6aW4gYGJsb2NrICgzIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSdcblxuICAyKSBleHBlY3RlZDogM1xuICAgICAgICAgIGdvdDogMlxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmI6NDU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo4OjRdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBza2lwcGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBoYXMgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNDgsCiAgICAgICJydW5fdGltZSI6IDQuMGUtNiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJUZW1wb3JhcmlseSBza2lwcGVkIHdpdGggeGl0IgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6NV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBoYXMgcGFzc2luZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNTMsCiAgICAgICJydW5fdGltZSI6IDAuMDAyMTE4LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogImZvciBhIHJlYXNvbiIsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpDb3JlOjpQZW5kaW5nOjpQZW5kaW5nRXhhbXBsZUZpeGVkRXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkV4cGVjdGVkIGV4YW1wbGUgdG8gZmFpbCBzaW5jZSBpdCBpcyBwZW5kaW5nLCBidXQgaXQgcGFzc2VkLiIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiOjUzIl0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6Nl0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIGZhaWxpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBoYXMgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDU4LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjQyOSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iCiAgICB9LAogICAgewogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgcGFzc2luZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGFzc2VkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogMiwKICAgICAgInJ1bl90aW1lIjogMC4wMDE5NiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo4Ojc6Ml0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAiZmFpbGVkIiwKICAgICAgImZpbGVfcGF0aCI6ICIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiIiwKICAgICAgImxpbmVfbnVtYmVyIjogNiwKICAgICAgInJ1bl90aW1lIjogMC4wMDE5ODksCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpFeHBlY3RhdGlvbk5vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJcbmV4cGVjdGVkOiAyXG4gICAgIGdvdDogMVxuXG4oY29tcGFyZWQgdXNpbmcgPT0pXG4iLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbF93aXRoLnJiOjM1OmluIGBmYWlsX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjM4OmluIGBoYW5kbGVfZmFpbHVyZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NTY6aW4gYGJsb2NrIGluIGhhbmRsZV9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjoyNzppbiBgd2l0aF9tYXRjaGVyJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjo0ODppbiBgaGFuZGxlX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6NjU6aW4gYHRvJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZXhwZWN0YXRpb25fdGFyZ2V0LnJiOjEwMTppbiBgdG8nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi9zcmMvcnd4LXJlc2VhcmNoL2NhcHRhaW4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6NzppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2MjY6aW4gYGJsb2NrIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvcnNwZWMtcmFpbHMtNi4wLjAucmMxL2xpYi9yc3BlYy9yYWlscy9hZGFwdGVycy5yYjo3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2Ntb2R1bGU6TWluaXRlc3RMaWZlY3ljbGVBZGFwdGVyXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjM5MDppbiBgZXhlY3V0ZV93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjg6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyOTppbiBgcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI1OTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjcwMTppbiBgYmxvY2sgaW4gcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMyBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMDY4OmluIGB3aXRoX3N1aXRlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTcwOmluIGBibG9jayBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3JlcG9ydGVyLnJiOjc0OmluIGByZXBvcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNjk6aW4gYHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEwNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NzE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjQ1OmluIGBpbnZva2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2V4ZS9yc3BlYzo0OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBga2VybmVsX2xvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6MjM6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6NDg0OmluIGBleGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2NvbW1hbmQucmI6Mjc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9pbnZvY2F0aW9uLnJiOjEyNzppbiBgaW52b2tlX2NvbW1hbmQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IucmI6MzkyOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MzE6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2Jhc2UucmI6NDg1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MjU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTo0ODppbiBgYmxvY2sgaW4gXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvZnJpZW5kbHlfZXJyb3JzLnJiOjEwMzppbiBgd2l0aF9mcmllbmRseV9lcnJvcnMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjM2OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgXHUwMDNjbWFpblx1MDAzZSciCiAgICAgICAgXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6ODo3OjNdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgYWdncmVnYXRlZCBmYWlsaW5nIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAxMCwKICAgICAgInJ1bl90aW1lIjogMC4wMDI1MTIsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiBudWxsLAogICAgICAiZXhjZXB0aW9uIjogewogICAgICAgICJjbGFzcyI6ICJSU3BlYzo6RXhwZWN0YXRpb25zOjpNdWx0aXBsZUV4cGVjdGF0aW9uc05vdE1ldEVycm9yIiwKICAgICAgICAibWVzc2FnZSI6ICJHb3QgMiBmYWlsdXJlcyBmcm9tIGZhaWx1cmUgYWdncmVnYXRpb24gYmxvY2s6XG5cbiAgMSkgZXhwZWN0ZWQ6IDJcbiAgICAgICAgICBnb3Q6IDFcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjoxMTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJ1xuXG4gIDIpIGV4cGVjdGVkOiAzXG4gICAgICAgICAgZ290OiAyXG5cbiAgICAgKGNvbXBhcmVkIHVzaW5nID09KVxuXG4gICAgIC4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmI6MTI6aW4gYGJsb2NrICgyIGxldmVscykgaW4gXHUwMDNjbWFpblx1MDAzZSciLAogICAgICAgICJiYWNrdHJhY2UiOiBbCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIFx1MDAzY21vZHVsZTpTdXBwb3J0XHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1zdXBwb3J0LWI4ZTJkMTBiMGY5YS9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjg1OmluIGBub3RpZnlfYWdncmVnYXRlZF9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWx1cmVfYWdncmVnYXRvci5yYjozMTppbiBgYWdncmVnYXRlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9tYXRjaGVycy5yYjozMDY6aW4gYGFnZ3JlZ2F0ZV9mYWlsdXJlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMjUxOmluIGBibG9jayBpbiBkZWZpbmVfYnVpbHRfaW5faG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6MzkwOmluIGBleGVjdXRlX3dpdGgnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyODppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjM1MjppbiBgY2FsbCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI5OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo0ODY6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjU5OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NzAxOmluIGBibG9jayBpbiBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6Njk3OmluIGBydW5fZXhhbXBsZXMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjExOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBibG9jayBpbiBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjEyOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBtYXAnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNjg6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzA6aW4gYGJsb2NrIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcmVwb3J0ZXIucmI6NzQ6aW4gYHJlcG9ydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE2OTppbiBgcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTA3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo3MTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NDU6aW4gYGludm9rZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvZXhlL3JzcGVjOjQ6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjU4OmluIGBrZXJuZWxfbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjoyMzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjo0ODQ6aW4gYGV4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvY29tbWFuZC5yYjoyNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2ludm9jYXRpb24ucmI6MTI3OmluIGBpbnZva2VfY29tbWFuZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci5yYjozOTI6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjozMTppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvYmFzZS5yYjo0ODU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS5yYjoyNTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjQ4OmluIGBibG9jayBpbiBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9mcmllbmRseV9lcnJvcnMucmI6MTAzOmluIGB3aXRoX2ZyaWVuZGx5X2Vycm9ycyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6MzY6aW4gYFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9iaW4vYnVuZGxlOjI1OmluIGBcdTAwM2NtYWluXHUwMDNlJyIKICAgICAgICBdCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo4Ojc6NF0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBza2lwcGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgc2tpcHBlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDE1LAogICAgICAicnVuX3RpbWUiOiA0LjBlLTYsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiVGVtcG9yYXJpbHkgc2tpcHBlZCB3aXRoIHhpdCIKICAgIH0sCiAgICB7CiAgICAgICJpZCI6ICIuL3NwZWMvZXhhbXBsZXMvc3RyaW5nX3NwZWMucmJbMTo4Ojc6NV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHRvcC1sZXZlbCBwYXNzaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyBoYXMgdG9wLWxldmVsIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAyMCwKICAgICAgInJ1bl90aW1lIjogMC4wMDI0MDIsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIiwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkNvcmU6OlBlbmRpbmc6OlBlbmRpbmdFeGFtcGxlRml4ZWRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiRXhwZWN0ZWQgZXhhbXBsZSB0byBmYWlsIHNpbmNlIGl0IGlzIHBlbmRpbmcsIGJ1dCBpdCBwYXNzZWQuIiwKICAgICAgICAiYmFja3RyYWNlIjogWyIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjIwIl0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6Nzo2XSIsCiAgICAgICJkZXNjcmlwdGlvbiI6ICJoYXMgdG9wLWxldmVsIGZhaWxpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIGhhcyB0b3AtbGV2ZWwgZmFpbGluZyBwZW5kZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiAyNSwKICAgICAgInJ1bl90aW1lIjogMC4wMDIxOTcsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIgogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6Nzo3OjFdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBwYXNzaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIHBhc3NpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBhc3NlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDMxLAogICAgICAicnVuX3RpbWUiOiAwLjAwMjE3LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogbnVsbAogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6Nzo3OjJdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIGZhaWxpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDM1LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjIxMiwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6OkV4cGVjdGF0aW9uTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIlxuZXhwZWN0ZWQ6IDJcbiAgICAgZ290OiAxXG5cbihjb21wYXJlZCB1c2luZyA9PSlcbiIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjEwMjppbiBgYmxvY2sgaW4gXHUwMDNjbW9kdWxlOlN1cHBvcnRcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjExMTppbiBgbm90aWZ5X2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9mYWlsX3dpdGgucmI6MzU6aW4gYGZhaWxfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mzg6aW4gYGhhbmRsZV9mYWlsdXJlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvaGFuZGxlci5yYjo1NjppbiBgYmxvY2sgaW4gaGFuZGxlX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjI3OmluIGB3aXRoX21hdGNoZXInIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjQ4OmluIGBoYW5kbGVfbWF0Y2hlciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLWQ1MDgxMDJkNzJjYi9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjo2NTppbiBgdG8nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6MTAxOmluIGB0byciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uL3NyYy9yd3gtcmVzZWFyY2gvY2FwdGFpbi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjozNjppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI2MzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0Njg6aW4gYGJsb2NrIGluIHdpdGhfYXJvdW5kX2V4YW1wbGVfaG9va3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2MjY6aW4gYGJsb2NrIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvcnNwZWMtcmFpbHMtNi4wLjAucmMxL2xpYi9yc3BlYy9yYWlscy9hZGFwdGVycy5yYjo3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBcdTAwM2Ntb2R1bGU6TWluaXRlc3RMaWZlY3ljbGVBZGFwdGVyXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ1NzppbiBgaW5zdGFuY2VfZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjM5MDppbiBgZXhlY3V0ZV93aXRoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjg6aW4gYGJsb2NrICgyIGxldmVscykgaW4gcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjozNTI6aW4gYGNhbGwnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjYyOTppbiBgcnVuX2Fyb3VuZF9leGFtcGxlX2hvb2tzX2ZvciciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDY4OmluIGB3aXRoX2Fyb3VuZF9leGFtcGxlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjUxMTppbiBgd2l0aF9hcm91bmRfYW5kX3NpbmdsZXRvbl9jb250ZXh0X2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI1OTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjcwMTppbiBgYmxvY2sgaW4gcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY5NzppbiBgcnVuX2V4YW1wbGVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMTppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgYmxvY2sgaW4gcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjYxMjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMyBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgbWFwJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTc1OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvY29uZmlndXJhdGlvbi5yYjoyMDY4OmluIGB3aXRoX3N1aXRlX2hvb2tzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTcwOmluIGBibG9jayBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3JlcG9ydGVyLnJiOjc0OmluIGByZXBvcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNjk6aW4gYHJ1bl9zcGVjcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEwNzppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NzE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjQ1OmluIGBpbnZva2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2V4ZS9yc3BlYzo0OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9iaW4vcnNwZWM6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkvZXhlYy5yYjo1ODppbiBga2VybmVsX2xvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6MjM6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6NDg0OmluIGBleGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2NvbW1hbmQucmI6Mjc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9pbnZvY2F0aW9uLnJiOjEyNzppbiBgaW52b2tlX2NvbW1hbmQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IucmI6MzkyOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MzE6aW4gYGRpc3BhdGNoJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yL2Jhc2UucmI6NDg1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci9jbGkucmI6MjU6aW4gYHN0YXJ0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTo0ODppbiBgYmxvY2sgaW4gXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvZnJpZW5kbHlfZXJyb3JzLnJiOjEwMzppbiBgd2l0aF9mcmllbmRseV9lcnJvcnMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvZ2Vtcy9idW5kbGVyLTIuMy43L2xpYmV4ZWMvYnVuZGxlOjM2OmluIGBcdTAwM2N0b3AgKHJlcXVpcmVkKVx1MDAzZSciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgbG9hZCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvYmluL2J1bmRsZToyNTppbiBgXHUwMDNjbWFpblx1MDAzZSciCiAgICAgICAgXQogICAgICB9CiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6ODo3Ojc6M10iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIGFnZ3JlZ2F0ZWQgZmFpbGluZyB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyB3aXRoaW4gYSBjb250ZXh0IGhhcyBhZ2dyZWdhdGVkIGZhaWxpbmcgdGVzdHMiLAogICAgICAic3RhdHVzIjogImZhaWxlZCIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDM5LAogICAgICAicnVuX3RpbWUiOiAwLjAwMzE2NSwKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6IG51bGwsCiAgICAgICJleGNlcHRpb24iOiB7CiAgICAgICAgImNsYXNzIjogIlJTcGVjOjpFeHBlY3RhdGlvbnM6Ok11bHRpcGxlRXhwZWN0YXRpb25zTm90TWV0RXJyb3IiLAogICAgICAgICJtZXNzYWdlIjogIkdvdCAyIGZhaWx1cmVzIGZyb20gZmFpbHVyZSBhZ2dyZWdhdGlvbiBibG9jazpcblxuICAxKSBleHBlY3RlZDogMlxuICAgICAgICAgIGdvdDogMVxuXG4gICAgIChjb21wYXJlZCB1c2luZyA9PSlcblxuICAgICAuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjQwOmluIGBibG9jayAoMyBsZXZlbHMpIGluIFx1MDAzY21haW5cdTAwM2UnXG5cbiAgMikgZXhwZWN0ZWQ6IDNcbiAgICAgICAgICBnb3Q6IDJcblxuICAgICAoY29tcGFyZWQgdXNpbmcgPT0pXG5cbiAgICAgLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYjo0MTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBcdTAwM2NtYWluXHUwMDNlJyIsCiAgICAgICAgImJhY2t0cmFjZSI6IFsKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjEwMjppbiBgYmxvY2sgaW4gXHUwMDNjbW9kdWxlOlN1cHBvcnRcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLXN1cHBvcnQtYjhlMmQxMGIwZjlhL2xpYi9yc3BlYy9zdXBwb3J0LnJiOjExMTppbiBgbm90aWZ5X2ZhaWx1cmUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9mYWlsdXJlX2FnZ3JlZ2F0b3IucmI6ODU6aW4gYG5vdGlmeV9hZ2dyZWdhdGVkX2ZhaWx1cmVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1leHBlY3RhdGlvbnMtZDUwODEwMmQ3MmNiL2xpYi9yc3BlYy9leHBlY3RhdGlvbnMvZmFpbHVyZV9hZ2dyZWdhdG9yLnJiOjMxOmluIGBhZ2dyZWdhdGUnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy1kNTA4MTAyZDcyY2IvbGliL3JzcGVjL21hdGNoZXJzLnJiOjMwNjppbiBgYWdncmVnYXRlX2ZhaWx1cmVzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIyNTE6aW4gYGJsb2NrIGluIGRlZmluZV9idWlsdF9pbl9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo0NTc6aW4gYGluc3RhbmNlX2V4ZWMnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NDU3OmluIGBpbnN0YW5jZV9leGVjJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjozOTA6aW4gYGV4ZWN1dGVfd2l0aCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI4OmluIGBibG9jayAoMiBsZXZlbHMpIGluIHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MzUyOmluIGBjYWxsJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ob29rcy5yYjo2Mjk6aW4gYHJ1bl9hcm91bmRfZXhhbXBsZV9ob29rc19mb3InIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgcnVuJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjo1MTE6aW4gYHdpdGhfYXJvdW5kX2FuZF9zaW5nbGV0b25fY29udGV4dF9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNTk6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo3MDE6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2OTc6aW4gYHJ1bl9leGFtcGxlcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTE6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYGJsb2NrIGluIHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MTI6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDMgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxNzU6aW4gYG1hcCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3NTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL2NvbmZpZ3VyYXRpb24ucmI6MjA2ODppbiBgd2l0aF9zdWl0ZV9ob29rcyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjE3MDppbiBgYmxvY2sgaW4gcnVuX3NwZWNzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTY5OmluIGBydW5fc3BlY3MnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMDc6aW4gYHJ1biciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9idW5kbGVyL2dlbXMvcnNwZWMtY29yZS0yZjc1M2I1MjI4ODQvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjcxOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYnVuZGxlci9nZW1zL3JzcGVjLWNvcmUtMmY3NTNiNTIyODg0L2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2J1bmRsZXIvZ2Vtcy9yc3BlYy1jb3JlLTJmNzUzYjUyMjg4NC9leGUvcnNwZWM6NDppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5L2dlbXMvMy4xLjAvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2Jpbi9yc3BlYzoyNTppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpL2V4ZWMucmI6NTg6aW4gYGtlcm5lbF9sb2FkJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2NsaS9leGVjLnJiOjIzOmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjQ4NDppbiBgZXhlYyciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9jb21tYW5kLnJiOjI3OmluIGBydW4nIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvdmVuZG9yL3Rob3IvbGliL3Rob3IvaW52b2NhdGlvbi5yYjoxMjc6aW4gYGludm9rZV9jb21tYW5kJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL3ZlbmRvci90aG9yL2xpYi90aG9yLnJiOjM5MjppbiBgZGlzcGF0Y2gnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjMxOmluIGBkaXNwYXRjaCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvMy4xLjAvYnVuZGxlci92ZW5kb3IvdGhvci9saWIvdGhvci9iYXNlLnJiOjQ4NTppbiBgc3RhcnQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2xpYi9ydWJ5LzMuMS4wL2J1bmRsZXIvY2xpLnJiOjI1OmluIGBzdGFydCciLAogICAgICAgICAgIi9Vc2Vycy9reWxla3Rob21wc29uLy5hc2RmL2luc3RhbGxzL3J1YnkvMy4xLjIvbGliL3J1YnkvZ2Vtcy8zLjEuMC9nZW1zL2J1bmRsZXItMi4zLjcvbGliZXhlYy9idW5kbGU6NDg6aW4gYGJsb2NrIGluIFx1MDAzY3RvcCAocmVxdWlyZWQpXHUwMDNlJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS8zLjEuMC9idW5kbGVyL2ZyaWVuZGx5X2Vycm9ycy5yYjoxMDM6aW4gYHdpdGhfZnJpZW5kbHlfZXJyb3JzJyIsCiAgICAgICAgICAiL1VzZXJzL2t5bGVrdGhvbXBzb24vLmFzZGYvaW5zdGFsbHMvcnVieS8zLjEuMi9saWIvcnVieS9nZW1zLzMuMS4wL2dlbXMvYnVuZGxlci0yLjMuNy9saWJleGVjL2J1bmRsZTozNjppbiBgXHUwMDNjdG9wIChyZXF1aXJlZClcdTAwM2UnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYGxvYWQnIiwKICAgICAgICAgICIvVXNlcnMva3lsZWt0aG9tcHNvbi8uYXNkZi9pbnN0YWxscy9ydWJ5LzMuMS4yL2Jpbi9idW5kbGU6MjU6aW4gYFx1MDAzY21haW5cdTAwM2UnIgogICAgICAgIF0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6Nzo3OjRdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBza2lwcGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIHNraXBwZWQgdGVzdHMiLAogICAgICAic3RhdHVzIjogInBlbmRpbmciLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA0NCwKICAgICAgInJ1bl90aW1lIjogMy4wZS02LAogICAgICAicGVuZGluZ19tZXNzYWdlIjogIlRlbXBvcmFyaWx5IHNraXBwZWQgd2l0aCB4aXQiCiAgICB9LAogICAgewogICAgICAiaWQiOiAiLi9zcGVjL2V4YW1wbGVzL3N0cmluZ19zcGVjLnJiWzE6ODo3Ojc6NV0iLAogICAgICAiZGVzY3JpcHRpb24iOiAiaGFzIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgImZ1bGxfZGVzY3JpcHRpb24iOiAic29tZSBzdHJpbmcgd2l0aGluIGEgY29udGV4dCBiZWhhdmVzIGxpa2Ugc2hhcmVkIGV4YW1wbGVzIHdpdGhpbiBhIGNvbnRleHQgaGFzIHBhc3NpbmcgcGVuZGVkIHRlc3RzIiwKICAgICAgInN0YXR1cyI6ICJmYWlsZWQiLAogICAgICAiZmlsZV9wYXRoIjogIi4vc3BlYy9leGFtcGxlcy9zaGFyZWRfZXhhbXBsZXMucmIiLAogICAgICAibGluZV9udW1iZXIiOiA0OSwKICAgICAgInJ1bl90aW1lIjogMC4wMDIyMTIsCiAgICAgICJwZW5kaW5nX21lc3NhZ2UiOiAiZm9yIGEgcmVhc29uIiwKICAgICAgImV4Y2VwdGlvbiI6IHsKICAgICAgICAiY2xhc3MiOiAiUlNwZWM6OkNvcmU6OlBlbmRpbmc6OlBlbmRpbmdFeGFtcGxlRml4ZWRFcnJvciIsCiAgICAgICAgIm1lc3NhZ2UiOiAiRXhwZWN0ZWQgZXhhbXBsZSB0byBmYWlsIHNpbmNlIGl0IGlzIHBlbmRpbmcsIGJ1dCBpdCBwYXNzZWQuIiwKICAgICAgICAiYmFja3RyYWNlIjogWyIuL3NwZWMvZXhhbXBsZXMvc2hhcmVkX2V4YW1wbGVzLnJiOjQ5Il0KICAgICAgfQogICAgfSwKICAgIHsKICAgICAgImlkIjogIi4vc3BlYy9leGFtcGxlcy9zdHJpbmdfc3BlYy5yYlsxOjg6Nzo3OjZdIiwKICAgICAgImRlc2NyaXB0aW9uIjogImhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJmdWxsX2Rlc2NyaXB0aW9uIjogInNvbWUgc3RyaW5nIHdpdGhpbiBhIGNvbnRleHQgYmVoYXZlcyBsaWtlIHNoYXJlZCBleGFtcGxlcyB3aXRoaW4gYSBjb250ZXh0IGhhcyBmYWlsaW5nIHBlbmRlZCB0ZXN0cyIsCiAgICAgICJzdGF0dXMiOiAicGVuZGluZyIsCiAgICAgICJmaWxlX3BhdGgiOiAiLi9zcGVjL2V4YW1wbGVzL3NoYXJlZF9leGFtcGxlcy5yYiIsCiAgICAgICJsaW5lX251bWJlciI6IDU0LAogICAgICAicnVuX3RpbWUiOiAwLjAwMjI1NywKICAgICAgInBlbmRpbmdfbWVzc2FnZSI6ICJmb3IgYSByZWFzb24iCiAgICB9CiAgXSwKICAic3VtbWFyeSI6IHsKICAgICJkdXJhdGlvbiI6IDAuMTk2MywKICAgICJleGFtcGxlX2NvdW50IjogNzIsCiAgICAiZmFpbHVyZV9jb3VudCI6IDM2LAogICAgInBlbmRpbmdfY291bnQiOiAyNCwKICAgICJlcnJvcnNfb3V0c2lkZV9vZl9leGFtcGxlc19jb3VudCI6IDAKICB9LAogICJzdW1tYXJ5X2xpbmUiOiAiNzIgZXhhbXBsZXMsIDM2IGZhaWx1cmVzLCAyNCBwZW5kaW5nIgp9Cg==",
+      "groupNumber": 1
+    }
+  ]
+}

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bradleyjkemp/cupaloy"
 	"github.com/google/uuid"
 	"github.com/rwx-research/captain-cli"
 	"github.com/rwx-research/captain-cli/test/helpers"
@@ -1002,6 +1003,24 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 
 				Expect(result.exitCode).To(Equal(0))
 				Expect(fileContents).To(Equal("[]\n"))
+			})
+		})
+	})
+
+	withoutBackwardsCompatibility(func() {
+		// `captain parse results` is a hidden command and not part of our public interface, so we don't
+		// assure backwards compatibility
+		Describe("captain parse", func() {
+			Describe("results", func() {
+				It("produces RWX JSON with the parsers", func() {
+					result := runCaptain(captainArgs{
+						args: []string{"parse", "results", "fixtures/rspec.json"},
+						env:  make(map[string]string),
+					})
+
+					Expect(result.exitCode).To(Equal(0))
+					cupaloy.SnapshotT(GinkgoT(), result.stdout)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
We found that this was broken. We don't want to expose this publicly, nor to we want to provide backwards compatibility guarantees, but this at least puts a small test around it (and fixes it).

- Fix the captain parse command
- Test the parse results command without backwards compatibility guarantees
