### PR TITLE
Add a cucumber-js parser

### DIFF
--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -30,7 +30,6 @@ var mutuallyExclusiveParsers []parsing.Parser = []parsing.Parser{
 	new(parsing.JavaScriptMochaParser),
 	new(parsing.JavaScriptPlaywrightParser),
 	new(parsing.PythonPytestParser),
-	new(parsing.RubyCucumberParser),
 	new(parsing.RubyRSpecParser),
 }
 
@@ -39,6 +38,7 @@ var frameworkParsers map[v1.Framework][]parsing.Parser = map[v1.Framework][]pars
 	v1.ElixirExUnitFramework:         {new(parsing.ElixirExUnitParser)},
 	v1.GoGinkgoFramework:             {new(parsing.GoGinkgoParser)},
 	v1.GoTestFramework:               {new(parsing.GoTestParser)},
+	v1.JavaScriptCucumberFramework:   {new(parsing.JavaScriptCucumberJSONParser)},
 	v1.JavaScriptCypressFramework:    {new(parsing.JavaScriptCypressParser)},
 	v1.JavaScriptJestFramework:       {new(parsing.JavaScriptJestParser)},
 	v1.JavaScriptKarmaFramework:      {new(parsing.JavaScriptKarmaParser)},

--- a/internal/parsing/.snapshots/JavaScriptCucumberJSONParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptCucumberJSONParser Parse parses the sample file
@@ -1,0 +1,652 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "JavaScript",
+    "kind": "Cucumber"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 18,
+    "otherErrors": 2,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 1,
+    "pended": 1,
+    "quarantined": 0,
+    "skipped": 4,
+    "successful": 8,
+    "timedOut": 0,
+    "todo": 4
+  },
+  "tests": [
+    {
+      "name": "Rule Sample \u003e A passing example \u003e this will pass",
+      "lineage": [
+        "Rule Sample",
+        "A passing example",
+        "this will pass"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 10
+      },
+      "attempt": {
+        "durationInNanoseconds": 142791,
+        "meta": {
+          "elementStart": "features/rule.feature:7",
+          "stepLocation": "features/support/steps.js:4",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A passing example \u003e I do an action",
+      "lineage": [
+        "Rule Sample",
+        "A passing example",
+        "I do an action"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 10
+      },
+      "attempt": {
+        "durationInNanoseconds": 16584,
+        "meta": {
+          "elementStart": "features/rule.feature:7",
+          "stepLocation": "features/support/steps.js:12",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A passing example \u003e some results should be there",
+      "lineage": [
+        "Rule Sample",
+        "A passing example",
+        "some results should be there"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 10
+      },
+      "attempt": {
+        "durationInNanoseconds": 20582,
+        "meta": {
+          "elementStart": "features/rule.feature:7",
+          "stepLocation": "features/support/steps.js:14",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A failing example \u003e this will fail",
+      "lineage": [
+        "Rule Sample",
+        "A failing example",
+        "this will fail"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 17
+      },
+      "attempt": {
+        "durationInNanoseconds": 28541,
+        "meta": {
+          "elementStart": "features/rule.feature:14",
+          "stepLocation": "features/support/steps.js:8",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            },
+            {
+              "name": "@flaky",
+              "line": 12
+            },
+            {
+              "name": "@failing",
+              "line": 13
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A failing example \u003e I do an action",
+      "lineage": [
+        "Rule Sample",
+        "A failing example",
+        "I do an action"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 17
+      },
+      "attempt": {
+        "durationInNanoseconds": 12542,
+        "meta": {
+          "elementStart": "features/rule.feature:14",
+          "stepLocation": "features/support/steps.js:12",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            },
+            {
+              "name": "@flaky",
+              "line": 12
+            },
+            {
+              "name": "@failing",
+              "line": 13
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A failing example \u003e some results should be there",
+      "lineage": [
+        "Rule Sample",
+        "A failing example",
+        "some results should be there"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 17
+      },
+      "attempt": {
+        "durationInNanoseconds": 67957,
+        "meta": {
+          "elementStart": "features/rule.feature:14",
+          "stepLocation": "features/support/steps.js:14",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            },
+            {
+              "name": "@flaky",
+              "line": 12
+            },
+            {
+              "name": "@failing",
+              "line": 13
+            }
+          ]
+        },
+        "status": {
+          "kind": "failed",
+          "message": "AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert(this.this_will_pass === true)\n\n    + expected - actual\n\n    -false\n    +true\n\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:15:3)"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A pending example \u003e this is pending",
+      "lineage": [
+        "Rule Sample",
+        "A pending example",
+        "this is pending"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 22
+      },
+      "attempt": {
+        "durationInNanoseconds": 22791,
+        "meta": {
+          "elementStart": "features/rule.feature:19",
+          "stepLocation": "features/support/steps.js:18",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "pended"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A pending example \u003e I do an action",
+      "lineage": [
+        "Rule Sample",
+        "A pending example",
+        "I do an action"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 22
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:19",
+          "stepLocation": "features/support/steps.js:12",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A pending example \u003e nothing should happen",
+      "lineage": [
+        "Rule Sample",
+        "A pending example",
+        "nothing should happen"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 22
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:19",
+          "stepLocation": "",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "todo"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A skipped example \u003e this is skipped",
+      "lineage": [
+        "Rule Sample",
+        "A skipped example",
+        "this is skipped"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 27
+      },
+      "attempt": {
+        "durationInNanoseconds": 91374,
+        "meta": {
+          "elementStart": "features/rule.feature:24",
+          "stepLocation": "features/support/steps.js:22",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A skipped example \u003e I do an action",
+      "lineage": [
+        "Rule Sample",
+        "A skipped example",
+        "I do an action"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 27
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:24",
+          "stepLocation": "features/support/steps.js:12",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e A skipped example \u003e nothing should happen",
+      "lineage": [
+        "Rule Sample",
+        "A skipped example",
+        "nothing should happen"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 27
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:24",
+          "stepLocation": "",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "todo"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e An undefined example \u003e this is undefined",
+      "lineage": [
+        "Rule Sample",
+        "An undefined example",
+        "this is undefined"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 32
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:29",
+          "stepLocation": "",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "todo"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e An undefined example \u003e I do an action",
+      "lineage": [
+        "Rule Sample",
+        "An undefined example",
+        "I do an action"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 32
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:29",
+          "stepLocation": "features/support/steps.js:12",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e An undefined example \u003e nothing should happen",
+      "lineage": [
+        "Rule Sample",
+        "An undefined example",
+        "nothing should happen"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 32
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "elementStart": "features/rule.feature:29",
+          "stepLocation": "",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            }
+          ]
+        },
+        "status": {
+          "kind": "todo"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e With a failing after hook \u003e this will pass",
+      "lineage": [
+        "Rule Sample",
+        "With a failing after hook",
+        "this will pass"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 0
+      },
+      "attempt": {
+        "durationInNanoseconds": 87083,
+        "meta": {
+          "elementStart": "features/rule.feature:41",
+          "stepLocation": "features/support/steps.js:4",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            },
+            {
+              "name": "@failing_after_hook",
+              "line": 40
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e With a failing after hook \u003e I do an action",
+      "lineage": [
+        "Rule Sample",
+        "With a failing after hook",
+        "I do an action"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 0
+      },
+      "attempt": {
+        "durationInNanoseconds": 9459,
+        "meta": {
+          "elementStart": "features/rule.feature:41",
+          "stepLocation": "features/support/steps.js:12",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            },
+            {
+              "name": "@failing_after_hook",
+              "line": 40
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Rule Sample \u003e With a failing after hook \u003e some results should be there",
+      "lineage": [
+        "Rule Sample",
+        "With a failing after hook",
+        "some results should be there"
+      ],
+      "location": {
+        "file": "features/rule.feature",
+        "line": 0
+      },
+      "attempt": {
+        "durationInNanoseconds": 6999,
+        "meta": {
+          "elementStart": "features/rule.feature:41",
+          "stepLocation": "features/support/steps.js:14",
+          "tags": [
+            {
+              "name": "@feature_tag",
+              "line": 1
+            },
+            {
+              "name": "@rule_tag",
+              "line": null
+            },
+            {
+              "name": "@failing_after_hook",
+              "line": 40
+            }
+          ]
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    }
+  ],
+  "otherErrors": [
+    {
+      "message": "Error: failed in before hook\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:27:9)",
+      "meta": {
+        "type": "Before"
+      }
+    },
+    {
+      "message": "Error: failed in after hook\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:31:9)",
+      "meta": {
+        "type": "After"
+      }
+    }
+  ]
+}

--- a/internal/parsing/javascript_cucumber_json_parser.go
+++ b/internal/parsing/javascript_cucumber_json_parser.go
@@ -1,0 +1,167 @@
+package parsing
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rwx-research/captain-cli/internal/errors"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+)
+
+type JavaScriptCucumberJSONParser struct{}
+
+type JavaScriptCucumberJSONFeature struct {
+	URI         string `json:"uri"`
+	ID          string `json:"id"`
+	Keyword     string `json:"keyword"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Line        int    `json:"line"`
+	Tags        []struct {
+		Name string `json:"name"`
+		Line *int   `json:"line"`
+	} `json:"tags"`
+	Elements []struct {
+		ID          string `json:"id"`
+		Keyword     string `json:"keyword"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Line        int    `json:"line"`
+		Steps       []struct {
+			Arguments []struct{} `json:"arguments"`
+			Keyword   string     `json:"keyword"`
+			Line      int        `json:"line"`
+			Name      string     `json:"name"`
+			Match     struct {
+				Location string `json:"location"`
+			} `json:"match"`
+			Result *struct {
+				Status       string `json:"status"`
+				Duration     *int   `json:"duration"`
+				ErrorMessage string `json:"error_message"`
+			} `json:"result"`
+		} `json:"steps"`
+		Tags []struct {
+			Name string `json:"name"`
+			Line *int   `json:"line"`
+		} `json:"tags"`
+		Type string `json:"type"`
+	} `json:"elements"`
+}
+
+func (p JavaScriptCucumberJSONParser) Parse(data io.Reader) (*v1.TestResults, error) {
+	var cucumberFeatures []JavaScriptCucumberJSONFeature
+
+	if err := json.NewDecoder(data).Decode(&cucumberFeatures); err != nil {
+		return nil, errors.NewInputError("Unable to parse test results as JSON: %s", err)
+	}
+	if len(cucumberFeatures) == 0 {
+		return nil, errors.NewInputError("No test results were found in the JSON")
+	}
+
+	// at least one feature has an element
+	foundOneStepResult := false
+outer:
+	for _, feature := range cucumberFeatures {
+		// Check if the element is divisible by 2
+		for _, element := range feature.Elements {
+			for _, step := range element.Steps {
+				if step.Result != nil {
+					foundOneStepResult = true
+					break outer
+				}
+			}
+		}
+	}
+
+	if !foundOneStepResult {
+		return nil, errors.NewInputError("Found features, but no steps in the JSON")
+	}
+
+	tests := make([]v1.Test, 0)
+	otherErrors := make([]v1.OtherError, 0)
+
+	for _, feature := range cucumberFeatures {
+		for _, element := range feature.Elements {
+			for _, step := range element.Steps {
+				if step.Result == nil {
+					break // we can't do anything without a result
+				}
+
+				if step.Keyword == "Before" || step.Keyword == "After" {
+					// treat hooks as other errors
+					if step.Result.Status != "failed" {
+						break
+					}
+
+					otherErrors = append(otherErrors, v1.OtherError{
+						Message: step.Result.ErrorMessage,
+						Meta: map[string]any{
+							"type": step.Keyword,
+						},
+					})
+					break
+				}
+
+				location := v1.Location{File: feature.URI, Line: &step.Line}
+
+				var duration *time.Duration
+				if step.Result.Duration != nil {
+					transformedDuration := time.Duration(*step.Result.Duration * int(time.Nanosecond))
+					duration = &transformedDuration
+				}
+
+				var status v1.TestStatus
+				switch step.Result.Status {
+				case "passed":
+					status = v1.NewSuccessfulTestStatus()
+				case "failed":
+					status = v1.NewFailedTestStatus(&step.Result.ErrorMessage, nil, nil)
+				case "undefined":
+					status = v1.NewTodoTestStatus(nil)
+				case "skipped":
+					status = v1.NewSkippedTestStatus(nil)
+				case "pending":
+					status = v1.NewPendedTestStatus(nil)
+				default:
+					return nil, errors.NewInputError(
+						"Unexpected status %q for cucumber step %v",
+						step.Result.Status,
+						step,
+					)
+				}
+
+				attempt := v1.TestAttempt{
+					Duration: duration,
+					Status:   status,
+					Meta: map[string]any{
+						"tags":         element.Tags,
+						"stepLocation": step.Match.Location,
+						"elementStart": feature.URI + ":" + strconv.Itoa(element.Line),
+					},
+				}
+
+				lineage := []string{feature.Name, element.Name, step.Name}
+				// note: the location and id are different
+				tests = append(
+					tests,
+					v1.Test{
+						Name:         strings.Join(lineage, " > "),
+						Lineage:      lineage,
+						Location:     &location,
+						Attempt:      attempt,
+						PastAttempts: nil,
+					})
+			}
+		}
+	}
+
+	return v1.NewTestResults(
+		v1.JavaScriptCucumberFramework,
+		tests,
+		otherErrors,
+	), nil
+}

--- a/internal/parsing/javascript_cucumber_json_parser_test.go
+++ b/internal/parsing/javascript_cucumber_json_parser_test.go
@@ -1,0 +1,62 @@
+package parsing_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/rwx-research/captain-cli/internal/parsing"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JavaScriptCucumberJSONParser", func() {
+	Describe("Parse", func() {
+		It("parses the sample file", func() {
+			fixture, err := os.Open("../../test/fixtures/cucumber-js.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptCucumberJSONParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+			rwxJSON, err := json.MarshalIndent(testResults, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
+		})
+
+		It("errors on malformed JSON", func() {
+			testResults, err := parsing.JavaScriptCucumberJSONParser{}.Parse(strings.NewReader(`{`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to parse test results as JSON"))
+			Expect(testResults).To(BeNil())
+		})
+
+		It("errors on JSON that doesn't look like Cucumber", func() {
+			var testResults *v1.TestResults
+			var err error
+
+			testResults, err = parsing.JavaScriptCucumberJSONParser{}.Parse(strings.NewReader(`[]`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No test results were found in the JSON"))
+			Expect(testResults).To(BeNil())
+
+			testResults, err = parsing.JavaScriptCucumberJSONParser{}.Parse(strings.NewReader(`
+				[
+					{
+						"id": "rule-sample",
+						"uri": "features/rule.feature",
+						"keyword": "Feature",
+						"name": "Rule Sample",
+						"description": "",
+						"line": 2
+					}
+				]`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Found features, but no steps in the JSON"))
+			Expect(testResults).To(BeNil())
+		})
+	})
+})

--- a/internal/testingschema/v1/framework.go
+++ b/internal/testingschema/v1/framework.go
@@ -65,6 +65,9 @@ var (
 	GoTestFramework = registerFramework(
 		Framework{Language: FrameworkLanguageGo, Kind: FrameworkKindGoTest},
 	)
+	JavaScriptCucumberFramework = registerFramework(
+		Framework{Language: FrameworkLanguageJavaScript, Kind: FrameworkKindCucumber},
+	)
 	JavaScriptCypressFramework = registerFramework(
 		Framework{Language: FrameworkLanguageJavaScript, Kind: FrameworkKindCypress},
 	)

--- a/test/fixtures/cucumber-js.json
+++ b/test/fixtures/cucumber-js.json
@@ -1,0 +1,447 @@
+[
+  {
+    "description": "",
+    "elements": [
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;a-passing-example",
+        "keyword": "Example",
+        "line": 7,
+        "name": "A passing example",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 8,
+            "name": "this will pass",
+            "match": {
+              "location": "features/support/steps.js:4"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 142791
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 9,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 16584
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 10,
+            "name": "some results should be there",
+            "match": {
+              "location": "features/support/steps.js:14"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 20582
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          }
+        ],
+        "type": "scenario"
+      },
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;a-failing-example",
+        "keyword": "Example",
+        "line": 14,
+        "name": "A failing example",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 15,
+            "name": "this will fail",
+            "match": {
+              "location": "features/support/steps.js:8"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 28541
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 16,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 12542
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 17,
+            "name": "some results should be there",
+            "match": {
+              "location": "features/support/steps.js:14"
+            },
+            "result": {
+              "status": "failed",
+              "duration": 67957,
+              "error_message": "AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert(this.this_will_pass === true)\n\n    + expected - actual\n\n    -false\n    +true\n\n    at World.<anonymous> (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:15:3)"
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          },
+          {
+            "name": "@flaky",
+            "line": 12
+          },
+          {
+            "name": "@failing",
+            "line": 13
+          }
+        ],
+        "type": "scenario"
+      },
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;a-pending-example",
+        "keyword": "Example",
+        "line": 19,
+        "name": "A pending example",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 20,
+            "name": "this is pending",
+            "match": {
+              "location": "features/support/steps.js:18"
+            },
+            "result": {
+              "status": "pending",
+              "duration": 22791
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 21,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 0
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 22,
+            "name": "nothing should happen",
+            "result": {
+              "status": "undefined",
+              "duration": 0
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          }
+        ],
+        "type": "scenario"
+      },
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;a-skipped-example",
+        "keyword": "Example",
+        "line": 24,
+        "name": "A skipped example",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "this is skipped",
+            "match": {
+              "location": "features/support/steps.js:22"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 91374
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 0
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "nothing should happen",
+            "result": {
+              "status": "undefined",
+              "duration": 0
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          }
+        ],
+        "type": "scenario"
+      },
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;an-undefined-example",
+        "keyword": "Example",
+        "line": 29,
+        "name": "An undefined example",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 30,
+            "name": "this is undefined",
+            "result": {
+              "status": "undefined",
+              "duration": 0
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 31,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 0
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 32,
+            "name": "nothing should happen",
+            "result": {
+              "status": "undefined",
+              "duration": 0
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          }
+        ],
+        "type": "scenario"
+      },
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;with-a-failing-before-hook",
+        "keyword": "Example",
+        "line": 35,
+        "name": "With a failing before hook",
+        "steps": [
+          {
+            "keyword": "Before",
+            "hidden": true,
+            "result": {
+              "status": "failed",
+              "duration": 104333,
+              "error_message": "Error: failed in before hook\n    at World.<anonymous> (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:27:9)"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 36,
+            "name": "this will pass",
+            "match": {
+              "location": "features/support/steps.js:4"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 0
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 37,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 0
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 38,
+            "name": "some results should be there",
+            "match": {
+              "location": "features/support/steps.js:14"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 0
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          },
+          {
+            "name": "@failing_before_hook",
+            "line": 34
+          }
+        ],
+        "type": "scenario"
+      },
+      {
+        "description": "",
+        "id": "rule-sample;this-is-a-rule;with-a-failing-after-hook",
+        "keyword": "Example",
+        "line": 41,
+        "name": "With a failing after hook",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 42,
+            "name": "this will pass",
+            "match": {
+              "location": "features/support/steps.js:4"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 87083
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 43,
+            "name": "I do an action",
+            "match": {
+              "location": "features/support/steps.js:12"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 9459
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 44,
+            "name": "some results should be there",
+            "match": {
+              "location": "features/support/steps.js:14"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 6999
+            }
+          },
+          {
+            "keyword": "After",
+            "hidden": true,
+            "result": {
+              "status": "failed",
+              "duration": 14750,
+              "error_message": "Error: failed in after hook\n    at World.<anonymous> (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:31:9)"
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@feature_tag",
+            "line": 1
+          },
+          {
+            "name": "@rule_tag"
+          },
+          {
+            "name": "@failing_after_hook",
+            "line": 40
+          }
+        ],
+        "type": "scenario"
+      }
+    ],
+    "id": "rule-sample",
+    "line": 2,
+    "keyword": "Feature",
+    "name": "Rule Sample",
+    "tags": [
+      {
+        "name": "@feature_tag",
+        "line": 1
+      }
+    ],
+    "uri": "features/rule.feature"
+  }
+]


### PR DESCRIPTION
It's worth noting that technically they've [deprecated their JSON](https://github.com/cucumber/cucumber-js/blob/5ce371870b677fe3d1a14915dc535688946f734c/docs/formatters.md#json) format insofar as they don't intend to add new features to it.

It is however MUCH easier to parse than their [JSONL messages format](https://github.com/cucumber/cucumber-js/blob/5ce371870b677fe3d1a14915dc535688946f734c/docs/formatters.md#message) (which seems to intend for you to construct a graph of their objects as messages come through).

I named this parser w/ JSON in it to leave room for a future messages format parser, but this was really quick to add and unblock anyone interested in using Captain with cucumber-js

If anyone is hesitant to use the JSON formatter for this reason, it looks like they also support [JUnit](https://github.com/cucumber/cucumber-js/blob/5ce371870b677fe3d1a14915dc535688946f734c/docs/formatters.md#junit) and the generic JUnit parser should be able to parse that