### PR TITLE
Make scenarios the test, not steps

### DIFF
--- a/internal/parsing/.snapshots/JavaScriptCucumberJSONParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptCucumberJSONParser Parse parses the sample file
@@ -13,12 +13,12 @@
     "retries": 0,
     "canceled": 0,
     "failed": 3,
-    "pended": 1,
+    "pended": 0,
     "quarantined": 0,
-    "skipped": 2,
+    "skipped": 0,
     "successful": 1,
     "timedOut": 0,
-    "todo": 0
+    "todo": 3
   },
   "tests": [
     {
@@ -113,7 +113,7 @@
           ]
         },
         "status": {
-          "kind": "pended"
+          "kind": "todo"
         }
       }
     },
@@ -142,7 +142,7 @@
           ]
         },
         "status": {
-          "kind": "skipped"
+          "kind": "todo"
         }
       }
     },
@@ -171,7 +171,7 @@
           ]
         },
         "status": {
-          "kind": "skipped"
+          "kind": "todo"
         }
       }
     },

--- a/internal/parsing/.snapshots/JavaScriptCucumberJSONParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptCucumberJSONParser Parse parses the sample file
@@ -8,35 +8,32 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 18,
-    "otherErrors": 2,
+    "tests": 7,
+    "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 1,
+    "failed": 3,
     "pended": 1,
     "quarantined": 0,
-    "skipped": 4,
-    "successful": 8,
+    "skipped": 2,
+    "successful": 1,
     "timedOut": 0,
