### PR TITLE
Adds file and line to the JUnit output

### DIFF
--- a/internal/reporting/junit.go
+++ b/internal/reporting/junit.go
@@ -42,6 +42,16 @@ func WriteJUnitSummary(file fs.File, testResults v1.TestResults, _ Configuration
 			finishedAt = *test.Attempt.FinishedAt
 		}
 
+		if test.Location != nil {
+			if test.Location.File != "" {
+				testCase.File = &test.Location.File
+			}
+
+			if test.Location.Line != nil {
+				testCase.Line = test.Location.Line
+			}
+		}
+
 		//nolint:exhaustive
 		switch test.Attempt.Status.Kind {
 		case v1.TestStatusPended, v1.TestStatusSkipped, v1.TestStatusTodo:

--- a/internal/reporting/junit_test.go
+++ b/internal/reporting/junit_test.go
@@ -49,6 +49,10 @@ var _ = Describe("JUnit Report", func() {
 						Duration: nil,
 						Status:   v1.TestStatus{Kind: "successful"},
 					},
+					Location: &v1.Location{
+						File: "/path/to/file",
+						Line: new(int),
+					},
 				},
 			},
 		}
@@ -67,5 +71,7 @@ var _ = Describe("JUnit Report", func() {
 
 		Expect(result.TestSuites[0].TestCases).To(HaveLen(1))
 		Expect(result.TestSuites[0].TestCases[0].Name).To(Equal("name of the test"))
+		Expect(*result.TestSuites[0].TestCases[0].File).To(Equal("/path/to/file"))
+		Expect(*result.TestSuites[0].TestCases[0].Line).To(Equal(0))
 	})
 })


### PR DESCRIPTION
Some tools rely on the file and line properties to, e.g., annotate code in a pull request. We already have this data in some cases so we might as well add it.

I tested this locally with ABQ + RSpec and it worked.