### PR TITLE
Run Build & Test CI weekly to avoid test file timings race.

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,59 @@
+name: Build & Test
+on:
+  # This schedule ensures we keep test file timings available to avoid a race
+  # condition between this these tests and the background processing job in cloud.
+  schedule:
+    - cron: "35 2 * * 2" # At 02:35 every Tuesday
+  workflow_call:
+    inputs:
+      legacy_version:
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            keep-derivations = true
+            keep-outputs = true
+      - name: build captain
+        run: |
+          CGO_ENABLED=0 \
+            LDFLAGS="-w -s -X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
+            nix develop --command mage
+
+      - name: run tests against current version
+        if: ${{ inputs.legacy_version == '' }}
+        run: |
+          CGO_ENABLED=0 \
+            LDFLAGS="-X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
+            ./captain run captain-cli-ginkgo
+        env:
+          RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+          RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
+          DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+          REPORT: true
+
+      - name: checkout old version
+        if: ${{ inputs.legacy_version != '' }}
+        run: |
+          git fetch --tags
+          git checkout ${{ inputs.legacy_version }} -- ./test
+      - name: run integration tests from ${{ inputs.legacy_version }}
+        if: ${{ inputs.legacy_version != '' }}
+        run: |
+          CGO_ENABLED=0 \
+            LDFLAGS="-X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
+            ./captain run captain-cli-backwards-compatibility
+        env:
+          RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+          RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
+          DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+          REPORT: true
+          LEGACY_VERSION_TO_TEST: ${{ inputs.legacy_version }}

--- a/.github/workflows/buildkite_agent.yaml
+++ b/.github/workflows/buildkite_agent.yaml
@@ -9,7 +9,7 @@ jobs:
       BUILDKITE_AGENT_TOKEN: ${{ secrets.BUILDKITE_AGENT_TOKEN }}
       BUILDKITE_SSH_KEY: ${{ secrets.BUILDKITE_SSH_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -5,27 +5,8 @@ on:
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
-        with:
-          extra_nix_config: |
-            keep-derivations = true
-            keep-outputs = true
-      - run: |
-          CGO_ENABLED=0 \
-            LDFLAGS="-w -s -X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
-            nix develop --command mage
-      - run: |
-          CGO_ENABLED=0 \
-            LDFLAGS="-X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
-            ./captain run captain-cli-ginkgo
-        env:
-          RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
-          RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
-          DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
-          REPORT: true
+    uses: ./.github/workflows/build_and_test.yaml
+    secrets: inherit
 
   unstable-release:
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -90,35 +71,10 @@ jobs:
     name: Backwards compatibility tests
     needs: which-versions-to-test
     if: ${{ needs.which-versions-to-test.outputs.versions != '[]' }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         legacy_version: ${{ fromJSON(needs.which-versions-to-test.outputs.versions) }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
-        with:
-          extra_nix_config: |
-            keep-derivations = true
-            keep-outputs = true
-
-      - name: build captain
-        run: |
-          CGO_ENABLED=0 \
-            LDFLAGS="-w -s -X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
-            nix develop --command mage
-      - name: checkout old version
-        run: |
-          git fetch --tags
-          git checkout ${{ matrix.legacy_version }} -- ./test
-      - name: run integration tests from ${{ matrix.legacy_version }}
-        run: |
-          CGO_ENABLED=0 \
-            LDFLAGS="-X github.com/rwx-research/captain-cli.Version=testing-$(git rev-parse HEAD)" \
-            ./captain run captain-cli-backwards-compatibility
-        env:
-          RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
-          RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
-          DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
-          REPORT: true
-          LEGACY_VERSION_TO_TEST: ${{ matrix.legacy_version }}
+    uses: ./.github/workflows/build_and_test.yaml
+    with:
+      legacy_version: ${{ matrix.legacy_version }}
+    secrets: inherit

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |
@@ -41,7 +41,7 @@ jobs:
     name: go mod tidy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |
@@ -56,7 +56,7 @@ jobs:
     outputs:
       versions: ${{ steps.output-tags.outputs.versions }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
       - name: Ensure this release has not been published
@@ -142,7 +142,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.extract-version-details.outputs.full-version }}
       - uses: cachix/install-nix-action@v18
@@ -204,7 +204,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.extract-version-details.outputs.full-version }}
       - name: Publish the full version release
@@ -246,12 +246,12 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::152560469324:role/captain-cli-cd
           role-duration-seconds: 900
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.extract-version-details.outputs.full-version }}
       - name: Download the binaries


### PR DESCRIPTION
When the tests don't run for a while, Cloud won't have the test file timings that integration tests rely on. The first run will fail as it relies on the manifest that Cloud now has, but has not yet processed into timings.

By running this weekly, Cloud will always have a fresh-enough timing to work with, and these tests should be stable and not require manual intervention (deleting manifests).