-    "todo": 4
+    "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e A passing example \u003e this will pass",
+      "name": "Rule Sample \u003e A passing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "this will pass"
+        "A passing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 142791,
+        "durationInNanoseconds": 179957,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/support/steps.js:4",
           "tags": [
             {
               "name": "@feature_tag",
@@ -54,165 +51,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A passing example \u003e I do an action",
+      "name": "Rule Sample \u003e A failing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "I do an action"
+        "A failing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 16584,
+        "durationInNanoseconds": 109040,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/support/steps.js:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A passing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A passing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 10
-      },
-      "attempt": {
-        "durationInNanoseconds": 20582,
-        "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/support/steps.js:14",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e this will fail",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "this will fail"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 17
-      },
-      "attempt": {
-        "durationInNanoseconds": 28541,
-        "meta": {
-          "elementStart": "features/rule.feature:14",
-          "stepLocation": "features/support/steps.js:8",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            },
-            {
-              "name": "@flaky",
-              "line": 12
-            },
-            {
-              "name": "@failing",
-              "line": 13
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 17
-      },
-      "attempt": {
-        "durationInNanoseconds": 12542,
-        "meta": {
-          "elementStart": "features/rule.feature:14",
-          "stepLocation": "features/support/steps.js:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            },
-            {
-              "name": "@flaky",
-              "line": 12
-            },
-            {
-              "name": "@failing",
-              "line": 13
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 17
-      },
-      "attempt": {
-        "durationInNanoseconds": 67957,
-        "meta": {
-          "elementStart": "features/rule.feature:14",
-          "stepLocation": "features/support/steps.js:14",
           "tags": [
             {
               "name": "@feature_tag",
@@ -239,21 +89,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A pending example \u003e this is pending",
+      "name": "Rule Sample \u003e A pending example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "this is pending"
+        "A pending example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 22
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 22791,
         "meta": {
-          "elementStart": "features/rule.feature:19",
-          "stepLocation": "features/support/steps.js:18",
           "tags": [
             {
               "name": "@feature_tag",
@@ -271,85 +118,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A pending example \u003e I do an action",
+      "name": "Rule Sample \u003e A skipped example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "I do an action"
+        "A skipped example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 22
-      },
-      "attempt": {
-        "durationInNanoseconds": 0,
-        "meta": {
-          "elementStart": "features/rule.feature:19",
-          "stepLocation": "features/support/steps.js:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A pending example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "A pending example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 22
-      },
-      "attempt": {
-        "durationInNanoseconds": 0,
-        "meta": {
-          "elementStart": "features/rule.feature:19",
-          "stepLocation": "",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A skipped example \u003e this is skipped",
-      "lineage": [
-        "Rule Sample",
-        "A skipped example",
-        "this is skipped"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 27
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 91374,
         "meta": {
-          "elementStart": "features/rule.feature:24",
-          "stepLocation": "features/support/steps.js:22",
           "tags": [
             {
               "name": "@feature_tag",
@@ -367,21 +147,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A skipped example \u003e I do an action",
+      "name": "Rule Sample \u003e An undefined example",
       "lineage": [
         "Rule Sample",
-        "A skipped example",
-        "I do an action"
+        "An undefined example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 27
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
-          "elementStart": "features/rule.feature:24",
-          "stepLocation": "features/support/steps.js:12",
           "tags": [
             {
               "name": "@feature_tag",
@@ -399,21 +176,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A skipped example \u003e nothing should happen",
+      "name": "Rule Sample \u003e With a failing before hook",
       "lineage": [
         "Rule Sample",
-        "A skipped example",
-        "nothing should happen"
+        "With a failing before hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 27
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 0,
+        "durationInNanoseconds": 104333,
         "meta": {
-          "elementStart": "features/rule.feature:24",
-          "stepLocation": "",
           "tags": [
             {
               "name": "@feature_tag",
@@ -422,126 +196,32 @@
             {
               "name": "@rule_tag",
               "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e this is undefined",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "this is undefined"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 32
-      },
-      "attempt": {
-        "durationInNanoseconds": 0,
-        "meta": {
-          "elementStart": "features/rule.feature:29",
-          "stepLocation": "",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
             },
             {
-              "name": "@rule_tag",
-              "line": null
+              "name": "@failing_before_hook",
+              "line": 34
             }
           ]
         },
         "status": {
-          "kind": "todo"
+          "kind": "failed",
+          "message": "Error: failed in before hook\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:27:9)"
         }
       }
     },
     {
-      "name": "Rule Sample \u003e An undefined example \u003e I do an action",
+      "name": "Rule Sample \u003e With a failing after hook",
       "lineage": [
         "Rule Sample",
-        "An undefined example",
-        "I do an action"
+        "With a failing after hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 32
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 0,
+        "durationInNanoseconds": 118291,
         "meta": {
-          "elementStart": "features/rule.feature:29",
-          "stepLocation": "features/support/steps.js:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 32
-      },
-      "attempt": {
-        "durationInNanoseconds": 0,
-        "meta": {
-          "elementStart": "features/rule.feature:29",
-          "stepLocation": "",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e this will pass",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "this will pass"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 0
-      },
-      "attempt": {
-        "durationInNanoseconds": 87083,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/support/steps.js:4",
           "tags": [
             {
               "name": "@feature_tag",
@@ -558,94 +238,9 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "Error: failed in after hook\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:31:9)"
         }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 0
-      },
-      "attempt": {
-        "durationInNanoseconds": 9459,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/support/steps.js:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 0
-      },
-      "attempt": {
-        "durationInNanoseconds": 6999,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/support/steps.js:14",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": null
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    }
-  ],
-  "otherErrors": [
-    {
-      "message": "Error: failed in before hook\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:27:9)",
-      "meta": {
-        "type": "Before"
-      }
-    },
-    {
-      "message": "Error: failed in after hook\n    at World.\u003canonymous\u003e (/Users/kylekthompson/src/captain-examples/cucumber-js/features/support/steps.js:31:9)",
-      "meta": {
-        "type": "After"
       }
     }
   ]

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a failing element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a failing element
@@ -8,7 +8,7 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 3,
+    "tests": 1,
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
@@ -16,99 +16,24 @@
     "pended": 0,
     "quarantined": 0,
     "skipped": 0,
-    "successful": 2,
+    "successful": 0,
     "timedOut": 0,
     "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e A failing example \u003e this will fail",
+      "name": "Rule Sample \u003e A failing example",
       "lineage": [
         "Rule Sample",
-        "A failing example",
-        "this will fail"
+        "A failing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 16
+        "line": 13
       },
       "attempt": {
-        "durationInNanoseconds": 11000,
+        "durationInNanoseconds": 26528000,
         "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:5",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing",
-              "line": 12
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 7000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing",
-              "line": 12
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 26510000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:12",
           "tags": [
             {
               "name": "@feature_tag",

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a passing element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a passing element
@@ -8,7 +8,7 @@
     "status": {
       "kind": "successful"
     },
-    "tests": 3,
+    "tests": 1,
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
@@ -16,91 +16,24 @@
     "pended": 0,
     "quarantined": 0,
     "skipped": 0,
-    "successful": 3,
+    "successful": 1,
     "timedOut": 0,
     "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e A passing example \u003e this will pass",
+      "name": "Rule Sample \u003e A passing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "this will pass"
+        "A passing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 7
       },
       "attempt": {
-        "durationInNanoseconds": 48000,
+        "durationInNanoseconds": 1189000,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:1",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A passing example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "A passing example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 10
-      },
-      "attempt": {
-        "durationInNanoseconds": 8000,
-        "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A passing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A passing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 10
-      },
-      "attempt": {
-        "durationInNanoseconds": 1133000,
-        "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:12",
           "tags": [
             {
               "name": "@feature_tag",

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a pending element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a pending element
@@ -13,9 +13,9 @@
     "retries": 0,
     "canceled": 0,
     "failed": 0,
-    "pended": 1,
+    "pended": 0,
     "quarantined": 0,
-    "skipped": 0,
+    "skipped": 1,
     "successful": 0,
     "timedOut": 0,
     "todo": 0
@@ -46,8 +46,7 @@
           ]
         },
         "status": {
-          "kind": "pended",
-          "message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:17:in `\"this is pending\"'\nfeatures/rule.feature:19:in `this is pending'"
+          "kind": "skipped"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a pending element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a pending element
@@ -8,35 +8,32 @@
     "status": {
       "kind": "successful"
     },
-    "tests": 3,
+    "tests": 1,
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
     "failed": 0,
     "pended": 1,
     "quarantined": 0,
-    "skipped": 1,
+    "skipped": 0,
     "successful": 0,
     "timedOut": 0,
-    "todo": 1
+    "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e A pending example \u003e this is pending",
+      "name": "Rule Sample \u003e A pending example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "this is pending"
+        "A pending example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 21
+        "line": 18
       },
       "attempt": {
         "durationInNanoseconds": 158000,
         "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/step_definitions/steps.rb:16",
           "tags": [
             {
               "name": "@feature_tag",
@@ -49,71 +46,8 @@
           ]
         },
         "status": {
-          "kind": "pended"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A pending example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "A pending example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 21
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A pending example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "A pending example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 21
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/rule.feature:21",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
+          "kind": "pended",
+          "message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:17:in `\"this is pending\"'\nfeatures/rule.feature:19:in `this is pending'"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a skipped element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a skipped element
@@ -8,35 +8,32 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 21,
-    "otherErrors": 2,
+    "tests": 7,
+    "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 1,
+    "failed": 3,
     "pended": 1,
     "quarantined": 0,
-    "skipped": 7,
-    "successful": 8,
+    "skipped": 2,
+    "successful": 1,
     "timedOut": 0,
-    "todo": 4
+    "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e A passing example \u003e this will pass",
+      "name": "Rule Sample \u003e A passing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "this will pass"
+        "A passing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 48000,
+        "durationInNanoseconds": 1189000,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -54,157 +51,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A passing example \u003e I do an action",
+      "name": "Rule Sample \u003e A failing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "I do an action"
+        "A failing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 8000,
+        "durationInNanoseconds": 26528000,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A passing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A passing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 10
-      },
-      "attempt": {
-        "durationInNanoseconds": 1133000,
-        "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e this will fail",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "this will fail"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 11000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:5",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing",
-              "line": 12
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 7000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing",
-              "line": 12
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 26510000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:12",
           "tags": [
             {
               "name": "@feature_tag",
@@ -227,21 +85,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A pending example \u003e this is pending",
+      "name": "Rule Sample \u003e A pending example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "this is pending"
+        "A pending example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 21
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 158000,
         "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/step_definitions/steps.rb:16",
           "tags": [
             {
               "name": "@feature_tag",
@@ -254,90 +109,24 @@
           ]
         },
         "status": {
-          "kind": "pended"
+          "kind": "pended",
+          "message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:17:in `\"this is pending\"'\nfeatures/rule.feature:19:in `this is pending'"
         }
       }
     },
     {
-      "name": "Rule Sample \u003e A pending example \u003e I do an action",
+      "name": "Rule Sample \u003e A skipped example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "I do an action"
+        "A skipped example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 21
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A pending example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "A pending example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 21
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/rule.feature:21",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A skipped example \u003e this is skipped",
-      "lineage": [
-        "Rule Sample",
-        "A skipped example",
-        "this is skipped"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 26
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 139000,
         "meta": {
-          "elementStart": "features/rule.feature:23",
-          "stepLocation": "features/step_definitions/steps.rb:20",
           "tags": [
             {
               "name": "@feature_tag",
@@ -355,21 +144,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A skipped example \u003e I do an action",
+      "name": "Rule Sample \u003e An undefined example",
       "lineage": [
         "Rule Sample",
-        "A skipped example",
-        "I do an action"
+        "An undefined example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 26
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 0,
         "meta": {
-          "elementStart": "features/rule.feature:23",
-          "stepLocation": "features/step_definitions/steps.rb:9",
           "tags": [
             {
               "name": "@feature_tag",
@@ -387,149 +173,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A skipped example \u003e nothing should happen",
+      "name": "Rule Sample \u003e With a failing before hook",
       "lineage": [
         "Rule Sample",
-        "A skipped example",
-        "nothing should happen"
+        "With a failing before hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 26
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 141000,
         "meta": {
-          "elementStart": "features/rule.feature:23",
-          "stepLocation": "features/rule.feature:26",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e this is undefined",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "this is undefined"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/rule.feature:29",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/rule.feature:31",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing before hook \u003e this will pass",
-      "lineage": [
-        "Rule Sample",
-        "With a failing before hook",
-        "this will pass"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 37
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -546,98 +201,24 @@
           ]
         },
         "status": {
-          "kind": "skipped"
+          "kind": "failed",
+          "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:25:in `Before'"
         }
       }
     },
     {
-      "name": "Rule Sample \u003e With a failing before hook \u003e I do an action",
+      "name": "Rule Sample \u003e With a failing after hook",
       "lineage": [
         "Rule Sample",
-        "With a failing before hook",
-        "I do an action"
+        "With a failing after hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 37
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 178000,
         "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_before_hook",
-              "line": 33
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing before hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing before hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 37
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_before_hook",
-              "line": 33
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e this will pass",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "this will pass"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 12000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -654,102 +235,9 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
         }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 7000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 30000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    }
-  ],
-  "otherErrors": [
-    {
-      "location": {
-        "file": "features/step_definitions/steps.rb",
-        "line": 24
-      },
-      "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:25:in `Before'",
-      "meta": {
-        "type": "before hook"
-      }
-    },
-    {
-      "location": {
-        "file": "features/step_definitions/steps.rb",
-        "line": 28
-      },
-      "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'",
-      "meta": {
-        "type": "after hook"
       }
     }
   ]

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a skipped element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a skipped element
@@ -12,11 +12,11 @@
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 3,
-    "pended": 1,
+    "failed": 2,
+    "pended": 0,
     "quarantined": 0,
-    "skipped": 2,
-    "successful": 1,
+    "skipped": 3,
+    "successful": 2,
     "timedOut": 0,
     "todo": 0
   },
@@ -109,8 +109,7 @@
           ]
         },
         "status": {
-          "kind": "pended",
-          "message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:17:in `\"this is pending\"'\nfeatures/rule.feature:19:in `this is pending'"
+          "kind": "skipped"
         }
       }
     },
@@ -183,7 +182,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 141000,
+        "durationInNanoseconds": 282000,
         "meta": {
           "tags": [
             {
@@ -217,7 +216,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 178000,
+        "durationInNanoseconds": 49000,
         "meta": {
           "tags": [
             {
@@ -235,8 +234,7 @@
           ]
         },
         "status": {
-          "kind": "failed",
-          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
+          "kind": "successful"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a undefined element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a undefined element
@@ -8,7 +8,7 @@
     "status": {
       "kind": "successful"
     },
-    "tests": 3,
+    "tests": 1,
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
@@ -18,57 +18,22 @@
     "skipped": 1,
     "successful": 0,
     "timedOut": 0,
-    "todo": 2
+    "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e An undefined example \u003e this is undefined",
+      "name": "Rule Sample \u003e An undefined example",
       "lineage": [
         "Rule Sample",
-        "An undefined example",
-        "this is undefined"
+        "An undefined example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 31
+        "line": 28
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 0,
         "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/rule.feature:29",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/step_definitions/steps.rb:9",
           "tags": [
             {
               "name": "@feature_tag",
@@ -82,38 +47,6 @@
         },
         "status": {
           "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/rule.feature:31",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing after hook
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing after hook
@@ -8,35 +8,32 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 3,
-    "otherErrors": 1,
+    "tests": 1,
+    "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 0,
+    "failed": 1,
     "pended": 0,
     "quarantined": 0,
     "skipped": 0,
-    "successful": 3,
+    "successful": 0,
     "timedOut": 0,
     "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e With a failing after hook \u003e this will pass",
+      "name": "Rule Sample \u003e With a failing after hook",
       "lineage": [
         "Rule Sample",
-        "With a failing after hook",
-        "this will pass"
+        "With a failing after hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 44
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 12000,
+        "durationInNanoseconds": 178000,
         "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -53,92 +50,9 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
         }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 7000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 30000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    }
-  ],
-  "otherErrors": [
-    {
-      "location": {
-        "file": "features/step_definitions/steps.rb",
-        "line": 28
-      },
-      "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'",
-      "meta": {
-        "type": "after hook"
       }
     }
   ]

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing after hook
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing after hook
@@ -6,17 +6,17 @@
   },
   "summary": {
     "status": {
-      "kind": "failed"
+      "kind": "successful"
     },
     "tests": 1,
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 1,
+    "failed": 0,
     "pended": 0,
     "quarantined": 0,
     "skipped": 0,
-    "successful": 0,
+    "successful": 1,
     "timedOut": 0,
     "todo": 0
   },
@@ -32,7 +32,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 178000,
+        "durationInNanoseconds": 49000,
         "meta": {
           "tags": [
             {
@@ -50,8 +50,7 @@
           ]
         },
         "status": {
-          "kind": "failed",
-          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
+          "kind": "successful"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing before hook
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing before hook
@@ -8,35 +8,32 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 3,
-    "otherErrors": 1,
+    "tests": 1,
+    "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 0,
+    "failed": 1,
     "pended": 0,
     "quarantined": 0,
-    "skipped": 3,
+    "skipped": 0,
     "successful": 0,
     "timedOut": 0,
     "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e With a failing before hook \u003e this will pass",
+      "name": "Rule Sample \u003e With a failing before hook",
       "lineage": [
         "Rule Sample",
-        "With a failing before hook",
-        "this will pass"
+        "With a failing before hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 37
+        "line": 34
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 141000,
         "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -53,92 +50,9 @@
           ]
         },
         "status": {
-          "kind": "skipped"
+          "kind": "failed",
+          "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:25:in `Before'"
         }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing before hook \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "With a failing before hook",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 37
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_before_hook",
-              "line": 33
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing before hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing before hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 37
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_before_hook",
-              "line": 33
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    }
-  ],
-  "otherErrors": [
-    {
-      "location": {
-        "file": "features/step_definitions/steps.rb",
-        "line": 24
-      },
-      "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:25:in `Before'",
-      "meta": {
-        "type": "before hook"
       }
     }
   ]

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing before hook
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing before hook
@@ -32,7 +32,7 @@
         "line": 34
       },
       "attempt": {
-        "durationInNanoseconds": 141000,
+        "durationInNanoseconds": 282000,
         "meta": {
           "tags": [
             {

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file
@@ -8,35 +8,32 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 21,
-    "otherErrors": 2,
+    "tests": 7,
+    "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 1,
+    "failed": 3,
     "pended": 1,
     "quarantined": 0,
-    "skipped": 7,
-    "successful": 8,
+    "skipped": 2,
+    "successful": 1,
     "timedOut": 0,
-    "todo": 4
+    "todo": 0
   },
   "tests": [
     {
-      "name": "Rule Sample \u003e A passing example \u003e this will pass",
+      "name": "Rule Sample \u003e A passing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "this will pass"
+        "A passing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 48000,
+        "durationInNanoseconds": 1189000,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -54,157 +51,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A passing example \u003e I do an action",
+      "name": "Rule Sample \u003e A failing example",
       "lineage": [
         "Rule Sample",
-        "A passing example",
-        "I do an action"
+        "A failing example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 10
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 8000,
+        "durationInNanoseconds": 26528000,
         "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A passing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A passing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 10
-      },
-      "attempt": {
-        "durationInNanoseconds": 1133000,
-        "meta": {
-          "elementStart": "features/rule.feature:7",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e this will fail",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "this will fail"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 11000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:5",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing",
-              "line": 12
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 7000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing",
-              "line": 12
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A failing example \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "A failing example",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 16
-      },
-      "attempt": {
-        "durationInNanoseconds": 26510000,
-        "meta": {
-          "elementStart": "features/rule.feature:13",
-          "stepLocation": "features/step_definitions/steps.rb:12",
           "tags": [
             {
               "name": "@feature_tag",
@@ -227,21 +85,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A pending example \u003e this is pending",
+      "name": "Rule Sample \u003e A pending example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "this is pending"
+        "A pending example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 21
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 158000,
         "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/step_definitions/steps.rb:16",
           "tags": [
             {
               "name": "@feature_tag",
@@ -254,90 +109,24 @@
           ]
         },
         "status": {
-          "kind": "pended"
+          "kind": "pended",
+          "message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:17:in `\"this is pending\"'\nfeatures/rule.feature:19:in `this is pending'"
         }
       }
     },
     {
-      "name": "Rule Sample \u003e A pending example \u003e I do an action",
+      "name": "Rule Sample \u003e A skipped example",
       "lineage": [
         "Rule Sample",
-        "A pending example",
-        "I do an action"
+        "A skipped example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 21
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A pending example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "A pending example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 21
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:18",
-          "stepLocation": "features/rule.feature:21",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e A skipped example \u003e this is skipped",
-      "lineage": [
-        "Rule Sample",
-        "A skipped example",
-        "this is skipped"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 26
+        "line": 41
       },
       "attempt": {
         "durationInNanoseconds": 139000,
         "meta": {
-          "elementStart": "features/rule.feature:23",
-          "stepLocation": "features/step_definitions/steps.rb:20",
           "tags": [
             {
               "name": "@feature_tag",
@@ -355,21 +144,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A skipped example \u003e I do an action",
+      "name": "Rule Sample \u003e An undefined example",
       "lineage": [
         "Rule Sample",
-        "A skipped example",
-        "I do an action"
+        "An undefined example"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 26
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 0,
         "meta": {
-          "elementStart": "features/rule.feature:23",
-          "stepLocation": "features/step_definitions/steps.rb:9",
           "tags": [
             {
               "name": "@feature_tag",
@@ -387,149 +173,18 @@
       }
     },
     {
-      "name": "Rule Sample \u003e A skipped example \u003e nothing should happen",
+      "name": "Rule Sample \u003e With a failing before hook",
       "lineage": [
         "Rule Sample",
-        "A skipped example",
-        "nothing should happen"
+        "With a failing before hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 26
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 141000,
         "meta": {
-          "elementStart": "features/rule.feature:23",
-          "stepLocation": "features/rule.feature:26",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e this is undefined",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "this is undefined"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/rule.feature:29",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e An undefined example \u003e nothing should happen",
-      "lineage": [
-        "Rule Sample",
-        "An undefined example",
-        "nothing should happen"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 31
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:28",
-          "stepLocation": "features/rule.feature:31",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            }
-          ]
-        },
-        "status": {
-          "kind": "todo"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing before hook \u003e this will pass",
-      "lineage": [
-        "Rule Sample",
-        "With a failing before hook",
-        "this will pass"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 37
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -546,98 +201,24 @@
           ]
         },
         "status": {
-          "kind": "skipped"
+          "kind": "failed",
+          "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:25:in `Before'"
         }
       }
     },
     {
-      "name": "Rule Sample \u003e With a failing before hook \u003e I do an action",
+      "name": "Rule Sample \u003e With a failing after hook",
       "lineage": [
         "Rule Sample",
-        "With a failing before hook",
-        "I do an action"
+        "With a failing after hook"
       ],
       "location": {
         "file": "features/rule.feature",
-        "line": 37
+        "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": null,
+        "durationInNanoseconds": 178000,
         "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_before_hook",
-              "line": 33
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing before hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing before hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 37
-      },
-      "attempt": {
-        "durationInNanoseconds": null,
-        "meta": {
-          "elementStart": "features/rule.feature:34",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_before_hook",
-              "line": 33
-            }
-          ]
-        },
-        "status": {
-          "kind": "skipped"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e this will pass",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "this will pass"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 12000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:1",
           "tags": [
             {
               "name": "@feature_tag",
@@ -654,102 +235,9 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
         }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e I do an action",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "I do an action"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 7000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:9",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    },
-    {
-      "name": "Rule Sample \u003e With a failing after hook \u003e some results should be there",
-      "lineage": [
-        "Rule Sample",
-        "With a failing after hook",
-        "some results should be there"
-      ],
-      "location": {
-        "file": "features/rule.feature",
-        "line": 44
-      },
-      "attempt": {
-        "durationInNanoseconds": 30000,
-        "meta": {
-          "elementStart": "features/rule.feature:41",
-          "stepLocation": "features/step_definitions/steps.rb:12",
-          "tags": [
-            {
-              "name": "@feature_tag",
-              "line": 1
-            },
-            {
-              "name": "@rule_tag",
-              "line": 4
-            },
-            {
-              "name": "@failing_after_hook",
-              "line": 40
-            }
-          ]
-        },
-        "status": {
-          "kind": "successful"
-        }
-      }
-    }
-  ],
-  "otherErrors": [
-    {
-      "location": {
-        "file": "features/step_definitions/steps.rb",
-        "line": 24
-      },
-      "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:25:in `Before'",
-      "meta": {
-        "type": "before hook"
-      }
-    },
-    {
-      "location": {
-        "file": "features/step_definitions/steps.rb",
-        "line": 28
-      },
-      "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'",
-      "meta": {
-        "type": "after hook"
       }
     }
   ]

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file
@@ -12,11 +12,11 @@
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 3,
-    "pended": 1,
+    "failed": 2,
+    "pended": 0,
     "quarantined": 0,
-    "skipped": 2,
-    "successful": 1,
+    "skipped": 3,
+    "successful": 2,
     "timedOut": 0,
     "todo": 0
   },
@@ -109,8 +109,7 @@
           ]
         },
         "status": {
-          "kind": "pended",
-          "message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:17:in `\"this is pending\"'\nfeatures/rule.feature:19:in `this is pending'"
+          "kind": "skipped"
         }
       }
     },
@@ -183,7 +182,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 141000,
+        "durationInNanoseconds": 282000,
         "meta": {
           "tags": [
             {
@@ -217,7 +216,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 178000,
+        "durationInNanoseconds": 49000,
         "meta": {
           "tags": [
             {
@@ -235,8 +234,7 @@
           ]
         },
         "status": {
-          "kind": "failed",
-          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
+          "kind": "successful"
         }
       }
     }

--- a/internal/parsing/javascript_cucumber_json_parser.go
+++ b/internal/parsing/javascript_cucumber_json_parser.go
@@ -38,8 +38,8 @@ type JavaScriptCucumberJSONFeature struct {
 				Location string `json:"location"`
 			} `json:"match"`
 			Result *struct {
-				Status       string `json:"status"`
-				Duration     *int   `json:"duration"`
+				Status       string  `json:"status"`
+				Duration     *int    `json:"duration"`
 				ErrorMessage *string `json:"error_message"`
 			} `json:"result"`
 		} `json:"steps"`
@@ -89,7 +89,7 @@ outer:
 
 			for _, step := range element.Steps {
 				if step.Result == nil {
-					break;
+					break
 				}
 
 				if firstErrorMessage == nil && step.Result.ErrorMessage != nil && *step.Result.ErrorMessage != "" {
@@ -125,8 +125,8 @@ outer:
 			location := v1.Location{File: feature.URI, Line: &element.Line}
 			attempt := v1.TestAttempt{
 				Duration: &duration,
-				Status: status,
-				Meta: map[string]any{"tags": element.Tags},
+				Status:   status,
+				Meta:     map[string]any{"tags": element.Tags},
 			}
 
 			lineage := []string{feature.Name, element.Name}

--- a/internal/parsing/javascript_cucumber_json_parser.go
+++ b/internal/parsing/javascript_cucumber_json_parser.go
@@ -81,45 +81,63 @@ outer:
 	tests := make([]v1.Test, 0)
 	otherErrors := make([]v1.OtherError, 0)
 
+	// https://github.com/cucumber/messages/blob/3a3c605d0ef7df53012d78ddc0796dbae3df17a1/javascript/src/getWorstTestStepResult.ts#L18-L26
+	// failed, then ambiguous, then undefined, then pending, then skipped, then passed
+	priority := map[string]int{
+		"failed":    6,
+		"ambiguous": 5,
+		"undefined": 4,
+		"pending":   3,
+		"skipped":   2,
+		"passed":    1,
+	}
+
 	for _, feature := range cucumberFeatures {
 		for _, element := range feature.Elements {
-			var firstErrorMessage *string
-			statusesSeen := map[string]bool{}
+			var stepStatus string
+			var status v1.TestStatus
 			duration := time.Duration(0)
 
 			for _, step := range element.Steps {
+				if step.Result.Duration != nil {
+					duration += time.Duration(*step.Result.Duration * int(time.Nanosecond))
+				}
+
 				if step.Result == nil {
 					break
 				}
 
-				if firstErrorMessage == nil && step.Result.ErrorMessage != nil && *step.Result.ErrorMessage != "" {
-					firstErrorMessage = step.Result.ErrorMessage
+				if _, ok := priority[step.Result.Status]; !ok {
+					return nil, errors.NewInputError(
+						"Unexpected status %v for cucumber step %v",
+						step.Result.Status,
+						step,
+					)
 				}
-				statusesSeen[step.Result.Status] = true
-				if step.Result.Duration != nil {
-					duration += time.Duration(*step.Result.Duration * int(time.Nanosecond))
-				}
-			}
 
-			var status v1.TestStatus
-			if statusesSeen["failed"] {
-				status = v1.NewFailedTestStatus(firstErrorMessage, nil, nil)
-			} else if statusesSeen["pending"] && !statusesSeen["passed"] {
-				status = v1.NewPendedTestStatus(firstErrorMessage)
-			} else if statusesSeen["skipped"] && !statusesSeen["passed"] {
-				status = v1.NewSkippedTestStatus(firstErrorMessage)
-			} else if statusesSeen["undefined"] && !statusesSeen["passed"] {
-				status = v1.NewTodoTestStatus(firstErrorMessage)
-			} else if statusesSeen["passed"] {
-				status = v1.NewSuccessfulTestStatus()
-			} else if len(statusesSeen) == 0 {
-				status = v1.NewTodoTestStatus(firstErrorMessage)
-			} else {
-				return nil, errors.NewInputError(
-					"Unexpected statuses %v for cucumber scenario %v",
-					statusesSeen,
-					element,
-				)
+				if stepStatus == "" || priority[stepStatus] < priority[step.Result.Status] {
+					stepStatus = step.Result.Status
+					switch step.Result.Status {
+					case "passed":
+						status = v1.NewSuccessfulTestStatus()
+					case "failed":
+						status = v1.NewFailedTestStatus(step.Result.ErrorMessage, nil, nil)
+					case "skipped":
+						status = v1.NewSkippedTestStatus(step.Result.ErrorMessage)
+					case "undefined":
+						status = v1.NewTodoTestStatus(step.Result.ErrorMessage)
+					case "pending":
+						status = v1.NewTodoTestStatus(step.Result.ErrorMessage)
+					case "ambiguous":
+						status = v1.NewFailedTestStatus(step.Result.ErrorMessage, nil, nil)
+					default:
+						return nil, errors.NewInputError(
+							"Unexpected status %v for cucumber step %v",
+							step.Result.Status,
+							step,
+						)
+					}
+				}
 			}
 
 			location := v1.Location{File: feature.URI, Line: &element.Line}

--- a/internal/parsing/javascript_cucumber_json_parser_test.go
+++ b/internal/parsing/javascript_cucumber_json_parser_test.go
@@ -55,7 +55,7 @@ var _ = Describe("JavaScriptCucumberJSONParser", func() {
 					}
 				]`))
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Found features, but no steps in the JSON"))
+			Expect(err.Error()).To(ContainSubstring("Found features, but no results in the JSON"))
 			Expect(testResults).To(BeNil())
 		})
 	})

--- a/internal/parsing/ruby_cucumber_parser.go
+++ b/internal/parsing/ruby_cucumber_parser.go
@@ -49,7 +49,7 @@ type RubyCucumberElement struct {
 }
 
 type RubyCucumberHook struct {
-	Match  RubyCucumberMatch     `json:"match"`
+	Match  RubyCucumberMatch      `json:"match"`
 	Result *FailingCucumberResult `json:"result"`
 }
 
@@ -136,7 +136,7 @@ outer:
 
 			for _, hook := range element.Before {
 				if hook.Result == nil {
-					break;
+					break
 				}
 
 				if firstErrorMessage == nil && hook.Result.ErrorMessage != "" {
@@ -150,7 +150,7 @@ outer:
 
 			for _, step := range element.Steps {
 				if step.Result == nil {
-					break;
+					break
 				}
 
 				if firstErrorMessage == nil && step.Result.ErrorMessage != nil && *step.Result.ErrorMessage != "" {
@@ -164,7 +164,7 @@ outer:
 
 			for _, hook := range element.After {
 				if hook.Result == nil {
-					break;
+					break
 				}
 
 				if firstErrorMessage == nil && hook.Result.ErrorMessage != "" {
@@ -200,8 +200,8 @@ outer:
 			location := v1.Location{File: feature.URI, Line: &element.Line}
 			attempt := v1.TestAttempt{
 				Duration: &duration,
-				Status: status,
-				Meta: map[string]any{"tags": element.Tags},
+				Status:   status,
+				Meta:     map[string]any{"tags": element.Tags},
 			}
 
 			lineage := []string{feature.Name, element.Name}

--- a/internal/parsing/ruby_cucumber_parser_test.go
+++ b/internal/parsing/ruby_cucumber_parser_test.go
@@ -132,7 +132,7 @@ var _ = Describe("RubyCucumberParser", func() {
 					}
 				]`))
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Found features, but no steps in the JSON"))
+			Expect(err.Error()).To(ContainSubstring("Found features, but no results in the JSON"))
 			Expect(testResults).To(BeNil())
 		})
 	})

--- a/internal/targetedretries/.snapshots/JavaScriptCucumberSubstitution works with a real file
+++ b/internal/targetedretries/.snapshots/JavaScriptCucumberSubstitution works with a real file
@@ -1,5 +1,5 @@
 ([]map[string]string) (len=1) {
   (map[string]string) (len=1) {
-    (string) (len=9) "scenarios": (string) (len=26) "'features/rule.feature:14'"
+    (string) (len=9) "scenarios": (string) (len=26) "'features/rule.feature:41'"
   }
 }

--- a/internal/targetedretries/.snapshots/RubyCucumberSubstitution works with a real file
+++ b/internal/targetedretries/.snapshots/RubyCucumberSubstitution works with a real file
@@ -1,5 +1,5 @@
 ([]map[string]string) (len=1) {
   (map[string]string) (len=1) {
-    (string) (len=8) "examples": (string) (len=26) "'features/rule.feature:13'"
+    (string) (len=9) "scenarios": (string) (len=26) "'features/rule.feature:41'"
   }
 }

--- a/internal/targetedretries/javascript_cucumber_substitution.go
+++ b/internal/targetedretries/javascript_cucumber_substitution.go
@@ -51,7 +51,11 @@ func (s JavaScriptCucumberSubstitution) SubstitutionsFor(
 
 	for _, test := range testResults.Tests {
 		if test.Attempt.Status.ImpliesFailure() && filter(test) {
-			example := templating.ShellEscape(test.Attempt.Meta["elementStart"].(string))
+			scenarioLocation := test.Location.File
+			if test.Location.Line != nil {
+				scenarioLocation = fmt.Sprintf("%s:%v", test.Location.File, *test.Location.Line)
+			}
+			example := templating.ShellEscape(scenarioLocation)
 			if _, ok := scenariosSeen[example]; ok {
 				continue
 			}

--- a/internal/targetedretries/javascript_cucumber_substitution_test.go
+++ b/internal/targetedretries/javascript_cucumber_substitution_test.go
@@ -101,47 +101,47 @@ var _ = Describe("JavaScriptCucumberSubstitution", func() {
 			compiledTemplate, compileErr := templating.CompileTemplate("npx cucumber-js {{ scenarios }}")
 			Expect(compileErr).NotTo(HaveOccurred())
 
-			elementStart1 := "elementStart1 with ' single quotes"
-			elementStart2 := "elementStart2"
-			elementStart3 := "elementStart3"
-			elementStart4 := "elementStart4"
-			elementStart5 := "elementStart5"
-			elementStart6 := "elementStart6"
+			file1 := "file1 with ' single quotes"
+			file2 := "file2"
+			file3 := "file3"
+			file4 := "file4"
+			file5 := "file5"
+			file6 := "file6"
 			testResults := v1.TestResults{
 				Tests: []v1.Test{
 					{
+						Location: &v1.Location{File: file1},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart1},
 							Status: v1.NewFailedTestStatus(nil, nil, nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file2},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart2},
 							Status: v1.NewCanceledTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart3},
 							Status: v1.NewTimedOutTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file4},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart4},
 							Status: v1.NewPendedTestStatus(nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file5},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart5},
 							Status: v1.NewSuccessfulTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file6},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart6},
 							Status: v1.NewSkippedTestStatus(nil),
 						},
 					},
@@ -156,9 +156,9 @@ var _ = Describe("JavaScriptCucumberSubstitution", func() {
 			)).To(Equal(
 				[]map[string]string{
 					{
-						"scenarios": `'elementStart1 with '"'"' single quotes' ` +
-							`'elementStart2' ` +
-							`'elementStart3'`,
+						"scenarios": `'file1 with '"'"' single quotes' ` +
+							`'file2' ` +
+							`'file3'`,
 					},
 				},
 			))
@@ -168,47 +168,47 @@ var _ = Describe("JavaScriptCucumberSubstitution", func() {
 			compiledTemplate, compileErr := templating.CompileTemplate("npx cucumber-js {{ scenarios }}")
 			Expect(compileErr).NotTo(HaveOccurred())
 
-			elementStart1 := "elementStart1 with ' single quotes"
-			elementStart2 := "elementStart2"
-			elementStart3 := "elementStart3"
-			elementStart4 := "elementStart4"
-			elementStart5 := "elementStart5"
-			elementStart6 := "elementStart6"
+			file1 := "file1 with ' single quotes"
+			file2 := "file2"
+			file3 := "file3"
+			file4 := "file4"
+			file5 := "file5"
+			file6 := "file6"
 			testResults := v1.TestResults{
 				Tests: []v1.Test{
 					{
+						Location: &v1.Location{File: file1},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart1},
 							Status: v1.NewFailedTestStatus(nil, nil, nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file2},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart2},
 							Status: v1.NewCanceledTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart3},
 							Status: v1.NewTimedOutTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file4},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart4},
 							Status: v1.NewPendedTestStatus(nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file5},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart5},
 							Status: v1.NewSuccessfulTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file6},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart6},
 							Status: v1.NewSkippedTestStatus(nil),
 						},
 					},
@@ -225,7 +225,7 @@ var _ = Describe("JavaScriptCucumberSubstitution", func() {
 			Expect(substitutions).To(Equal(
 				[]map[string]string{
 					{
-						"scenarios": `'elementStart1 with '"'"' single quotes'`,
+						"scenarios": `'file1 with '"'"' single quotes'`,
 					},
 				},
 			))

--- a/internal/targetedretries/ruby_cucumber_substitution_test.go
+++ b/internal/targetedretries/ruby_cucumber_substitution_test.go
@@ -29,7 +29,7 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 		err := substitution.ValidateTemplate(compiledTemplate)
 		Expect(err).NotTo(HaveOccurred())
 
-		fixture, err := os.Open("../../test/fixtures/cucumber/failing.json")
+		fixture, err := os.Open("../../test/fixtures/cucumber-js.json")
 		Expect(err).ToNot(HaveOccurred())
 
 		testResults, err := parsing.RubyCucumberParser{}.Parse(fixture)
@@ -42,7 +42,7 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		sort.SliceStable(substitutions, func(i int, j int) bool {
-			return substitutions[i]["examples"] < substitutions[j]["examples"]
+			return substitutions[i]["scenarios"] < substitutions[j]["scenarios"]
 		})
 		cupaloy.SnapshotT(GinkgoT(), substitutions)
 	})
@@ -70,14 +70,14 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 
 		It("is invalid for a template with too many placeholders", func() {
 			substitution := targetedretries.RubyCucumberSubstitution{}
-			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ file }} {{ examples }}")
+			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ file }} {{ scenarios }}")
 			Expect(compileErr).NotTo(HaveOccurred())
 
 			err := substitution.ValidateTemplate(compiledTemplate)
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("is invalid for a template without a examples placeholder", func() {
+		It("is invalid for a template without a scenarios placeholder", func() {
 			substitution := targetedretries.RubyCucumberSubstitution{}
 			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ file }}")
 			Expect(compileErr).NotTo(HaveOccurred())
@@ -86,9 +86,9 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("is valid for a template with only a examples placeholder", func() {
+		It("is valid for a template with only a scenarios placeholder", func() {
 			substitution := targetedretries.RubyCucumberSubstitution{}
-			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ examples }}")
+			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ scenarios }}")
 			Expect(compileErr).NotTo(HaveOccurred())
 
 			err := substitution.ValidateTemplate(compiledTemplate)
@@ -98,50 +98,50 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 
 	Describe("Substitutions", func() {
 		It("returns the shell escaped element start identifiers", func() {
-			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ examples }}")
+			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ scenarios }}")
 			Expect(compileErr).NotTo(HaveOccurred())
 
-			elementStart1 := "elementStart1 with ' single quotes"
-			elementStart2 := "elementStart2"
-			elementStart3 := "elementStart3"
-			elementStart4 := "elementStart4"
-			elementStart5 := "elementStart5"
-			elementStart6 := "elementStart6"
+			file1 := "file1 with ' single quotes"
+			file2 := "file2"
+			file3 := "file3"
+			file4 := "file4"
+			file5 := "file5"
+			file6 := "file6"
 			testResults := v1.TestResults{
 				Tests: []v1.Test{
 					{
+						Location: &v1.Location{File: file1},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart1},
 							Status: v1.NewFailedTestStatus(nil, nil, nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file2},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart2},
 							Status: v1.NewCanceledTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart3},
 							Status: v1.NewTimedOutTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file4},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart4},
 							Status: v1.NewPendedTestStatus(nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file5},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart5},
 							Status: v1.NewSuccessfulTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file6},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart6},
 							Status: v1.NewSkippedTestStatus(nil),
 						},
 					},
@@ -156,59 +156,59 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 			)).To(Equal(
 				[]map[string]string{
 					{
-						"examples": `'elementStart1 with '"'"' single quotes' ` +
-							`'elementStart2' ` +
-							`'elementStart3'`,
+						"scenarios": `'file1 with '"'"' single quotes' ` +
+							`'file2' ` +
+							`'file3'`,
 					},
 				},
 			))
 		})
 
 		It("filters the tests with the provided function", func() {
-			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ examples }}")
+			compiledTemplate, compileErr := templating.CompileTemplate("bundle exec cucumber {{ scenarios }}")
 			Expect(compileErr).NotTo(HaveOccurred())
 
-			elementStart1 := "elementStart1 with ' single quotes"
-			elementStart2 := "elementStart2"
-			elementStart3 := "elementStart3"
-			elementStart4 := "elementStart4"
-			elementStart5 := "elementStart5"
-			elementStart6 := "elementStart6"
+			file1 := "file1 with ' single quotes"
+			file2 := "file2"
+			file3 := "file3"
+			file4 := "file4"
+			file5 := "file5"
+			file6 := "file6"
 			testResults := v1.TestResults{
 				Tests: []v1.Test{
 					{
+						Location: &v1.Location{File: file1},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart1},
 							Status: v1.NewFailedTestStatus(nil, nil, nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file2},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart2},
 							Status: v1.NewCanceledTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart3},
 							Status: v1.NewTimedOutTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file4},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart4},
 							Status: v1.NewPendedTestStatus(nil),
 						},
 					},
 					{
+						Location: &v1.Location{File: file5},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart5},
 							Status: v1.NewSuccessfulTestStatus(),
 						},
 					},
 					{
+						Location: &v1.Location{File: file6},
 						Attempt: v1.TestAttempt{
-							Meta:   map[string]any{"elementStart": elementStart6},
 							Status: v1.NewSkippedTestStatus(nil),
 						},
 					},
@@ -225,7 +225,7 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 			Expect(substitutions).To(Equal(
 				[]map[string]string{
 					{
-						"examples": `'elementStart1 with '"'"' single quotes'`,
+						"scenarios": `'file1 with '"'"' single quotes'`,
 					},
 				},
 			))


### PR DESCRIPTION
Migrates the cucumber parsers from treating steps as tests and hooks as errors to simply calling a scenario a test. @TAGraves and I think this aligns better with the cucumber model and it seems like it is how retries would need to function (you can't retry only part of a scenario)