### PR TITLE
Fix vitest parsing of times and durations

### DIFF
--- a/internal/parsing/javascript_vitest_parser.go
+++ b/internal/parsing/javascript_vitest_parser.go
@@ -50,7 +50,7 @@ type JavaScriptVitestTaskMeta struct{}
 // https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/vitest/src/node/reporters/json.ts#L30-L39
 type JavaScriptVitestAssertionResult struct {
 	AncestorTitles  []string                  `json:"ancestorTitles"`
-	Duration        *int                      `json:"duration"`
+	Duration        *float64                  `json:"duration"`
 	FailureMessages []string                  `json:"failureMessages"`
 	FullName        string                    `json:"fullName"`
 	Location        *JavaScriptVitestCallsite `json:"location"`
@@ -62,10 +62,10 @@ type JavaScriptVitestAssertionResult struct {
 // https://github.com/vitest-dev/vitest/blob/95f0203f27f5659f5758638edc4d1d90283801ac/packages/vitest/src/node/reporters/json.ts#L41-L50
 type JavaScriptVitestTestResult struct {
 	AssertionResults []JavaScriptVitestAssertionResult `json:"assertionResults"`
-	EndTime          int                               `json:"endTime"`
+	EndTime          float64                           `json:"endTime"`
 	Message          string                            `json:"message"`
 	Name             string                            `json:"name"`
-	StartTime        int                               `json:"startTime"`
+	StartTime        float64                           `json:"startTime"`
 	Status           string                            `json:"status"`
 }
 
@@ -81,7 +81,7 @@ type JavaScriptVitestTestResults struct {
 	NumTotalTests        int                          `json:"numTotalTests"`
 	NumTotalTestSuites   int                          `json:"numTotalTestSuites"`
 	Snapshot             *JavaScriptVitestSnapshot    `json:"snapshot"`
-	StartTime            int                          `json:"startTime"`
+	StartTime            float64                      `json:"startTime"`
 	Success              bool                         `json:"success"`
 	TestResults          []JavaScriptVitestTestResult `json:"testResults"`
 }
@@ -126,7 +126,7 @@ func (p JavaScriptVitestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 
 			var duration *time.Duration
 			if assertionResult.Duration != nil {
-				transformedDuration := time.Duration(*assertionResult.Duration * int(time.Millisecond))
+				transformedDuration := time.Duration(*assertionResult.Duration * float64(time.Millisecond))
 				duration = &transformedDuration
 			}
 

--- a/internal/parsing/javascript_vitest_parser_test.go
+++ b/internal/parsing/javascript_vitest_parser_test.go
@@ -61,7 +61,7 @@ var _ = Describe("JavaScriptVitestParser", func() {
 		})
 
 		It("parses a minimally failing test", func() {
-			durationInMilliseconds := 653
+			durationInMilliseconds := 653.0
 			jestResults := parsing.JavaScriptVitestTestResults{
 				Snapshot: &parsing.JavaScriptVitestSnapshot{},
 				TestResults: []parsing.JavaScriptVitestTestResult{
@@ -101,7 +101,7 @@ var _ = Describe("JavaScriptVitestParser", func() {
 		})
 
 		It("parses a maximally failing test", func() {
-			durationInMilliseconds := 653
+			durationInMilliseconds := 653.0
 			jestResults := parsing.JavaScriptVitestTestResults{
 				Snapshot: &parsing.JavaScriptVitestSnapshot{},
 				TestResults: []parsing.JavaScriptVitestTestResult{
@@ -148,7 +148,7 @@ var _ = Describe("JavaScriptVitestParser", func() {
 		})
 
 		It("parses passed statuses", func() {
-			durationInMilliseconds := 653
+			durationInMilliseconds := 653.0
 			jestResults := parsing.JavaScriptVitestTestResults{
 				Snapshot: &parsing.JavaScriptVitestSnapshot{},
 				TestResults: []parsing.JavaScriptVitestTestResult{


### PR DESCRIPTION
Vitest v2.1.1 appears to be using floats instead of ints for some of the times and durations. This code previously expected ints, but I've updated to float64 so it can parse both now.

<img width="433" alt="Screenshot 2024-09-22 at 5 31 44 PM" src="https://github.com/user-attachments/assets/e90fa7db-ec92-4e6f-bad4-3cbc52c6d0c4">
