### PR TITLE
Update captain to use cloud host

### DIFF
--- a/internal/backend/remote/client.go
+++ b/internal/backend/remote/client.go
@@ -83,7 +83,7 @@ func (c Client) GetTestTimingManifest(
 	ctx context.Context,
 	testSuiteIdentifier string,
 ) ([]testing.TestFileTiming, error) {
-	endpoint := "/api/test_suites/timing_manifest"
+	endpoint := "/captain/api/test_suites/timing_manifest"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -177,7 +177,7 @@ func (c Client) GetRunConfiguration(
 	ctx context.Context,
 	testSuiteIdentifier string,
 ) (backend.RunConfiguration, error) {
-	endpoint := "/api/test_suites/run_configuration"
+	endpoint := "/captain/api/test_suites/run_configuration"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/internal/backend/remote/client.go
+++ b/internal/backend/remote/client.go
@@ -83,7 +83,7 @@ func (c Client) GetTestTimingManifest(
 	ctx context.Context,
 	testSuiteIdentifier string,
 ) ([]testing.TestFileTiming, error) {
-	endpoint := "/captain/api/test_suites/timing_manifest"
+	endpoint := hostEndpointCompat(c, "/api/test_suites/timing_manifest")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -177,7 +177,7 @@ func (c Client) GetRunConfiguration(
 	ctx context.Context,
 	testSuiteIdentifier string,
 ) (backend.RunConfiguration, error) {
-	endpoint := "/captain/api/test_suites/run_configuration"
+	endpoint := hostEndpointCompat(c, "/api/test_suites/run_configuration")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -213,4 +213,14 @@ func (c Client) GetRunConfiguration(
 	}
 
 	return runConfiguration, nil
+}
+
+// TODO(TS): Remove this once we're no longer testing against versions that use captain.build
+func hostEndpointCompat(c Client, endpoint string) string {
+	remoteHost := c.ClientConfig.Host
+
+	if !strings.Contains(remoteHost, "cloud") {
+		return endpoint
+	}
+	return "/captain" + endpoint
 }

--- a/internal/backend/remote/defaults.go
+++ b/internal/backend/remote/defaults.go
@@ -3,7 +3,7 @@ package remote
 import "regexp"
 
 const (
-	defaultHost = "captain.build"
+	defaultHost = "cloud.rwx.com"
 
 	contentTypeJSON   = "application/json"
 	headerContentType = "Content-Type"

--- a/internal/backend/remote/get_test_timing_manifest_test.go
+++ b/internal/backend/remote/get_test_timing_manifest_test.go
@@ -1,0 +1,88 @@
+package remote_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/rwx-research/captain-cli/internal/backend/remote"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetTestTimingManifest", func() {
+	var (
+		apiClient        remote.Client
+		mockRoundTripper func(*http.Request) (*http.Response, error)
+		host             string
+	)
+
+	JustBeforeEach(func() {
+		apiClientConfig := remote.ClientConfig{Log: zap.NewNop().Sugar(), Host: host}
+		apiClient = remote.Client{ClientConfig: apiClientConfig, RoundTrip: mockRoundTripper}
+	})
+
+	Context("when the response is successful against captain.build", func() {
+		BeforeEach(func() {
+			host = "captain.build"
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/timing_manifest"))
+				Expect(req.URL.Query().Has("test_suite_identifier")).To(BeTrue())
+				Expect(req.URL.Query().Has("commit_sha")).To(BeTrue())
+
+				resp.Body = io.NopCloser(strings.NewReader(`
+					{
+						"file_timings": [
+							{ "file_path": "some-file", "duration": 200 }
+						]
+					}
+				`))
+				resp.StatusCode = 200
+				return &resp, nil
+			}
+		})
+
+		It("returns the test file timing", func() {
+			testFileTiming, err := apiClient.GetTestTimingManifest(context.Background(), "test-suite-id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFileTiming).To(HaveLen(1))
+		})
+	})
+
+	Context("when the response is successful", func() {
+		BeforeEach(func() {
+			host = "cloud.rwx.com"
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.URL.Path).To(HaveSuffix("/captain/api/test_suites/timing_manifest"))
+				Expect(req.URL.Query().Has("test_suite_identifier")).To(BeTrue())
+				Expect(req.URL.Query().Has("commit_sha")).To(BeTrue())
+
+				resp.Body = io.NopCloser(strings.NewReader(`
+					{
+						"file_timings": [
+							{ "file_path": "some-file", "duration": 200 }
+						]
+					}
+				`))
+				resp.StatusCode = 200
+				return &resp, nil
+			}
+		})
+
+		It("returns the test file timing", func() {
+			testFileTiming, err := apiClient.GetTestTimingManifest(context.Background(), "test-suite-id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testFileTiming).To(HaveLen(1))
+		})
+	})
+})

--- a/internal/backend/remote/update_test_results.go
+++ b/internal/backend/remote/update_test_results.go
@@ -20,7 +20,7 @@ func (c Client) registerTestResults(
 	testSuite string,
 	testResultsFiles []TestResultsFile,
 ) ([]TestResultsFile, error) {
-	endpoint := "/captain/api/test_suites/bulk_test_results"
+	endpoint := hostEndpointCompat(c, "/api/test_suites/bulk_test_results")
 
 	reqBody := struct {
 		AttemptedBy         string            `json:"attempted_by"`
@@ -105,7 +105,7 @@ func (c Client) updateTestResultsStatuses(
 	testSuite string,
 	testResultsFiles []TestResultsFile,
 ) error {
-	endpoint := "/captain/api/test_suites/bulk_test_results"
+	endpoint := hostEndpointCompat(c, "/api/test_suites/bulk_test_results")
 
 	type uploadStatus struct {
 		CaptainID string `json:"id"`

--- a/internal/backend/remote/update_test_results.go
+++ b/internal/backend/remote/update_test_results.go
@@ -20,7 +20,7 @@ func (c Client) registerTestResults(
 	testSuite string,
 	testResultsFiles []TestResultsFile,
 ) ([]TestResultsFile, error) {
-	endpoint := "/api/test_suites/bulk_test_results"
+	endpoint := "/captain/api/test_suites/bulk_test_results"
 
 	reqBody := struct {
 		AttemptedBy         string            `json:"attempted_by"`
@@ -105,7 +105,7 @@ func (c Client) updateTestResultsStatuses(
 	testSuite string,
 	testResultsFiles []TestResultsFile,
 ) error {
-	endpoint := "/api/test_suites/bulk_test_results"
+	endpoint := "/captain/api/test_suites/bulk_test_results"
 
 	type uploadStatus struct {
 		CaptainID string `json:"id"`

--- a/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
+++ b/internal/reporting/.snapshots/Markdown Report produces a readable summary when cloud is enabled
@@ -1,6 +1,6 @@
 # `some-suite-id` Summary
 
-[🔗 View in Captain Cloud](https://example.com/deep_link/test_suite_summaries/some-suite-id/some/branch/abcdef113131)
+[🔗 View in Captain Cloud](https://example.com/captain/deep_link/test_suite_summaries/some-suite-id/some/branch/abcdef113131)
 
 9 tests, 1 flaky, 3 failed, 1 timed out, 1 quarantined, 1 canceled, 1 skipped, 2 retries
 

--- a/internal/reporting/markdown.go
+++ b/internal/reporting/markdown.go
@@ -71,7 +71,7 @@ func WriteMarkdownSummary(file fs.File, testResults v1.TestResults, cfg Configur
 	if cfg.CloudEnabled {
 		if _, err := markdown.WriteString(
 			fmt.Sprintf(
-				"[🔗 View in Captain Cloud](https://%v/deep_link/test_suite_summaries/%v/%v/%v)\n\n",
+				"[🔗 View in Captain Cloud](https://%v/captain/deep_link/test_suite_summaries/%v/%v/%v)\n\n",
 				cfg.CloudHost,
 				cfg.SuiteID,
 				cfg.Provider.BranchName,

--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -19,7 +19,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 	withAndWithoutInheritedEnv(func(getEnv envGenerator, prefix string) {
 		getEnvWithAccessToken := func() map[string]string {
 			env := getEnv()
-			env["CAPTAIN_HOST"] = "staging.captain.build"
+			env["CAPTAIN_HOST"] = "staging.cloud.rwx.com"
 			env["RWX_ACCESS_TOKEN"] = os.Getenv("RWX_ACCESS_TOKEN_STAGING")
 			return env
 		}


### PR DESCRIPTION
Prior to merge, I need to make some changes to the web acl to accompany these changes.

Converting `captain.build/api` to `cloud.rwx.com/captain/api`

* Adds coverage to ensure api endpoints behave as expected when using either captain.build or any rwx cloud.
* Adds missing GetTestTimingManifest client spec