### PR TITLE
fix: escape the .net filter subsitution for shells

### DIFF
--- a/internal/targetedretries/dot_net_xunit_substitution.go
+++ b/internal/targetedretries/dot_net_xunit_substitution.go
@@ -2,6 +2,7 @@ package targetedretries
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/rwx-research/captain-cli/internal/errors"
@@ -39,6 +40,13 @@ func (s DotNetxUnitSubstitution) ValidateTemplate(compiledTemplate templating.Co
 	return nil
 }
 
+// https://github.com/microsoft/vstest/blob/main/docs/filter.md
+var testFilterSpecialCharacters = regexp.MustCompile("[()\\\\&|=!~]")
+
+func escapeTestFilterCharacter(value string) string {
+	return fmt.Sprintf("\\%v", value)
+}
+
 func (s DotNetxUnitSubstitution) SubstitutionsFor(
 	_ templating.CompiledTemplate,
 	testResults v1.TestResults,
@@ -57,7 +65,11 @@ func (s DotNetxUnitSubstitution) SubstitutionsFor(
 
 		testType := test.Attempt.Meta["type"].(*string)
 		testMethod := test.Attempt.Meta["method"].(*string)
-		formattedTest := fmt.Sprintf("FullyQualifiedName=%v.%v", *testType, *testMethod)
+		fullyQualifiedName := testFilterSpecialCharacters.ReplaceAllStringFunc(
+			fmt.Sprintf("%v.%v", *testType, *testMethod),
+			escapeTestFilterCharacter,
+		)
+		formattedTest := templating.ShellEscape(fmt.Sprintf("FullyQualifiedName=%v", fullyQualifiedName))
 		if _, ok := testsSeen[formattedTest]; ok {
 			continue
 		}

--- a/internal/targetedretries/dot_net_xunit_substitution.go
+++ b/internal/targetedretries/dot_net_xunit_substitution.go
@@ -44,7 +44,7 @@ func (s DotNetxUnitSubstitution) ValidateTemplate(compiledTemplate templating.Co
 var testFilterSpecialCharacters = regexp.MustCompile(`[()\\&|=!~]`)
 
 func escapeTestFilterCharacter(value string) string {
-	return fmt.Sprintf("\\%v", value)
+	return fmt.Sprintf(`\%v`, value)
 }
 
 func (s DotNetxUnitSubstitution) SubstitutionsFor(

--- a/internal/targetedretries/dot_net_xunit_substitution.go
+++ b/internal/targetedretries/dot_net_xunit_substitution.go
@@ -41,7 +41,7 @@ func (s DotNetxUnitSubstitution) ValidateTemplate(compiledTemplate templating.Co
 }
 
 // https://github.com/microsoft/vstest/blob/main/docs/filter.md
-var testFilterSpecialCharacters = regexp.MustCompile("[()\\\\&|=!~]")
+var testFilterSpecialCharacters = regexp.MustCompile(`[()\\&|=!~]`)
 
 func escapeTestFilterCharacter(value string) string {
 	return fmt.Sprintf("\\%v", value)

--- a/internal/targetedretries/dot_net_xunit_substitution_test.go
+++ b/internal/targetedretries/dot_net_xunit_substitution_test.go
@@ -253,5 +253,46 @@ var _ = Describe("DotNetxUnitSubstitution", func() {
 				},
 			))
 		})
+
+		It("correctly escapes the filter substitution", func() {
+			compiledTemplate, compileErr := templating.CompileTemplate("dotnet test --filter '{{ filter }}'")
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			type1 := "type1"
+			method1 := "method1(val1: 100, val2: \"test\")"
+			type2 := "type2"
+			method2 := "!method2=|&\\"
+			testResults := v1.TestResults{
+				Tests: []v1.Test{
+					{
+						Attempt: v1.TestAttempt{
+							Meta:   map[string]any{"type": &type1, "method": &method1},
+							Status: v1.NewFailedTestStatus(nil, nil, nil),
+						},
+					},
+					{
+						Attempt: v1.TestAttempt{
+							Meta:   map[string]any{"type": &type2, "method": &method2},
+							Status: v1.NewFailedTestStatus(nil, nil, nil),
+						},
+					},
+				},
+			}
+
+			substitution := targetedretries.DotNetxUnitSubstitution{}
+			substitutions, err := substitution.SubstitutionsFor(
+				compiledTemplate,
+				testResults,
+				func(test v1.Test) bool { return test.Attempt.Status.Kind == v1.TestStatusFailed },
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(substitutions).To(Equal(
+				[]map[string]string{
+					{
+						"filter": "FullyQualifiedName=type1.method1\\(val1: 100, val2: \"test\"\\) | FullyQualifiedName=type2.\\!method2\\=\\|\\&\\\\",
+					},
+				},
+			))
+		})
 	})
 })

--- a/internal/targetedretries/dot_net_xunit_substitution_test.go
+++ b/internal/targetedretries/dot_net_xunit_substitution_test.go
@@ -289,7 +289,8 @@ var _ = Describe("DotNetxUnitSubstitution", func() {
 			Expect(substitutions).To(Equal(
 				[]map[string]string{
 					{
-						"filter": "FullyQualifiedName=type1.method1\\(val1: 100, val2: \"test\"\\) | FullyQualifiedName=type2.\\!method2\\=\\|\\&\\\\",
+						"filter": "FullyQualifiedName=type1.method1\\(val1: 100, val2: \"test\"\\) | " +
+							"FullyQualifiedName=type2.\\!method2\\=\\|\\&\\\\",
 					},
 				},
 			))

--- a/internal/targetedretries/dot_net_xunit_substitution_test.go
+++ b/internal/targetedretries/dot_net_xunit_substitution_test.go
@@ -259,9 +259,9 @@ var _ = Describe("DotNetxUnitSubstitution", func() {
 			Expect(compileErr).NotTo(HaveOccurred())
 
 			type1 := "type1"
-			method1 := "method1(val1: 100, val2: \"test\")"
+			method1 := `method1(val1: 100, val2: "test")`
 			type2 := "type2"
-			method2 := "!method2=|&\\"
+			method2 := `!method2=|&\`
 			testResults := v1.TestResults{
 				Tests: []v1.Test{
 					{
@@ -289,8 +289,8 @@ var _ = Describe("DotNetxUnitSubstitution", func() {
 			Expect(substitutions).To(Equal(
 				[]map[string]string{
 					{
-						"filter": "FullyQualifiedName=type1.method1\\(val1: 100, val2: \"test\"\\) | " +
-							"FullyQualifiedName=type2.\\!method2\\=\\|\\&\\\\",
+						"filter": `FullyQualifiedName=type1.method1\(val1: 100, val2: "test"\) | ` +
+							`FullyQualifiedName=type2.\!method2\=\|\&\\`,
 					},
 				},
 			))


### PR DESCRIPTION
copy of #54 

The filter substition is directly embedded into the command, which means
that `"` quotes will behave according to the shell. Resulting in
something along the lines of:

```sh
dotnet test --filter "FullyQualifiedName=Foo.Bar(val: "Hello World")"
```

The shell will interpret this and pass an invalid string to dotnet test,
resulting in the following error:

> 2023-08-01T20:20:59.7326742Z [xUnit.net 00:00:00.24] Cmg.DataLabGateway
> .IntegrationTests: Exception filtering tests: Incorrect format for
> TestCaseFilter Missing Operator '|' or '&'. Specify the correct format and
> try again. Note that the incorrect format can lead to no test getting
> executed.

This change will simply replace all occurrences of `"` with `\"`, which
should be interpreted by the shell correctly.
