### PR TITLE
Replace captain.build messaging w/ cloud.rwx.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://www.rwx.com/captain.svg" height="60" alt="captain">
 
-:globe_with_meridians: [captain.build](https://captain.build) &ensp;
+:globe_with_meridians: [website](https://rwx.com/captain) &ensp;
 :bird: [@rwx_research](https://twitter.com/rwx_research) &ensp;
 :speech_balloon: [discord](https://discord.gg/h4ha5Cue7j) &ensp;
 :books: [documentation](https://www.rwx.com/docs/captain)

--- a/cmd/captain/main.go
+++ b/cmd/captain/main.go
@@ -16,7 +16,7 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use: "captain",
 		Long: "Captain provides client-side utilities related to build- and test-suites. This CLI is a complementary " +
-			"component to the main WebUI at https://captain.build.",
+			"component to the main WebUI at https://cloud.rwx.com/captain",
 
 		Version: captainCLI.Version,
 	}

--- a/internal/backend/remote/config.go
+++ b/internal/backend/remote/config.go
@@ -30,7 +30,7 @@ func (cfg ClientConfig) Validate() error {
 			"Missing API token",
 			"In order to use the CLI in conjunction with Captain Cloud, please supply an API token.",
 			"The token can be set by using the RWX_ACCESS_TOKEN environment variable. If you don't have a token yet "+
-				"you can create one under \"Organization Settings\" at https://account.rwx.com/.",
+				"you can create one under \"Organization Settings\" at https://cloud.rwx.com/.",
 		)
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -42,7 +42,7 @@ func (s Service) AddFlake(_ context.Context, args []string) error {
 			"'captain add flake' only works in OSS mode",
 			"You are trying to register a new flake in Captain, however it appears that you are using "+
 				"Captain Cloud.",
-			"Please visit https://captain.build/ to configure your flakes or quarantines.",
+			"Please visit https://cloud.rwx.com/captain to configure your flakes or quarantines.",
 		)
 	}
 
@@ -58,7 +58,7 @@ func (s Service) AddQuarantine(_ context.Context, args []string) error {
 			"'captain add quarantine' only works in OSS mode",
 			"You are trying to quarantine a new test in Captain, however it appears that you are using "+
 				"Captain Cloud.",
-			"Please visit https://captain.build/ to configure your flakes or quarantines.",
+			"Please visit https://cloud.rwx.com/captain to configure your flakes or quarantines.",
 		)
 	}
 
@@ -74,7 +74,7 @@ func (s Service) RemoveFlake(_ context.Context, args []string) error {
 			"'captain remove flake' only works in OSS mode",
 			"You are trying to remove a flake in Captain, however it appears that you are using "+
 				"Captain Cloud.",
-			"Please visit https://captain.build/ to configure your flakes or quarantines.",
+			"Please visit https://cloud.rwx.com/captain to configure your flakes or quarantines.",
 		)
 	}
 
@@ -95,7 +95,7 @@ func (s Service) RemoveQuarantine(_ context.Context, args []string) error {
 			"'captain remove quarantine' only works in OSS mode",
 			"You are trying to remove a quarantine in Captain, however it appears that you are using "+
 				"Captain Cloud.",
-			"Please visit https://captain.build/ to configure your flakes or quarantines.",
+			"Please visit https://cloud.rwx.com/captain to configure your flakes or quarantines.",
 		)
 	}
 


### PR DESCRIPTION
~Waiting to merge this until after cut-over~.

Non-functional change. Updating error messages to point folks to cloud.rwx.com/captain and cloud.rwx.com instead of captain.build.