### PR TITLE
Support targeted retries for Vitest

### DIFF
--- a/internal/targetedretries/.snapshots/JavaScriptVitestSubstitution works with a real file
+++ b/internal/targetedretries/.snapshots/JavaScriptVitestSubstitution works with a real file
@@ -1,0 +1,6 @@
+([]map[string]string) (len=1) {
+  (map[string]string) (len=2) {
+    (string) (len=4) "file": (string) (len=60) "/Users/kylekthompson/src/captain-examples/vitest/sum.test.js",
+    (string) (len=15) "testNamePattern": (string) (len=89) "^first level of nesting it fails|first level of nesting second level of nesting it fails$"
+  }
+}

--- a/internal/targetedretries/javascript_vitest_substitution.go
+++ b/internal/targetedretries/javascript_vitest_substitution.go
@@ -1,0 +1,93 @@
+package targetedretries
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rwx-research/captain-cli/internal/errors"
+	"github.com/rwx-research/captain-cli/internal/templating"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+)
+
+type JavaScriptVitestSubstitution struct{}
+
+func (s JavaScriptVitestSubstitution) Example() string {
+	return "npx vitest run '{{ file }}' --testNamePattern '{{ testNamePattern }}'"
+}
+
+func (s JavaScriptVitestSubstitution) ValidateTemplate(compiledTemplate templating.CompiledTemplate) error {
+	keywords := compiledTemplate.Keywords()
+
+	if len(keywords) == 0 {
+		return errors.NewInputError(
+			"Retrying Vitest requires a template with the 'file' and 'testNamePattern' keywords; " +
+				"no keywords were found",
+		)
+	}
+
+	if len(keywords) != 2 {
+		return errors.NewInputError(
+			"Retrying Vitest requires a template with the 'file' and 'testNamePattern' keywords; "+
+				"these were found: %v",
+			strings.Join(keywords, ", "),
+		)
+	}
+
+	if (keywords[0] == "file" && keywords[1] == "testNamePattern") ||
+		(keywords[0] == "testNamePattern" && keywords[1] == "file") {
+		return nil
+	}
+
+	return errors.NewInputError(
+		"Retrying Vitest requires a template with the 'file' and 'testNamePattern' keywords; "+
+			"'%v' and '%v' were found instead",
+		keywords[0],
+		keywords[1],
+	)
+}
+
+func (s JavaScriptVitestSubstitution) SubstitutionsFor(
+	_ templating.CompiledTemplate,
+	testResults v1.TestResults,
+	filter func(v1.Test) bool,
+) ([]map[string]string, error) {
+	testsByFile := map[string][]string{}
+	testsSeenByFile := map[string]map[string]struct{}{}
+
+	for _, test := range testResults.Tests {
+		if !test.Attempt.Status.ImpliesFailure() {
+			continue
+		}
+		if !filter(test) {
+			continue
+		}
+
+		file := templating.ShellEscape(test.Location.File)
+		if _, ok := testsSeenByFile[file]; !ok {
+			testsSeenByFile[file] = map[string]struct{}{}
+		}
+		if _, ok := testsByFile[file]; !ok {
+			testsByFile[file] = make([]string, 0)
+		}
+
+		formattedName := templating.ShellEscape(templating.RegexpEscape(strings.Join(test.Lineage, " ")))
+		if _, ok := testsSeenByFile[file][formattedName]; ok {
+			continue
+		}
+
+		testsByFile[file] = append(testsByFile[file], formattedName)
+		testsSeenByFile[file][formattedName] = struct{}{}
+	}
+
+	substitutions := make([]map[string]string, len(testsByFile))
+	i := 0
+	for file, tests := range testsByFile {
+		substitutions[i] = map[string]string{
+			"file":            file,
+			"testNamePattern": fmt.Sprintf("^%v$", strings.Join(tests, "|")),
+		}
+		i++
+	}
+
+	return substitutions, nil
+}

