### PR TITLE
Add fileAttachments to test attempt meta for Playwright.

### DIFF
--- a/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file
@@ -467,6 +467,12 @@
           "durationInNanoseconds": 711000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-failing-test-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -534,6 +540,12 @@
           "durationInNanoseconds": 622000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-throw-error-test-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -593,6 +605,12 @@
           "durationInNanoseconds": 618000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-throw-string-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -715,6 +733,12 @@
                 "type": "fail"
               }
             ],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-passing-w-fail-annotation-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -774,6 +798,12 @@
           "durationInNanoseconds": 138000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-fails-then-passes-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -833,6 +863,12 @@
           "durationInNanoseconds": 1000000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-times-out-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -1004,6 +1040,12 @@
           "durationInNanoseconds": 1077000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-failing-test-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -1071,6 +1113,12 @@
           "durationInNanoseconds": 873000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-throw-error-test-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -1130,6 +1178,12 @@
           "durationInNanoseconds": 1089000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-throw-string-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -1252,6 +1306,12 @@
                 "type": "fail"
               }
             ],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-passing-w-fail-annotation-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -1311,6 +1371,12 @@
           "durationInNanoseconds": 568000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-fails-then-passes-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -1370,6 +1436,12 @@
           "durationInNanoseconds": 1000000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/example-times-out-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -1647,6 +1719,12 @@
           "durationInNanoseconds": 519000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-failing-test-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -1773,6 +1851,12 @@
                 "type": "fail"
               }
             ],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-passing-w-fail-annotation-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -1832,6 +1916,12 @@
           "durationInNanoseconds": 163000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-fails-then-passes-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -1891,6 +1981,12 @@
           "durationInNanoseconds": 999000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-times-out-chromium-retry1/trace.zip"
+              }
+            ],
             "project": "chromium",
             "tags": []
           },
@@ -2062,6 +2158,12 @@
           "durationInNanoseconds": 878000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-failing-test-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -2188,6 +2290,12 @@
                 "type": "fail"
               }
             ],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-passing-w-fail-annotation-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -2247,6 +2355,12 @@
           "durationInNanoseconds": 459000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-fails-then-passes-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },
@@ -2306,6 +2420,12 @@
           "durationInNanoseconds": 1000000000,
           "meta": {
             "annotations": [],
+            "fileAttachments": [
+              {
+                "name": "trace",
+                "path": "/Users/kylekthompson/src/captain-examples/playwright/test-results/nested-example-times-out-firefox-retry1/trace.zip"
+              }
+            ],
             "project": "firefox",
             "tags": []
           },


### PR DESCRIPTION
When trace files are available in Playwright output, add them to the output.