### PR TITLE
Ensure ability to run w/out partition when partition configured

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -137,8 +137,7 @@ func (rc RunConfig) MaxTestsToRetryPercentage() (*float64, error) {
 
 func (rc RunConfig) IsRunningPartition() bool {
 	// TODO: Should we have a bit somewhere that indicates provider defaulted?
-	return rc.PartitionCommandTemplate != "" &&
-		(rc.PartitionConfig.PartitionNodes.Index != -1 || rc.PartitionConfig.PartitionNodes.Total != -1)
+	return rc.PartitionCommandTemplate != "" && rc.PartitionConfig.PartitionNodes.Total >= 1
 }
 
 type PartitionConfig struct {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -90,11 +90,7 @@ func Merge(into Provider, from Provider) Provider {
 		into.CommitMessage = firstNonempty(from.CommitMessage, into.CommitMessage)
 		into.Title = firstNonempty(from.Title, into.Title)
 
-		intoPartitionImplicitlyUnset := into.PartitionNodes == config.PartitionNodes{}
-		intoPartitionExplicitlyUnset := into.PartitionNodes.Index < 0 || into.PartitionNodes.Total < 0
-		fromPartitionExplicitlySet := from.PartitionNodes.Index >= 0 && from.PartitionNodes.Total >= 1
-
-		if fromPartitionExplicitlySet && (intoPartitionExplicitlyUnset || intoPartitionImplicitlyUnset) {
+		if into.PartitionNodes.Total <= 0 && from.PartitionNodes.Total >= 1 {
 			into.PartitionNodes = from.PartitionNodes
 		}
 

--- a/test/oss_integration_test.go
+++ b/test/oss_integration_test.go
@@ -779,6 +779,22 @@ var _ = Describe(versionedPrefixForQuarantining()+"OSS mode Integration Tests", 
 				Expect(result.exitCode).To(Equal(0))
 			})
 		})
+
+		Context("when partitioning is configured but flags aren't provided", func() {
+			It("runs the default run command", func() {
+				result := runCaptain(captainArgs{
+					args: []string{
+						"run",
+						"oss-run-with-partition",
+						"--config-file", "fixtures/integration-tests/partition-config.yaml",
+					},
+					env: make(map[string]string),
+				})
+
+				Expect(result.exitCode).To(Equal(123))
+				Expect(result.stdout).To(Equal("default run"))
+			})
+		})
 	})
 
 	Describe("captain run w/ partition", func() {


### PR DESCRIPTION
## Desired State

We should be able to run the same suite using either the partition command or the default run command. This determination is made by whether or we've detected the command is intending to partition or not.

## Bug Details

This was [previously accounted for](https://github.com/rwx-research/captain/pull/43) by checking to see if the partition index and total were set to a value not equal to -1.

This was sufficient until [a patch was introduced](https://github.com/rwx-research/captain/pull/46) to fix how CAPTAIN_PARTITION_* env variables were threaded into the partition config.

That patch fixed the issue where the environment variables weren't getting picked up, however, made the approach of determining whether or not the command was running with partition insufficient. As a result, suite's configured with partitioning lost the ability to run without partitioning.

## Approach

This PR simplifies the determination of whether or not you are partitioning to "is there a sensible partition total provided? (i.e >= 1)".

This handles both possible scenarios where the partition config is defaulted to -1 or not set at all (which would end up a struct with a golang "zero values").

## Regression

In addition, an integration test is added to ensure that a test suite with partitioning configured can in fact run without partitioning.

I also updated the config unit tests for determining whether you are partitioning to use scenarios that are more realistic -- and added validation tests ensuring the scenarios that don't make sense are configuration errors.