### PR TITLE
Only write to MINT_LINKS when cloud is enabled

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -657,7 +657,9 @@ func (s Service) reportTestResults(
 	}
 
 	mintLinksPath := os.Getenv("MINT_LINKS")
-	if reportingConfiguration.CloudEnabled && reportingConfiguration.Provider.ProviderName == "mint" && mintLinksPath != "" {
+	if reportingConfiguration.CloudEnabled &&
+		reportingConfiguration.Provider.ProviderName == "mint" &&
+		mintLinksPath != "" {
 		backlinkPath := filepath.Join(mintLinksPath, "View Captain results")
 		backlinkURL := fmt.Sprintf(
 			"https://%v/captain/deep_link/test_suite_summaries/%v/%v/%v",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -657,7 +657,7 @@ func (s Service) reportTestResults(
 	}
 
 	mintLinksPath := os.Getenv("MINT_LINKS")
-	if reportingConfiguration.Provider.ProviderName == "mint" && mintLinksPath != "" {
+	if reportingConfiguration.CloudEnabled && reportingConfiguration.Provider.ProviderName == "mint" && mintLinksPath != "" {
 		backlinkPath := filepath.Join(mintLinksPath, "View Captain results")
 		backlinkURL := fmt.Sprintf(
 			"https://%v/captain/deep_link/test_suite_summaries/%v/%v/%v",


### PR DESCRIPTION
In OSS mode, we should avoid writing to `MINT_LINKS` because those results won't be available in Captain Cloud.