### PR TITLE
Respect CAPTAIN_{BUILD_URL,TITLE,COMMIT_MESSAGE} variables in run

### DIFF
--- a/cmd/captain/config_test.go
+++ b/cmd/captain/config_test.go
@@ -146,4 +146,32 @@ var _ = Describe("InitConfig", func() {
 			Expect(cfg.ProvidersEnv.GitLab.APIV4URL).To(Equal("https://gitlab.com/api/v4"))
 		})
 	})
+
+	Context("with Captain environment variables", func() {
+		BeforeEach(func() {
+			helpers.SetEnv(map[string]string{
+				"CAPTAIN_WHO":            "tester",
+				"CAPTAIN_SHA":            "1fc108cab0bb46083c6cdd50f8cd1deb5005e235",
+				"CAPTAIN_BRANCH":         "main",
+				"CAPTAIN_BUILD_URL":      "https://example.com/build/1",
+				"CAPTAIN_TITLE":          "Captain Test",
+				"CAPTAIN_COMMIT_MESSAGE": "print env",
+			})
+		})
+
+		It("parses the Captain variables", func() {
+			err := captain.AddFlags(cmd, &cliArgs)
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg, err := captain.InitConfig(cmd, cliArgs)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(cfg.ProvidersEnv.Generic.Who).To(Equal("tester"))
+			Expect(cfg.ProvidersEnv.Generic.Sha).To(Equal("1fc108cab0bb46083c6cdd50f8cd1deb5005e235"))
+			Expect(cfg.ProvidersEnv.Generic.Branch).To(Equal("main"))
+			Expect(cfg.ProvidersEnv.Generic.BuildURL).To(Equal("https://example.com/build/1"))
+			Expect(cfg.ProvidersEnv.Generic.Title).To(Equal("Captain Test"))
+			Expect(cfg.ProvidersEnv.Generic.CommitMessage).To(Equal("print env"))
+		})
+	})
 })

--- a/internal/providers/generic_provider.go
+++ b/internal/providers/generic_provider.go
@@ -38,5 +38,8 @@ func MergeGeneric(into GenericEnv, from GenericEnv) GenericEnv {
 	into.Who = firstNonempty(from.Who, into.Who)
 	into.Branch = firstNonempty(from.Branch, into.Branch)
 	into.Sha = firstNonempty(from.Sha, into.Sha)
+	into.CommitMessage = firstNonempty(from.CommitMessage, into.CommitMessage)
+	into.BuildURL = firstNonempty(from.BuildURL, into.BuildURL)
+	into.Title = firstNonempty(from.Title, into.Title)
 	return into
 }

--- a/internal/providers/generic_provider_test.go
+++ b/internal/providers/generic_provider_test.go
@@ -21,3 +21,35 @@ var _ = Describe("GenericEnv.MakeProvider", func() {
 		Expect(provider.JobTags).To(Equal(map[string]any{"captain_build_url": "https://jenkins.example.com/job/test/123/"}))
 	})
 })
+
+var _ = Describe("MergeGeneric", func() {
+	It("merges Who", func() {
+		Expect(providers.MergeGeneric(providers.GenericEnv{Who: "p1"}, providers.GenericEnv{Who: "p2"}).Who).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Who: "p1"}, providers.GenericEnv{}).Who).To(Equal("p1"))
+	})
+
+	It("merges Branch", func() {
+		Expect(providers.MergeGeneric(providers.GenericEnv{Branch: "p1"}, providers.GenericEnv{Branch: "p2"}).Branch).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Branch: "p1"}, providers.GenericEnv{}).Branch).To(Equal("p1"))
+	})
+
+	It("merges Sha", func() {
+		Expect(providers.MergeGeneric(providers.GenericEnv{Sha: "p1"}, providers.GenericEnv{Sha: "p2"}).Sha).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Sha: "p1"}, providers.GenericEnv{}).Sha).To(Equal("p1"))
+	})
+
+	It("merges CommitMessage", func() {
+		Expect(providers.MergeGeneric(providers.GenericEnv{CommitMessage: "p1"}, providers.GenericEnv{CommitMessage: "p2"}).CommitMessage).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{CommitMessage: "p1"}, providers.GenericEnv{}).CommitMessage).To(Equal("p1"))
+	})
+
+	It("merges BuildURL", func() {
+		Expect(providers.MergeGeneric(providers.GenericEnv{BuildURL: "p1"}, providers.GenericEnv{BuildURL: "p2"}).BuildURL).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{BuildURL: "p1"}, providers.GenericEnv{}).BuildURL).To(Equal("p1"))
+	})
+
+	It("merges Title", func() {
+		Expect(providers.MergeGeneric(providers.GenericEnv{Title: "p1"}, providers.GenericEnv{Title: "p2"}).Title).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Title: "p1"}, providers.GenericEnv{}).Title).To(Equal("p1"))
+	})
+})

