### PR TITLE
Removes the warning about a configured retry command with no retries

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -56,11 +56,6 @@ func (rc RunConfig) Validate(log *zap.SugaredLogger) error {
 		)
 	}
 
-	if rc.RetryCommandTemplate != "" && !(rc.Retries > 0 || rc.FlakyRetries > 0) {
-		log.Warn("There is a retry command configured for this test suite, however the retry count is set to 0.")
-		log.Warn("Retries are disabled.")
-	}
-
 	if rc.MaxTestsToRetry != "" && !maxTestsToRetryRegexp.MatchString(rc.MaxTestsToRetry) {
 		return errors.NewConfigurationError(
 			"Unsupported --max-tests-to-retry value",


### PR DESCRIPTION
Now that you can use a retry command even when retries are disabled, this warning isn't necessary.

It's a little unfortunate that if you aren't taking advantage of "Retry failed tests" and you have a retry command configured but no retries, you won't get a notice that retries are disabled -- but at the same time, I think that is discoverable in other ways.