### PR TITLE
Fix parsing `max-tests` option

### DIFF
--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -112,6 +112,10 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 						partitionTotal = provider.PartitionNodes.Total
 					}
 
+					if suiteConfig.Retries.MaxTests == "" && suiteConfig.Retries.MaxTestsLegacyName != "" {
+						suiteConfig.Retries.MaxTests = suiteConfig.Retries.MaxTestsLegacyName
+					}
+
 					runConfig = cli.RunConfig{
 						Args:                      args,
 						CloudOrganizationSlug:     "deep_link",

--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -29,9 +29,9 @@ type SuiteConfigResults struct {
 type SuiteConfigRetries struct {
 	Attempts                  int
 	Command                   string
-	FailFast                  bool `yaml:"fail-fast"`
-	FlakyAttempts             int  `yaml:"flaky-attempts"`
-	MaxTests                  string
+	FailFast                  bool     `yaml:"fail-fast"`
+	FlakyAttempts             int      `yaml:"flaky-attempts"`
+	MaxTests                  string   `yaml:"max-tests"`
 	PostRetryCommands         []string `yaml:"post-retry-commands"`
 	PreRetryCommands          []string `yaml:"pre-retry-commands"`
 	IntermediateArtifactsPath string   `yaml:"intermediate-artifacts-path"`

--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -32,6 +32,7 @@ type SuiteConfigRetries struct {
 	FailFast                  bool     `yaml:"fail-fast"`
 	FlakyAttempts             int      `yaml:"flaky-attempts"`
 	MaxTests                  string   `yaml:"max-tests"`
+	MaxTestsLegacyName        string   `yaml:"maxtests"`
 	PostRetryCommands         []string `yaml:"post-retry-commands"`
 	PreRetryCommands          []string `yaml:"pre-retry-commands"`
 	IntermediateArtifactsPath string   `yaml:"intermediate-artifacts-path"`

--- a/test/fixtures/integration-tests/captain-configs/junit-xml-reporter.printf-yaml
+++ b/test/fixtures/integration-tests/captain-configs/junit-xml-reporter.printf-yaml
@@ -23,7 +23,7 @@ test-suites:
       command: ""
       fail-fast: false
       flaky-attempts: 0
-      maxtests: ""
+      max-tests: ""
       post-retry-commands: []
       pre-retry-commands: []
       intermediate-artifacts-path: ""

--- a/test/fixtures/integration-tests/captain-configs/markdown-summary-reporter.printf-yaml
+++ b/test/fixtures/integration-tests/captain-configs/markdown-summary-reporter.printf-yaml
@@ -23,7 +23,7 @@ test-suites:
       command: ""
       fail-fast: false
       flaky-attempts: 0
-      maxtests: ""
+      max-tests: ""
       post-retry-commands: []
       pre-retry-commands: []
       intermediate-artifacts-path: ""

--- a/test/fixtures/integration-tests/captain-configs/rwx-v1-json-reporter.printf-yaml
+++ b/test/fixtures/integration-tests/captain-configs/rwx-v1-json-reporter.printf-yaml
@@ -23,7 +23,7 @@ test-suites:
       command: ""
       fail-fast: false
       flaky-attempts: 0
-      maxtests: ""
+      max-tests: ""
       post-retry-commands: []
       pre-retry-commands: []
       intermediate-artifacts-path: ""


### PR DESCRIPTION
The field was previously missing a YAML annotation, thus Go's YAML decoder expected the name to be `maxtests`, instead of the documented `max-tests`. 

This was reported in #85