### PR TITLE
Initialize the run error when doing a failed tests retry

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -107,6 +107,9 @@ func (s Service) RunSuite(ctx context.Context, cfg RunConfig) (finalErr error) {
 			cfg.FlakyRetries = 1
 		}
 
+		// start with runErr in an error state to represent the error from the previous task attempt
+		runErr = errors.NewExecutionError(1, "test suite had failed tests")
+
 		largestGroupNumberPreviouslySeen := 0
 		for _, derivedFrom := range testResults.DerivedFrom {
 			if derivedFrom.GroupNumber > largestGroupNumberPreviouslySeen {


### PR DESCRIPTION
Without this, we might exit 0 even when there are test failures. 

I considered some other options for fixing this, but they're all breaking changes that might cause existing test suites to start failing. Ideally we would have a check at the end of execution to see if we have test failures or other errors and exit with a nonzero exit code, but today we just rely on the initial command's exit code being nonzero. Since a Mint retry doesn't have n initial command, we had no nonzero exit code to fall back on.