### PR TITLE
Add support for vitest

### DIFF
--- a/.mint/ci.yaml
+++ b/.mint/ci.yaml
@@ -2,12 +2,20 @@ on:
   github:
     push:
       init:
+        trigger: push
         commit-sha: ${{ event.git.sha }}
         branch: ${{ event.git.branch }}
     pull_request:
       init:
+        trigger: pull_request
         commit-sha: ${{ event.git.sha }}
         branch: ${{ event.git.branch }}
+
+concurrency-pools:
+  - id: rwx-research/captain:ci:${{ init.commit-sha }}:${{ init.trigger }}
+    if: ${{ init.branch != "main" }}
+    capacity: 1
+    on-overflow: cancel-running
 
 tasks:
   - key: test
@@ -37,4 +45,4 @@ tasks:
     init:
       commit-sha: ${{ init.commit-sha }}
       kind: unstable
-      version: ''
+      version: ""

--- a/cmd/captain/init.go
+++ b/cmd/captain/init.go
@@ -26,6 +26,7 @@ var mutuallyExclusiveParsers []parsing.Parser = []parsing.Parser{
 	parsing.GoTestParser{},
 	parsing.JavaScriptCypressParser{},
 	parsing.JavaScriptJestParser{},
+	parsing.JavaScriptVitestParser{}, // Vitest MUST be after Jest as Jest _looks like_ a superset of Vitest
 	parsing.JavaScriptKarmaParser{},
 	parsing.JavaScriptMochaParser{},
 	parsing.JavaScriptPlaywrightParser{},
@@ -44,6 +45,7 @@ var frameworkParsers map[v1.Framework][]parsing.Parser = map[v1.Framework][]pars
 	v1.JavaScriptKarmaFramework:      {parsing.JavaScriptKarmaParser{}},
 	v1.JavaScriptMochaFramework:      {parsing.JavaScriptMochaParser{}},
 	v1.JavaScriptPlaywrightFramework: {parsing.JavaScriptPlaywrightParser{}},
+	v1.JavaScriptVitestFramework:     {parsing.JavaScriptVitestParser{}},
 	v1.PHPUnitFramework:              {parsing.PHPUnitParser{}},
 	v1.PythonPytestFramework:         {parsing.PythonPytestParser{}},
 	v1.PythonUnitTestFramework:       {parsing.PythonUnitTestParser{}},

--- a/internal/parsing/.snapshots/JavaScriptVitestParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptVitestParser Parse parses the sample file
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "JavaScript",
+    "kind": "Vitest"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 10,
+    "otherErrors": 0,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 2,
+    "pended": 0,
+    "quarantined": 0,
+    "skipped": 2,
+    "successful": 5,
+    "timedOut": 0,
+    "todo": 1
+  },
+  "tests": [
+    {
+      "name": "adds 1 + 2 to equal 3",
+      "lineage": [
+        "adds 1 + 2 to equal 3"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 4,
+        "column": 1
+      },
+      "attempt": {
+        "durationInNanoseconds": 1000000,
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "it is pended",
+      "lineage": [
+        "it is pended"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 8,
+        "column": 6
+      },
+      "attempt": {
+        "durationInNanoseconds": null,
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "it is not written yet",
+      "lineage": [
+        "it is not written yet"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 12,
+        "column": 6
+      },
+      "attempt": {
+        "durationInNanoseconds": null,
+        "status": {
+          "kind": "todo"
+        }
+      }
+    },
+    {
+      "name": "first level of nesting \u003e it passes",
+      "lineage": [
+        "first level of nesting",
+        "it passes"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 15,
+        "column": 3
+      },
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "first level of nesting \u003e it fails",
+      "lineage": [
+        "first level of nesting",
+        "it fails"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 19,
+        "column": 3
+      },
+      "attempt": {
+        "durationInNanoseconds": 2000000,
+        "status": {
+          "kind": "failed",
+          "message": "AssertionError: expected 1 to be 2 // Object.is equality",
+          "backtrace": [
+            "at /Users/kylekthompson/src/captain-examples/vitest/sum.test.js:20:15",
+            "at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:146:14",
+            "at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:61:7",
+            "at runTest (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:960:17)",
+            "at processTicksAndRejections (node:internal/process/task_queues:95:5)",
+            "at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)",
+            "at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)",
+            "at runFiles (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1173:5)",
+            "at startTests (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1182:3)",
+            "at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/vitest/dist/chunks/runBaseTests.CyvqmuC9.js:130:11"
+          ]
+        }
+      }
+    },
+    {
+      "name": "first level of nesting \u003e it is slow",
+      "lineage": [
+        "first level of nesting",
+        "it is slow"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 23,
+        "column": 3
+      },
+      "attempt": {
+        "durationInNanoseconds": 5002000000,
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "first level of nesting \u003e second level of nesting \u003e it passes",
+      "lineage": [
+        "first level of nesting",
+        "second level of nesting",
+        "it passes"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 29,
+        "column": 5
+      },
+      "attempt": {
+        "durationInNanoseconds": 1000000,
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "first level of nesting \u003e second level of nesting \u003e it fails",
+      "lineage": [
+        "first level of nesting",
+        "second level of nesting",
+        "it fails"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 33,
+        "column": 5
+      },
+      "attempt": {
+        "durationInNanoseconds": 2000000,
+        "status": {
+          "kind": "failed",
+          "message": "AssertionError: expected 1 to be 2 // Object.is equality",
+          "backtrace": [
+            "at /Users/kylekthompson/src/captain-examples/vitest/sum.test.js:34:17",
+            "at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:146:14",
+            "at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:61:7",
+            "at runTest (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:960:17)",
+            "at runNextTicks (node:internal/process/task_queues:60:5)",
+            "at listOnTimeout (node:internal/timers:538:9)",
+            "at processTimers (node:internal/timers:512:7)",
+            "at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)",
+            "at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)",
+            "at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)"
+          ]
+        }
+      }
+    },
+    {
+      "name": "first level of nesting \u003e second level of nesting \u003e it is slow",
+      "lineage": [
+        "first level of nesting",
+        "second level of nesting",
+        "it is slow"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 37,
+        "column": 5
+      },
+      "attempt": {
+        "durationInNanoseconds": 5001000000,
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "skipped whole nested describe \u003e there's a test in here though",
+      "lineage": [
+        "skipped whole nested describe",
+        "there's a test in here though"
+      ],
+      "location": {
+        "file": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+        "line": 45,
+        "column": 3
+      },
+      "attempt": {
+        "durationInNanoseconds": null,
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    }
+  ]
+}

--- a/internal/parsing/javascript_vitest_parser.go
+++ b/internal/parsing/javascript_vitest_parser.go
@@ -1,0 +1,194 @@
+package parsing
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/rwx-research/captain-cli/internal/errors"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+)
+
+type JavaScriptVitestParser struct{}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/snapshot/src/types/index.ts#L47-L50
+type JavaScriptVitestUncheckedSnapshot struct {
+	FilePath string   `json:"filePath"`
+	Keys     []string `json:"keys"`
+}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/snapshot/src/types/index.ts#L52-L67
+type JavaScriptVitestSnapshot struct {
+	Added               int                                 `json:"added"`
+	DidUpdate           bool                                `json:"didUpdate"`
+	Failure             bool                                `json:"failure"`
+	FilesAdded          int                                 `json:"filesAdded"`
+	FilesRemoved        int                                 `json:"filesRemoved"`
+	FilesRemovedList    []string                            `json:"filesRemovedList"`
+	FilesUnmatched      int                                 `json:"filesUnmatched"`
+	FilesUpdated        int                                 `json:"filesUpdated"`
+	Matched             int                                 `json:"matched"`
+	Total               int                                 `json:"total"`
+	Unchecked           int                                 `json:"unchecked"`
+	UncheckedKeysByFile []JavaScriptVitestUncheckedSnapshot `json:"uncheckedKeysByFile"`
+	Unmatched           int                                 `json:"unmatched"`
+	Updated             int                                 `json:"updated"`
+}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/vitest/src/node/reporters/json.ts#L16-L19
+type JavaScriptVitestCallsite struct {
+	Column int `json:"column"`
+	Line   int `json:"line"`
+}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/runner/src/types/tasks.ts#L105
+type JavaScriptVitestTaskMeta struct{}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/vitest/src/node/reporters/json.ts#L30-L39
+type JavaScriptVitestAssertionResult struct {
+	AncestorTitles  []string                  `json:"ancestorTitles"`
+	Duration        *int                      `json:"duration"`
+	FailureMessages []string                  `json:"failureMessages"`
+	FullName        string                    `json:"fullName"`
+	Location        *JavaScriptVitestCallsite `json:"location"`
+	Status          string                    `json:"status"`
+	Title           string                    `json:"title"`
+	Meta            JavaScriptVitestTaskMeta  `json:"meta"`
+}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/vitest/src/node/reporters/json.ts#L41-L50
+type JavaScriptVitestTestResult struct {
+	AssertionResults []JavaScriptVitestAssertionResult `json:"assertionResults"`
+	EndTime          int                               `json:"endTime"`
+	Message          string                            `json:"message"`
+	Name             string                            `json:"name"`
+	StartTime        int                               `json:"startTime"`
+	Status           string                            `json:"status"`
+}
+
+// https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/vitest/src/node/reporters/json.ts#L52-L69
+type JavaScriptVitestTestResults struct {
+	NumFailedTests       int                          `json:"numFailedTests"`
+	NumFailedTestSuites  int                          `json:"numFailedTestSuites"`
+	NumPassedTests       int                          `json:"numPassedTests"`
+	NumPassedTestSuites  int                          `json:"numPassedTestSuites"`
+	NumPendingTests      int                          `json:"numPendingTests"`
+	NumPendingTestSuites int                          `json:"numPendingTestSuites"`
+	NumTodoTests         int                          `json:"numTodoTests"`
+	NumTotalTests        int                          `json:"numTotalTests"`
+	NumTotalTestSuites   int                          `json:"numTotalTestSuites"`
+	Snapshot             *JavaScriptVitestSnapshot    `json:"snapshot"`
+	StartTime            int                          `json:"startTime"`
+	Success              bool                         `json:"success"`
+	TestResults          []JavaScriptVitestTestResult `json:"testResults"`
+}
+
+var javaScriptVitestBacktraceSeparatorRegexp = regexp.MustCompile(`\r?\n\s{4}at`)
+
+func (p JavaScriptVitestParser) Parse(data io.Reader) (*v1.TestResults, error) {
+	var testResults JavaScriptVitestTestResults
+
+	if err := json.NewDecoder(data).Decode(&testResults); err != nil {
+		return nil, errors.NewInputError("Unable to parse test results as JSON: %s", err)
+	}
+	if testResults.TestResults == nil {
+		return nil, errors.NewInputError("No test results were found in the JSON")
+	}
+	if testResults.Snapshot == nil {
+		return nil, errors.NewInputError("No snapshot was found in the JSON")
+	}
+	if len(testResults.TestResults) > 0 && testResults.TestResults[0].AssertionResults == nil {
+		return nil, errors.NewInputError("The test results in the JSON do not appear to match Vitest JSON")
+	}
+
+	tests := make([]v1.Test, 0)
+	otherErrors := make([]v1.OtherError, 0)
+	for _, testResult := range testResults.TestResults {
+		sawFailedTest := false
+		file := testResult.Name
+
+		for _, assertionResult := range testResult.AssertionResults {
+			lineage := assertionResult.AncestorTitles
+			lineage = append(lineage, assertionResult.Title)
+			name := strings.Join(lineage, " > ")
+
+			var line *int
+			var column *int
+			if assertionResult.Location != nil {
+				assertionResult := assertionResult
+				line = &assertionResult.Location.Line
+				column = &assertionResult.Location.Column
+			}
+			location := v1.Location{File: file, Line: line, Column: column}
+
+			var duration *time.Duration
+			if assertionResult.Duration != nil {
+				transformedDuration := time.Duration(*assertionResult.Duration * int(time.Millisecond))
+				duration = &transformedDuration
+			}
+
+			var status v1.TestStatus
+			switch assertionResult.Status {
+			case "passed":
+				status = v1.NewSuccessfulTestStatus()
+			case "failed":
+				message, backtrace := p.extractFailureMetadata(assertionResult.FailureMessages)
+				status = v1.NewFailedTestStatus(message, nil, backtrace)
+				sawFailedTest = true
+			case "skipped":
+				status = v1.NewSkippedTestStatus(nil)
+			case "pending":
+				status = v1.NewPendedTestStatus(nil)
+			case "todo":
+				status = v1.NewTodoTestStatus(nil)
+			default:
+				return nil, errors.NewInputError(
+					"Unexpected status %q for assertion result %v",
+					assertionResult.Status,
+					assertionResult,
+				)
+			}
+
+			attempt := v1.TestAttempt{Duration: duration, Status: status}
+			tests = append(
+				tests,
+				v1.Test{
+					Name:     name,
+					Lineage:  lineage,
+					Location: &location,
+					Attempt:  attempt,
+				},
+			)
+		}
+
+		if !sawFailedTest && testResult.Status == "failed" {
+			otherErrors = append(otherErrors, v1.OtherError{Message: testResult.Message})
+		}
+	}
+
+	return v1.NewTestResults(
+		v1.JavaScriptVitestFramework,
+		tests,
+		otherErrors,
+	), nil
+}
+
+func (p JavaScriptVitestParser) extractFailureMetadata(failureMessages []string) (*string, []string) {
+	var message *string
+	var backtrace []string
+
+	if failureMessages != nil && failureMessages[0] != "" {
+		parts := javaScriptVitestBacktraceSeparatorRegexp.Split(failureMessages[0], -1)
+		first, rest := parts[0], parts[1:]
+		message = &first
+
+		for _, part := range rest {
+			backtrace = append(backtrace, fmt.Sprintf("at%s", part))
+		}
+	}
+
+	return message, backtrace
+}

--- a/internal/parsing/javascript_vitest_parser_test.go
+++ b/internal/parsing/javascript_vitest_parser_test.go
@@ -1,0 +1,339 @@
+package parsing_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/rwx-research/captain-cli/internal/parsing"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JavaScriptVitestParser", func() {
+	Describe("Parse", func() {
+		It("parses the sample file", func() {
+			fixture, err := os.Open("../../test/fixtures/vitest.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+
+			rwxJSON, err := json.MarshalIndent(testResults, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
+		})
+
+		It("errors on malformed JSON", func() {
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(`{`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to parse test results as JSON"))
+			Expect(testResults).To(BeNil())
+		})
+
+		It("errors on JSON that doesn't look like Vitest", func() {
+			var testResults *v1.TestResults
+			var err error
+
+			testResults, err = parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(`{}`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No test results were found in the JSON"))
+			Expect(testResults).To(BeNil())
+
+			testResults, err = parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(`{"testResults": []}`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No snapshot was found in the JSON"))
+			Expect(testResults).To(BeNil())
+
+			testResults, err = parsing.JavaScriptVitestParser{}.Parse(
+				strings.NewReader(`{"testResults": [{}], "snapshot": {}}`),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				ContainSubstring("The test results in the JSON do not appear to match Vitest JSON"),
+			)
+			Expect(testResults).To(BeNil())
+		})
+
+		It("parses a minimally failing test", func() {
+			durationInMilliseconds := 653
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Duration: &durationInMilliseconds,
+								Status:   "failed",
+								Title:    "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+
+			expectedDuration := time.Duration(653000000)
+			Expect(testResults.Tests[0]).To(Equal(
+				v1.Test{
+					Name:     "title",
+					Lineage:  []string{"title"},
+					Location: &v1.Location{File: "/some/path/to/name/of/file.js"},
+					Attempt: v1.TestAttempt{
+						Duration: &expectedDuration,
+						Status:   v1.NewFailedTestStatus(nil, nil, nil),
+					},
+				},
+			))
+		})
+
+		It("parses a maximally failing test", func() {
+			durationInMilliseconds := 653
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								AncestorTitles:  []string{"part 1", "part 2"},
+								Duration:        &durationInMilliseconds,
+								FailureMessages: []string{"final\n\nmessage\n    at stacktrace"},
+								Status:          "failed",
+								Title:           "title",
+								Location:        &parsing.JavaScriptVitestCallsite{Line: 10, Column: 12},
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+
+			expectedDuration := time.Duration(653000000)
+			line := 10
+			column := 12
+			finalFailureMessage := "final\n\nmessage"
+			finalBacktrace := []string{"at stacktrace"}
+			Expect(testResults.Tests[0]).To(Equal(
+				v1.Test{
+					Name:     "part 1 > part 2 > title",
+					Lineage:  []string{"part 1", "part 2", "title"},
+					Location: &v1.Location{File: "/some/path/to/name/of/file.js", Line: &line, Column: &column},
+					Attempt: v1.TestAttempt{
+						Duration: &expectedDuration,
+						Status:   v1.NewFailedTestStatus(&finalFailureMessage, nil, finalBacktrace),
+					},
+				},
+			))
+		})
+
+		It("parses passed statuses", func() {
+			durationInMilliseconds := 653
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Duration: &durationInMilliseconds,
+								Status:   "passed",
+								Title:    "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+			Expect(testResults.Tests[0].Attempt.Status).To(Equal(v1.NewSuccessfulTestStatus()))
+		})
+
+		It("parses todo statuses", func() {
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "todo",
+								Title:  "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+			Expect(testResults.Tests[0].Attempt.Duration).To(BeNil())
+			Expect(testResults.Tests[0].Attempt.Status).To(Equal(v1.NewTodoTestStatus(nil)))
+		})
+
+		It("parses skipped statuses", func() {
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "skipped",
+								Title:  "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+			Expect(testResults.Tests[0].Attempt.Status).To(Equal(v1.NewSkippedTestStatus(nil)))
+		})
+
+		It("parses pending statuses", func() {
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "pending",
+								Title:  "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+			Expect(testResults.Tests[0].Attempt.Status).To(Equal(v1.NewPendedTestStatus(nil)))
+		})
+
+		It("errors on other statuses", func() {
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:   "/some/path/to/name/of/file.js",
+						Status: "passed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "wat",
+								Title:  "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unexpected status \"wat\""))
+			Expect(testResults).To(BeNil())
+		})
+
+		It("parses an other error when a whole test result fails", func() {
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:    "/some/path/to/name/of/file.js",
+						Status:  "failed",
+						Message: "the reason it failed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "passed",
+								Title:  "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Message: "the reason it failed"}))
+			Expect(testResults.Tests[0]).NotTo(BeNil())
+		})
+
+		It("does not parse an other error when a whole test result fails due to a failing test", func() {
+			jestResults := parsing.JavaScriptVitestTestResults{
+				Snapshot: &parsing.JavaScriptVitestSnapshot{},
+				TestResults: []parsing.JavaScriptVitestTestResult{
+					{
+						Name:    "/some/path/to/name/of/file.js",
+						Status:  "failed",
+						Message: "the reason it failed",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "failed",
+								Title:  "title",
+							},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(jestResults)
+			Expect(err).NotTo(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptVitestParser{}.Parse(strings.NewReader(string(data)))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testResults).NotTo(BeNil())
+			Expect(testResults.OtherErrors).To(HaveLen(0))
+			Expect(testResults.Tests[0]).NotTo(BeNil())
+		})
+	})
+})

--- a/internal/testingschema/v1/framework.go
+++ b/internal/testingschema/v1/framework.go
@@ -25,6 +25,7 @@ const (
 	FrameworkKindUnitTest   FrameworkKind = "unittest"
 	FrameworkKindRSpec      FrameworkKind = "RSpec"
 	FrameworkKindxUnit      FrameworkKind = "xUnit"
+	FrameworkKindVitest     FrameworkKind = "Vitest"
 
 	FrameworkLanguageDotNet     FrameworkLanguage = ".NET"
 	FrameworkLanguageElixir     FrameworkLanguage = "Elixir"
@@ -82,6 +83,9 @@ var (
 	)
 	JavaScriptPlaywrightFramework = registerFramework(
 		Framework{Language: FrameworkLanguageJavaScript, Kind: FrameworkKindPlaywright},
+	)
+	JavaScriptVitestFramework = registerFramework(
+		Framework{Language: FrameworkLanguageJavaScript, Kind: FrameworkKindVitest},
 	)
 	PHPUnitFramework = registerFramework(
 		Framework{Language: FrameworkLanguagePHP, Kind: FrameworkKindPHPUnit},

--- a/test/fixtures/vitest.json
+++ b/test/fixtures/vitest.json
@@ -1,0 +1,171 @@
+{
+  "numTotalTestSuites": 4,
+  "numPassedTestSuites": 4,
+  "numFailedTestSuites": 0,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 10,
+  "numPassedTests": 8,
+  "numFailedTests": 2,
+  "numPendingTests": 0,
+  "numTodoTests": 1,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0,
+    "didUpdate": false
+  },
+  "startTime": 1724351128553,
+  "success": false,
+  "testResults": [
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [],
+          "fullName": "adds 1 + 2 to equal 3",
+          "status": "passed",
+          "title": "adds 1 + 2 to equal 3",
+          "duration": 1,
+          "failureMessages": [],
+          "location": {
+            "line": 4,
+            "column": 1
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": [],
+          "fullName": "it is pended",
+          "status": "skipped",
+          "title": "it is pended",
+          "failureMessages": [],
+          "location": {
+            "line": 8,
+            "column": 6
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": [],
+          "fullName": "it is not written yet",
+          "status": "todo",
+          "title": "it is not written yet",
+          "failureMessages": [],
+          "location": {
+            "line": 12,
+            "column": 6
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["first level of nesting"],
+          "fullName": "first level of nesting it passes",
+          "status": "passed",
+          "title": "it passes",
+          "duration": 0,
+          "failureMessages": [],
+          "location": {
+            "line": 15,
+            "column": 3
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["first level of nesting"],
+          "fullName": "first level of nesting it fails",
+          "status": "failed",
+          "title": "it fails",
+          "duration": 2,
+          "failureMessages": [
+            "AssertionError: expected 1 to be 2 // Object.is equality\n    at /Users/kylekthompson/src/captain-examples/vitest/sum.test.js:20:15\n    at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:146:14\n    at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:61:7\n    at runTest (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:960:17)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)\n    at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)\n    at runFiles (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1173:5)\n    at startTests (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1182:3)\n    at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/vitest/dist/chunks/runBaseTests.CyvqmuC9.js:130:11"
+          ],
+          "location": {
+            "line": 19,
+            "column": 3
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["first level of nesting"],
+          "fullName": "first level of nesting it is slow",
+          "status": "passed",
+          "title": "it is slow",
+          "duration": 5002,
+          "failureMessages": [],
+          "location": {
+            "line": 23,
+            "column": 3
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["first level of nesting", "second level of nesting"],
+          "fullName": "first level of nesting second level of nesting it passes",
+          "status": "passed",
+          "title": "it passes",
+          "duration": 1,
+          "failureMessages": [],
+          "location": {
+            "line": 29,
+            "column": 5
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["first level of nesting", "second level of nesting"],
+          "fullName": "first level of nesting second level of nesting it fails",
+          "status": "failed",
+          "title": "it fails",
+          "duration": 2,
+          "failureMessages": [
+            "AssertionError: expected 1 to be 2 // Object.is equality\n    at /Users/kylekthompson/src/captain-examples/vitest/sum.test.js:34:17\n    at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:146:14\n    at file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:61:7\n    at runTest (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:960:17)\n    at runNextTicks (node:internal/process/task_queues:60:5)\n    at listOnTimeout (node:internal/timers:538:9)\n    at processTimers (node:internal/timers:512:7)\n    at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)\n    at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)\n    at runSuite (file:///Users/kylekthompson/src/captain-examples/vitest/node_modules/@vitest/runner/dist/index.js:1116:15)"
+          ],
+          "location": {
+            "line": 33,
+            "column": 5
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["first level of nesting", "second level of nesting"],
+          "fullName": "first level of nesting second level of nesting it is slow",
+          "status": "passed",
+          "title": "it is slow",
+          "duration": 5001,
+          "failureMessages": [],
+          "location": {
+            "line": 37,
+            "column": 5
+          },
+          "meta": {}
+        },
+        {
+          "ancestorTitles": ["skipped whole nested describe"],
+          "fullName": "skipped whole nested describe there's a test in here though",
+          "status": "skipped",
+          "title": "there's a test in here though",
+          "failureMessages": [],
+          "location": {
+            "line": 45,
+            "column": 3
+          },
+          "meta": {}
+        }
+      ],
+      "startTime": 1724351128781,
+      "endTime": 1724351138790,
+      "status": "failed",
+      "message": "",
+      "name": "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js"
+    }
+  ]
+}


### PR DESCRIPTION
This change adds support for Vitest. 

Notably, this is _nearly_ the same as the Jest one (just with a few fields missing). Unfortunately, that means it makes it super challenging to tell if a file we're parsing is Jest or Vitest. We need to parse Jest _first_ in case it's Jest. If it is, the Vitest parser likely can parse it, but we'll prefer the first parser we find.