--- a/internal/providers/generic_provider_test.go
+++ b/internal/providers/generic_provider_test.go
@@ -24,32 +24,44 @@ var _ = Describe("GenericEnv.MakeProvider", func() {
 
 var _ = Describe("MergeGeneric", func() {
 	It("merges Who", func() {
-		Expect(providers.MergeGeneric(providers.GenericEnv{Who: "p1"}, providers.GenericEnv{Who: "p2"}).Who).To(Equal("p2"))
-		Expect(providers.MergeGeneric(providers.GenericEnv{Who: "p1"}, providers.GenericEnv{}).Who).To(Equal("p1"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Who: "p1"},
+			providers.GenericEnv{Who: "p2"}).Who).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Who: "p1"},
+			providers.GenericEnv{}).Who).To(Equal("p1"))
 	})
 
 	It("merges Branch", func() {
-		Expect(providers.MergeGeneric(providers.GenericEnv{Branch: "p1"}, providers.GenericEnv{Branch: "p2"}).Branch).To(Equal("p2"))
-		Expect(providers.MergeGeneric(providers.GenericEnv{Branch: "p1"}, providers.GenericEnv{}).Branch).To(Equal("p1"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Branch: "p1"},
+			providers.GenericEnv{Branch: "p2"}).Branch).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Branch: "p1"},
+			providers.GenericEnv{}).Branch).To(Equal("p1"))
 	})
 
 	It("merges Sha", func() {
-		Expect(providers.MergeGeneric(providers.GenericEnv{Sha: "p1"}, providers.GenericEnv{Sha: "p2"}).Sha).To(Equal("p2"))
-		Expect(providers.MergeGeneric(providers.GenericEnv{Sha: "p1"}, providers.GenericEnv{}).Sha).To(Equal("p1"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Sha: "p1"},
+			providers.GenericEnv{Sha: "p2"}).Sha).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Sha: "p1"},
+			providers.GenericEnv{}).Sha).To(Equal("p1"))
 	})
 
 	It("merges CommitMessage", func() {
-		Expect(providers.MergeGeneric(providers.GenericEnv{CommitMessage: "p1"}, providers.GenericEnv{CommitMessage: "p2"}).CommitMessage).To(Equal("p2"))
-		Expect(providers.MergeGeneric(providers.GenericEnv{CommitMessage: "p1"}, providers.GenericEnv{}).CommitMessage).To(Equal("p1"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{CommitMessage: "p1"},
+			providers.GenericEnv{CommitMessage: "p2"}).CommitMessage).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{CommitMessage: "p1"},
+			providers.GenericEnv{}).CommitMessage).To(Equal("p1"))
 	})
 
 	It("merges BuildURL", func() {
-		Expect(providers.MergeGeneric(providers.GenericEnv{BuildURL: "p1"}, providers.GenericEnv{BuildURL: "p2"}).BuildURL).To(Equal("p2"))
-		Expect(providers.MergeGeneric(providers.GenericEnv{BuildURL: "p1"}, providers.GenericEnv{}).BuildURL).To(Equal("p1"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{BuildURL: "p1"},
+			providers.GenericEnv{BuildURL: "p2"}).BuildURL).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{BuildURL: "p1"},
+			providers.GenericEnv{}).BuildURL).To(Equal("p1"))
 	})
 
 	It("merges Title", func() {
-		Expect(providers.MergeGeneric(providers.GenericEnv{Title: "p1"}, providers.GenericEnv{Title: "p2"}).Title).To(Equal("p2"))
-		Expect(providers.MergeGeneric(providers.GenericEnv{Title: "p1"}, providers.GenericEnv{}).Title).To(Equal("p1"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Title: "p1"},
+			providers.GenericEnv{Title: "p2"}).Title).To(Equal("p2"))
+		Expect(providers.MergeGeneric(providers.GenericEnv{Title: "p1"},
+			providers.GenericEnv{}).Title).To(Equal("p1"))
 	})
 })

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -37,6 +37,12 @@ func SetEnvFromFile(fileName string) {
 	}
 }
 
+func SetEnv(env map[string]string) {
+	for name, value := range env {
+		os.Setenv(name, value)
+	}
+}
+
 func UnsetCIEnv() {
 	envPrefixes := []string{"GITHUB", "BUILDKITE", "CIRCLE", "GITLAB", "CI", "RWX", "CAPTAIN"}
 	for _, env := range os.Environ() {


### PR DESCRIPTION
Prior to this commit, `captain run` would parse the `CAPTAIN_BUILD_URL`, `CAPTAIN_TITLE`, and `CAPTAIN_COMMIT_MESSAGE` environment variables into its arguments, but those arguments would not be merged into the GenericProvider environment provided to Captain Cloud during test results updates. This diff resolves those issues.

Internal: see
https://captain.build/rwx/test_suite_summaries/84885e32-e61c-41dd-86c9-c014264b113c as an example of a manually-executed `captain run` that picks up these variables. The invocation was

```
$ cd $MINT_REPO

$ CAPTAIN_TITLE=test123 CAPTAIN_COMMIT_MESSAGE=test123message CAPTAIN_WHO=ayazhafiz CAPTAIN_BRANCH=ayaz/test-captain-env CAPTAIN_SHA=0a4e30a8bd572351d8a44cf6ece49ff4eb5d7fd9 RWX_ACCESS_TOKEN=$(cat /tmp/access-token) $(echo $CAPTAIN_REPO)/captain --debug run mint-test packages/server/database.test.ts
```

Reviewers: is there an existing integration test suite to which I should add a test covering this issue? I could not find one.