### PR TITLE
Only use the new test results when writing the output summary

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -809,7 +809,7 @@ func (s Service) reportTestResults(
 	}
 
 	if cfg.PrintSummary {
-		if err := reporting.WriteTextSummary(os.Stdout, testResults, reportingConfiguration); err != nil {
+		if err := reporting.WriteTextSummary(os.Stdout, newlyExecutedTestResults, reportingConfiguration); err != nil {
 			s.Log.Warnf("Unable to write text summary to stdout: %s", err.Error())
 		} else {
 			// Append an empty line to make output more readable

--- a/internal/reporting/text.go
+++ b/internal/reporting/text.go
@@ -27,7 +27,12 @@ func WriteTextSummary(file fs.File, testResults v1.TestResults, _ Configuration)
 		statuses[test.Attempt.Status.Kind] = tests
 	}
 
-	_, err := file.Write([]byte(fmt.Sprintf("\nCaptain detected a total of %d tests.\n", totalTests)))
+	pluralizeTests := "tests"
+	if totalTests == 1 {
+		pluralizeTests = "test"
+	}
+
+	_, err := file.Write([]byte(fmt.Sprintf("\nCaptain detected a total of %d %s.\n", totalTests, pluralizeTests)))
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
We felt things were a little unclear when we used the merged results.