### PR TITLE
Fix the assignment of the --framework and --language CLI flags

### DIFF
--- a/cmd/captain/framework_flags.go
+++ b/cmd/captain/framework_flags.go
@@ -44,12 +44,12 @@ func addFrameworkFlags(command *cobra.Command, frameworkParams *frameworkParams)
 
 func bindFrameworkFlags(cfg Config, frameworkParams frameworkParams, suiteID string) Config {
 	if suiteConfig, ok := cfg.TestSuites[suiteID]; ok {
-		if frameworkParams.language != "" {
+		if frameworkParams.kind != "" {
 			suiteConfig.Results.Framework = frameworkParams.kind
 		}
 
 		if frameworkParams.language != "" {
-			suiteConfig.Results.Language = frameworkParams.kind
+			suiteConfig.Results.Language = frameworkParams.language
 		}
 
 		cfg.TestSuites[suiteID] = suiteConfig

--- a/test/.snapshots/OSS mode Integration Tests captain run accepts the language and framework CLI flags and parses with their parser
+++ b/test/.snapshots/OSS mode Integration Tests captain run accepts the language and framework CLI flags and parses with their parser
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "Ruby",
+    "kind": "RSpec"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 1,
+    "otherErrors": 0,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 1,
+    "pended": 0,
+    "quarantined": 0,
+    "skipped": 0,
+    "successful": 0,
+    "timedOut": 0,
+    "todo": 0
+  },
+  "tests": [
+    {
+      "id": "./x.rb[1:1]",
+      "name": "is failing",
+      "lineage": [
+        "",
+        "is failing"
+      ],
+      "location": {
+        "file": "./x.rb"
+      },
+      "attempt": {
+        "durationInNanoseconds": 8077000,
+        "meta": {
+          "filePath": "./x.rb",
+          "lineNumber": 2
+        },
+        "status": {
+          "kind": "failed",
+          "message": "expected: \u003e= 2\n     got:    1",
+          "exception": "RSpec::Expectations::ExpectationNotMetError",
+          "backtrace": [
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-support-3.12.0/lib/rspec/support.rb:102:in `block in \u003cmodule:Support\u003e'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-support-3.12.0/lib/rspec/support.rb:111:in `notify_failure'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/handler.rb:40:in `handle_failure'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-expectations-3.12.0/lib/rspec/expectations/expectation_target.rb:101:in `to'",
+            "/Users/dan/code/captain-cli/x.rb:3:in `block (2 levels) in \u003ctop (required)\u003e'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:263:in `block in run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/hooks.rb:486:in `block in run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/hooks.rb:486:in `run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:468:in `with_around_example_hooks'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:259:in `run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example_group.rb:646:in `block in run_examples'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example_group.rb:642:in `map'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example_group.rb:642:in `run_examples'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example_group.rb:607:in `run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:121:in `map'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/configuration.rb:2070:in `with_suite_hooks'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:116:in `block in run_specs'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/reporter.rb:74:in `report'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:115:in `run_specs'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:89:in `run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:71:in `run'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/runner.rb:45:in `invoke'",
+            "/Users/dan/.local/share/gem/ruby/3.1.0/gems/rspec-core-3.12.0/exe/rspec:4:in `\u003ctop (required)\u003e'",
+            "/Users/dan/.rbenv/versions/3.1.2/bin/rspec:25:in `load'",
+            "/Users/dan/.rbenv/versions/3.1.2/bin/rspec:25:in `\u003cmain\u003e'"
+          ]
+        }
+      }
+    }
+  ],
+  "derivedFrom": [
+    {
+      "originalFilePath": "fixtures/integration-tests/rspec-failed-not-quarantined.json",
+      "contents": "eyJ2ZXJzaW9uIjoiMy4xMi4wIiwiZXhhbXBsZXMiOlt7ImlkIjoiLi94LnJiWzE6MV0iLCJkZXNjcmlwdGlvbiI6ImlzIGZhaWxpbmciLCJmdWxsX2Rlc2NyaXB0aW9uIjoiaXMgZmFpbGluZyIsInN0YXR1cyI6ImZhaWxlZCIsImZpbGVfcGF0aCI6Ii4veC5yYiIsImxpbmVfbnVtYmVyIjoyLCJydW5fdGltZSI6MC4wMDgwNzcsInBlbmRpbmdfbWVzc2FnZSI6bnVsbCwiZXhjZXB0aW9uIjp7ImNsYXNzIjoiUlNwZWM6OkV4cGVjdGF0aW9uczo6RXhwZWN0YXRpb25Ob3RNZXRFcnJvciIsIm1lc3NhZ2UiOiJleHBlY3RlZDogPj0gMlxuICAgICBnb3Q6ICAgIDEiLCJiYWNrdHJhY2UiOlsiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1zdXBwb3J0LTMuMTIuMC9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMDI6aW4gYGJsb2NrIGluIDxtb2R1bGU6U3VwcG9ydD4nIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1zdXBwb3J0LTMuMTIuMC9saWIvcnNwZWMvc3VwcG9ydC5yYjoxMTE6aW4gYG5vdGlmeV9mYWlsdXJlJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLTMuMTIuMC9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2ZhaWxfd2l0aC5yYjozNTppbiBgZmFpbF93aXRoJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLTMuMTIuMC9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NDA6aW4gYGhhbmRsZV9mYWlsdXJlJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLTMuMTIuMC9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6NTY6aW4gYGJsb2NrIGluIGhhbmRsZV9tYXRjaGVyJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLTMuMTIuMC9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2hhbmRsZXIucmI6Mjc6aW4gYHdpdGhfbWF0Y2hlciciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy0zLjEyLjAvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9oYW5kbGVyLnJiOjQ4OmluIGBoYW5kbGVfbWF0Y2hlciciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWV4cGVjdGF0aW9ucy0zLjEyLjAvbGliL3JzcGVjL2V4cGVjdGF0aW9ucy9leHBlY3RhdGlvbl90YXJnZXQucmI6NjU6aW4gYHRvJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtZXhwZWN0YXRpb25zLTMuMTIuMC9saWIvcnNwZWMvZXhwZWN0YXRpb25zL2V4cGVjdGF0aW9uX3RhcmdldC5yYjoxMDE6aW4gYHRvJyIsIi9Vc2Vycy9kYW4vY29kZS9jYXB0YWluLWNsaS94LnJiOjM6aW4gYGJsb2NrICgyIGxldmVscykgaW4gPHRvcCAocmVxdWlyZWQpPiciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6MjYzOmluIGBpbnN0YW5jZV9leGVjJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvZXhhbXBsZS5yYjoyNjM6aW4gYGJsb2NrIGluIHJ1biciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGBibG9jayBpbiB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgYmxvY2sgaW4gd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL2hvb2tzLnJiOjQ4NjppbiBgYmxvY2sgaW4gcnVuJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NjI0OmluIGBydW5fYXJvdW5kX2V4YW1wbGVfaG9va3NfZm9yJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvaG9va3MucmI6NDg2OmluIGBydW4nIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjQ2ODppbiBgd2l0aF9hcm91bmRfZXhhbXBsZV9ob29rcyciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL2V4YW1wbGUucmI6NTExOmluIGB3aXRoX2Fyb3VuZF9hbmRfc2luZ2xldG9uX2NvbnRleHRfaG9va3MnIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9leGFtcGxlLnJiOjI1OTppbiBgcnVuJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2NDY6aW4gYGJsb2NrIGluIHJ1bl9leGFtcGxlcyciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL2V4YW1wbGVfZ3JvdXAucmI6NjQyOmluIGBtYXAnIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9leGFtcGxlX2dyb3VwLnJiOjY0MjppbiBgcnVuX2V4YW1wbGVzJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvZXhhbXBsZV9ncm91cC5yYjo2MDc6aW4gYHJ1biciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjoxMjE6aW4gYGJsb2NrICgzIGxldmVscykgaW4gcnVuX3NwZWNzJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEyMTppbiBgbWFwJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjEyMTppbiBgYmxvY2sgKDIgbGV2ZWxzKSBpbiBydW5fc3BlY3MnIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9jb25maWd1cmF0aW9uLnJiOjIwNzA6aW4gYHdpdGhfc3VpdGVfaG9va3MnIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6MTE2OmluIGBibG9jayBpbiBydW5fc3BlY3MnIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9yZXBvcnRlci5yYjo3NDppbiBgcmVwb3J0JyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjExNTppbiBgcnVuX3NwZWNzJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvbGliL3JzcGVjL2NvcmUvcnVubmVyLnJiOjg5OmluIGBydW4nIiwiL1VzZXJzL2Rhbi8ubG9jYWwvc2hhcmUvZ2VtL3J1YnkvMy4xLjAvZ2Vtcy9yc3BlYy1jb3JlLTMuMTIuMC9saWIvcnNwZWMvY29yZS9ydW5uZXIucmI6NzE6aW4gYHJ1biciLCIvVXNlcnMvZGFuLy5sb2NhbC9zaGFyZS9nZW0vcnVieS8zLjEuMC9nZW1zL3JzcGVjLWNvcmUtMy4xMi4wL2xpYi9yc3BlYy9jb3JlL3J1bm5lci5yYjo0NTppbiBgaW52b2tlJyIsIi9Vc2Vycy9kYW4vLmxvY2FsL3NoYXJlL2dlbS9ydWJ5LzMuMS4wL2dlbXMvcnNwZWMtY29yZS0zLjEyLjAvZXhlL3JzcGVjOjQ6aW4gYDx0b3AgKHJlcXVpcmVkKT4nIiwiL1VzZXJzL2Rhbi8ucmJlbnYvdmVyc2lvbnMvMy4xLjIvYmluL3JzcGVjOjI1OmluIGBsb2FkJyIsIi9Vc2Vycy9kYW4vLnJiZW52L3ZlcnNpb25zLzMuMS4yL2Jpbi9yc3BlYzoyNTppbiBgPG1haW4+JyJdfX1dLCJzdW1tYXJ5Ijp7ImR1cmF0aW9uIjowLjAwOTA3NSwiZXhhbXBsZV9jb3VudCI6MSwiZmFpbHVyZV9jb3VudCI6MSwicGVuZGluZ19jb3VudCI6MCwiZXJyb3JzX291dHNpZGVfb2ZfZXhhbXBsZXNfY291bnQiOjB9LCJzdW1tYXJ5X2xpbmUiOiIxIGV4YW1wbGUsIDEgZmFpbHVyZSJ9Cg==",
+      "groupNumber": 1
+    }
+  ]
+}
+

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -561,7 +561,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 			})
 		})
 
-		It("accepts the language and framework flags CLI flags and parses with their parser", func() {
+		It("accepts the language and framework CLI flags and parses with their parser", func() {
 			tmp, err := os.MkdirTemp("", "*")
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
While working on #47 I happened to stumble on this broken behavior.

# Before

```
$ ./captain parse results --language baz --framework bar  ./test/fixtures/junit.xml | jq '.framework'
{
  "language": "other",
  "kind": "other",
  "providedLanguage": "bar",
  "providedKind": "bar"
}

$ ./captain parse results --language Ruby --framework RSpec  ./test/fixtures/rspec.json
Error: Unable to parse "./test/fixtures/rspec.json" with the available parsers
```

# After

```
$ ./captain parse results --language baz --framework bar  ./test/fixtures/junit.xml | jq '.framework'
{
  "language": "other",
  "kind": "other",
  "providedLanguage": "baz",
  "providedKind": "bar"
}

$ ./captain parse results --language Ruby --framework RSpec  ./test/fixtures/rspec.json | jq '.framework'
{
  "language": "Ruby",
  "kind": "RSpec"
}
```