--- a/internal/targetedretries/javascript_vitest_substitution_test.go
+++ b/internal/targetedretries/javascript_vitest_substitution_test.go
@@ -1,0 +1,261 @@
+package targetedretries_test
+
+import (
+	"os"
+	"sort"
+
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/rwx-research/captain-cli/internal/parsing"
+	"github.com/rwx-research/captain-cli/internal/targetedretries"
+	"github.com/rwx-research/captain-cli/internal/templating"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JavaScriptVitestSubstitution", func() {
+	It("adheres to the Substitution interface", func() {
+		var substitution targetedretries.Substitution = targetedretries.JavaScriptVitestSubstitution{}
+		Expect(substitution).NotTo(BeNil())
+	})
+
+	It("works with a real file", func() {
+		substitution := targetedretries.JavaScriptVitestSubstitution{}
+		compiledTemplate, compileErr := templating.CompileTemplate(substitution.Example())
+		Expect(compileErr).NotTo(HaveOccurred())
+
+		err := substitution.ValidateTemplate(compiledTemplate)
+		Expect(err).NotTo(HaveOccurred())
+
+		fixture, err := os.Open("../../test/fixtures/vitest.json")
+		Expect(err).ToNot(HaveOccurred())
+
+		testResults, err := parsing.JavaScriptVitestParser{}.Parse(fixture)
+		Expect(err).ToNot(HaveOccurred())
+
+		substitutions, err := substitution.SubstitutionsFor(
+			compiledTemplate,
+			*testResults,
+			func(_ v1.Test) bool { return true },
+		)
+		Expect(err).NotTo(HaveOccurred())
+		sort.SliceStable(substitutions, func(i int, j int) bool {
+			if substitutions[i]["file"] != substitutions[j]["file"] {
+				return substitutions[i]["file"] < substitutions[j]["file"]
+			}
+
+			return substitutions[i]["testNamePattern"] < substitutions[j]["testNamePattern"]
+		})
+		cupaloy.SnapshotT(GinkgoT(), substitutions)
+	})
+
+	Describe("Example", func() {
+		It("compiles and is valid", func() {
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			compiledTemplate, compileErr := templating.CompileTemplate(substitution.Example())
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			err := substitution.ValidateTemplate(compiledTemplate)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("ValidateTemplate", func() {
+		It("is invalid for a template without placeholders", func() {
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			compiledTemplate, compileErr := templating.CompileTemplate("npx jest")
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			err := substitution.ValidateTemplate(compiledTemplate)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("is invalid for a template with too few placeholders", func() {
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			compiledTemplate, compileErr := templating.CompileTemplate(
+				"npx jest --file '{{ file }}'",
+			)
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			err := substitution.ValidateTemplate(compiledTemplate)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("is invalid for a template with additional placeholders", func() {
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			compiledTemplate, compileErr := templating.CompileTemplate(
+				"npx jest --file '{{ file }}' --testNamePattern '{{ testNamePattern }}' {{ foo }}",
+			)
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			err := substitution.ValidateTemplate(compiledTemplate)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("is invalid for a template with incorrect placeholders", func() {
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			compiledTemplate, compileErr := templating.CompileTemplate(
+				"npx jest --file '{{ wat }}' --testNamePattern '{{ foo }}'",
+			)
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			err := substitution.ValidateTemplate(compiledTemplate)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("is valid for a template with the file and testNamePattern placeholders", func() {
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			compiledTemplate, compileErr := templating.CompileTemplate(
+				"npx jest --file '{{ file }}' --testNamePattern '{{ testNamePattern }}'",
+			)
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			err := substitution.ValidateTemplate(compiledTemplate)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Substitutions", func() {
+		It("returns tests grouped by file", func() {
+			compiledTemplate, compileErr := templating.CompileTemplate(
+				"npx jest --file '{{ file }}' --testNamePattern '{{ testNamePattern }}'",
+			)
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			file1 := "path/to/file1.js"
+			file2 := "path/to/file with '.js"
+
+			lineage1 := []string{"name of describe", "test 'one' + 1"}
+			lineage2 := []string{"name of describe", "test 2"}
+			lineage3 := []string{"name of describe", "test 3"}
+
+			testResults := v1.TestResults{
+				Tests: []v1.Test{
+					{
+						Lineage:  lineage1,
+						Location: &v1.Location{File: file1},
+						Attempt:  v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)},
+					},
+					{
+						Lineage:  lineage1,
+						Location: &v1.Location{File: file2},
+						Attempt:  v1.TestAttempt{Status: v1.NewCanceledTestStatus()},
+					},
+					{
+						Lineage:  lineage2,
+						Location: &v1.Location{File: file1},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+					},
+					{
+						Lineage:  lineage2,
+						Location: &v1.Location{File: file2},
+						Attempt:  v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)},
+					},
+					{
+						Lineage:  lineage3,
+						Location: &v1.Location{File: file1},
+						Attempt:  v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()},
+					},
+					{
+						Lineage:  lineage3,
+						Location: &v1.Location{File: file2},
+						Attempt:  v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)},
+					},
+				},
+			}
+
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			substitutions, err := substitution.SubstitutionsFor(
+				compiledTemplate,
+				testResults,
+				func(_ v1.Test) bool { return true },
+			)
+			Expect(err).NotTo(HaveOccurred())
+			sort.SliceStable(substitutions, func(i int, j int) bool {
+				return substitutions[i]["file"] < substitutions[j]["file"]
+			})
+			Expect(substitutions).To(Equal(
+				[]map[string]string{
+					{
+						"file":            `path/to/file with '"'"'.js`,
+						"testNamePattern": `^name of describe test '"'"'one'"'"' \+ 1$`,
+					},
+					{
+						"file":            "path/to/file1.js",
+						"testNamePattern": `^name of describe test '"'"'one'"'"' \+ 1|name of describe test 2$`,
+					},
+				},
+			))
+		})
+
+		It("filters the tests with the provided function", func() {
+			compiledTemplate, compileErr := templating.CompileTemplate(
+				"npx jest --file '{{ file }}' --testNamePattern '{{ testNamePattern }}'",
+			)
+			Expect(compileErr).NotTo(HaveOccurred())
+
+			file1 := "path/to/file1.js"
+			file2 := "path/to/file with '.js"
+
+			lineage1 := []string{"name of describe", "test 'one' + 1"}
+			lineage2 := []string{"name of describe", "test 2"}
+			lineage3 := []string{"name of describe", "test 3"}
+
+			testResults := v1.TestResults{
+				Tests: []v1.Test{
+					{
+						Lineage:  lineage1,
+						Location: &v1.Location{File: file1},
+						Attempt:  v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)},
+					},
+					{
+						Lineage:  lineage1,
+						Location: &v1.Location{File: file2},
+						Attempt:  v1.TestAttempt{Status: v1.NewCanceledTestStatus()},
+					},
+					{
+						Lineage:  lineage2,
+						Location: &v1.Location{File: file1},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+					},
+					{
+						Lineage:  lineage2,
+						Location: &v1.Location{File: file2},
+						Attempt:  v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)},
+					},
+					{
+						Lineage:  lineage3,
+						Location: &v1.Location{File: file1},
+						Attempt:  v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()},
+					},
+					{
+						Lineage:  lineage3,
+						Location: &v1.Location{File: file2},
+						Attempt:  v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)},
+					},
+				},
+			}
+
+			substitution := targetedretries.JavaScriptVitestSubstitution{}
+			substitutions, err := substitution.SubstitutionsFor(
+				compiledTemplate,
+				testResults,
+				func(test v1.Test) bool { return test.Attempt.Status.Kind == v1.TestStatusFailed },
+			)
+			Expect(err).NotTo(HaveOccurred())
+			sort.SliceStable(substitutions, func(i int, j int) bool {
+				return substitutions[i]["file"] < substitutions[j]["file"]
+			})
+			Expect(substitutions).To(Equal(
+				[]map[string]string{
+					{
+						"file":            "path/to/file1.js",
+						"testNamePattern": `^name of describe test '"'"'one'"'"' \+ 1$`,
+					},
+				},
+			))
+		})
+	})
+})

--- a/internal/targetedretries/substitution.go
+++ b/internal/targetedretries/substitution.go
@@ -25,6 +25,7 @@ var SubstitutionsByFramework = map[v1.Framework]Substitution{
 	v1.JavaScriptJestFramework:       new(JavaScriptJestSubstitution),
 	v1.JavaScriptMochaFramework:      new(JavaScriptMochaSubstitution),
 	v1.JavaScriptPlaywrightFramework: new(JavaScriptPlaywrightSubstitution),
+	v1.JavaScriptVitestFramework:     new(JavaScriptVitestSubstitution),
 	v1.PHPUnitFramework:              new(PHPUnitSubstitution),
 	v1.PythonPytestFramework:         new(PythonPytestSubstitution),
 	v1.PythonUnitTestFramework:       new(PythonUnitTestSubstitution),


### PR DESCRIPTION
I neglected to add this in #77 because I haven't added a new framework in a bit!

With this change, those using Captain with Vitest can use Captain's retries as well.