### PR TITLE
Protect against misconfiguration

### DIFF
--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -133,7 +133,9 @@ func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 				return cfg, errors.Wrap(err, fmt.Sprintf("unable to open config file %q", cliArgs.RootCliArgs.configFilePath))
 			}
 		} else {
-			if err = yaml.NewDecoder(fd).Decode(&cfg.ConfigFile); err != nil {
+			decoder := yaml.NewDecoder(fd)
+			decoder.KnownFields(true)
+			if err = decoder.Decode(&cfg.ConfigFile); err != nil {
 				return cfg, errors.Wrap(err, "unable to parse config file")
 			}
 		}

--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/caarlos0/env/v7"
 	"github.com/spf13/cobra"
@@ -136,6 +137,16 @@ func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 			decoder := yaml.NewDecoder(fd)
 			decoder.KnownFields(true)
 			if err = decoder.Decode(&cfg.ConfigFile); err != nil {
+				typeError := new(yaml.TypeError)
+				if errors.As(err, &typeError) {
+					err = errors.NewConfigurationError(
+						"Parsing Error",
+						strings.Join(typeError.Errors, "\n"),
+						"Please refer to the documentation at https://www.rwx.com/docs/captain/cli-configuration/config-yaml for the"+
+							" correct config file syntax.",
+					)
+				}
+
 				return cfg, errors.Wrap(err, "unable to parse config file")
 			}
 		}

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -249,7 +249,7 @@ func AddFlags(runCmd *cobra.Command, cliArgs *CliArgs) error {
 		false,
 		"if set, your test suite will fail as quickly as we know it will fail (e.g. with --retries 1 and "+
 			"--flaky-retries 5, you might have a non-flaky test that we stop retrying after 1 additional attempt. "+
-			"in this situation, we know the tests overall will fail so we can stop retrying to save compute. similarly "+
+			"In this situation, we know the tests overall will fail so we can stop retrying to save compute. Similarly "+
 			"if you only set --flaky-retries 1, we can stop retrying if any non-flaky tests fail because we won't retry "+
 			"them)",
 	)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -74,9 +74,8 @@ func (rc RunConfig) Validate(log *zap.SugaredLogger) error {
 		log.Warn("The --max-tests-to-retry flag has no effect as no retries are otherwise configured.")
 	}
 
-	if rc.PartitionCommandTemplate != "" && rc.PartitionConfig.PartitionNodes.Total <= 0 {
-		log.Warnf("There is a partition command configured for this test suite, however the partition total is set to 0.")
-		log.Warnf("Partitioning is disabled.")
+	if rc.PartitionCommandTemplate != "" && rc.PartitionConfig.PartitionNodes.Total <= 1 {
+		log.Warnf("There is a partition command configured for this test suite, but partitioning is disabled.")
 	}
 
 	if rc.IsRunningPartition() {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,6 +1,8 @@
 package cli_test
 
 import (
+	"go.uber.org/zap/zaptest"
+
 	"github.com/rwx-research/captain-cli/internal/cli"
 	"github.com/rwx-research/captain-cli/internal/config"
 
@@ -9,94 +11,96 @@ import (
 )
 
 var _ = Describe("RunConfig", func() {
+	logger := zaptest.NewLogger(GinkgoT()).Sugar()
+
 	Describe("Validate", func() {
 		It("errs when max-tests-to-retry is neither an integer nor float percentage", func() {
 			var err error
 
-			err = cli.RunConfig{MaxTestsToRetry: "1.5"}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: "1.5"}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unsupported --max-tests-to-retry value"))
 
-			err = cli.RunConfig{MaxTestsToRetry: "something"}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: "something"}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unsupported --max-tests-to-retry value"))
 
-			err = cli.RunConfig{MaxTestsToRetry: "something%"}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: "something%"}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unsupported --max-tests-to-retry value"))
 
-			err = cli.RunConfig{MaxTestsToRetry: " 1 "}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: " 1 "}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = cli.RunConfig{MaxTestsToRetry: " 1.5% "}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: " 1.5% "}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = cli.RunConfig{MaxTestsToRetry: " 1% "}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: " 1% "}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = cli.RunConfig{MaxTestsToRetry: ""}.Validate()
+			err = cli.RunConfig{MaxTestsToRetry: ""}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("errs when retries are positive and the retry command is missing", func() {
-			err := cli.RunConfig{Retries: 1, RetryCommandTemplate: ""}.Validate()
+			err := cli.RunConfig{Retries: 1, RetryCommandTemplate: ""}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Missing retry command"))
 		})
 
 		It("errs when flaky-retries are positive and the retry command is missing", func() {
-			err := cli.RunConfig{FlakyRetries: 1, RetryCommandTemplate: ""}.Validate()
+			err := cli.RunConfig{FlakyRetries: 1, RetryCommandTemplate: ""}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Missing retry command"))
 		})
 
 		It("is valid when retries are positive and the retry command is present", func() {
-			err := cli.RunConfig{Retries: 1, RetryCommandTemplate: "some-command"}.Validate()
+			err := cli.RunConfig{Retries: 1, RetryCommandTemplate: "some-command"}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when flaky-retries are positive and the retry command is present", func() {
-			err := cli.RunConfig{FlakyRetries: 1, RetryCommandTemplate: "some-command"}.Validate()
+			err := cli.RunConfig{FlakyRetries: 1, RetryCommandTemplate: "some-command"}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when retries are 0 and the retry command is missing", func() {
-			err := cli.RunConfig{Retries: 0, RetryCommandTemplate: ""}.Validate()
+			err := cli.RunConfig{Retries: 0, RetryCommandTemplate: ""}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when flaky-retries are 0 and the retry command is missing", func() {
-			err := cli.RunConfig{FlakyRetries: 0, RetryCommandTemplate: ""}.Validate()
+			err := cli.RunConfig{FlakyRetries: 0, RetryCommandTemplate: ""}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when retries are 0 and the retry command is present", func() {
-			err := cli.RunConfig{Retries: 0, RetryCommandTemplate: "some-command"}.Validate()
+			err := cli.RunConfig{Retries: 0, RetryCommandTemplate: "some-command"}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when flaky-retries are 0 and the retry command is present", func() {
-			err := cli.RunConfig{FlakyRetries: 0, RetryCommandTemplate: "some-command"}.Validate()
+			err := cli.RunConfig{FlakyRetries: 0, RetryCommandTemplate: "some-command"}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when retries are negative and the retry command is missing", func() {
-			err := cli.RunConfig{Retries: -1, RetryCommandTemplate: ""}.Validate()
+			err := cli.RunConfig{Retries: -1, RetryCommandTemplate: ""}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when flaky-retries are negative and the retry command is missing", func() {
-			err := cli.RunConfig{FlakyRetries: -1, RetryCommandTemplate: ""}.Validate()
+			err := cli.RunConfig{FlakyRetries: -1, RetryCommandTemplate: ""}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when retries are negative and the retry command is present", func() {
-			err := cli.RunConfig{Retries: -1, RetryCommandTemplate: "some-command"}.Validate()
+			err := cli.RunConfig{Retries: -1, RetryCommandTemplate: "some-command"}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("is valid when flaky-retries are negative and the retry command is present", func() {
-			err := cli.RunConfig{FlakyRetries: -1, RetryCommandTemplate: "some-command"}.Validate()
+			err := cli.RunConfig{FlakyRetries: -1, RetryCommandTemplate: "some-command"}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -109,7 +113,7 @@ var _ = Describe("RunConfig", func() {
 						Total: 1,
 					},
 				},
-			}.Validate()
+			}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Missing suite ID"))
 		})
@@ -124,7 +128,7 @@ var _ = Describe("RunConfig", func() {
 						Total: 1,
 					},
 				},
-			}.Validate()
+			}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Missing test file paths"))
 		})
@@ -139,7 +143,7 @@ var _ = Describe("RunConfig", func() {
 						Total: 1,
 					},
 				},
-			}.Validate()
+			}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unsupported partitioning setup"))
 		})
@@ -154,7 +158,7 @@ var _ = Describe("RunConfig", func() {
 						Total: 1,
 					},
 				},
-			}.Validate()
+			}.Validate(logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Missing partition index"))
 		})
@@ -169,7 +173,7 @@ var _ = Describe("RunConfig", func() {
 						Total: -1,
 					},
 				},
-			}.Validate()
+			}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -184,7 +188,7 @@ var _ = Describe("RunConfig", func() {
 					},
 					TestFilePaths: []string{"spec/**/*_spec.rb"},
 				},
-			}.Validate()
+			}.Validate(logger)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -24,7 +24,7 @@ import (
 
 // RunSuite runs the specified build- or test-suite and optionally uploads the resulting test results file.
 func (s Service) RunSuite(ctx context.Context, cfg RunConfig) (finalErr error) {
-	err := cfg.Validate()
+	err := cfg.Validate(s.Log)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Changes in this PR:

* Captain will return an error in case there are unknown fields in the YAML (**potentially breaking**)
* Captain will print a warning if
  - there is a retry command, but total retries are set to 0.
  - the --max-tests-to-retry option is configured, but there are no retries.
  - there is a partitioning command, but the total partition count is set to 0 or 1. 
  - no parser could be found using the provided framework & language values.
  
 Some caveats:
 
 * If the YAML parsing fails due to an unknown field, it will reference the name of the Go struct in its error message: `line 11: field retries not found in type cli.ConfigFile`. I think having the line number & field name in the error message is important, so I would not omit this. We _could_ try to filter this string, but that seems buggy / unstable. Unfortunately I'm not aware of any method to control the error message further (other than forking / modifying the yaml library itself)
 * If multiple flags are provided for a single value, only the last one will be used. For example ` ./captain run --suite-id="test" --command "echo one" --command "echo two"` will output `two`. It looks like this was a design decision in `spf13/cobra`. To protect against that, we'd need to rewrite every flag to accept an array of values and then manually ensure / check the length of each flag-array. I don't think this is worth the effort at the moment. (this issue only exists for the flags, not the config file fyi)
 