### PR TITLE
Remove derivedFrom data when it is too big

### DIFF
--- a/internal/backend/local/client.go
+++ b/internal/backend/local/client.go
@@ -145,6 +145,7 @@ func (c Client) UpdateTestResults(
 	_ context.Context,
 	_ string,
 	testResults v1.TestResults,
+	_ bool,
 ) ([]backend.TestResultsUploadResult, error) {
 	if c.Timings == nil {
 		c.Timings = make(map[string]time.Duration)

--- a/internal/backend/local/client_test.go
+++ b/internal/backend/local/client_test.go
@@ -103,7 +103,7 @@ var _ = Describe("local backend client", func() {
 		})
 
 		JustBeforeEach(func() {
-			uploadResults, err = client.UpdateTestResults(context.Background(), suiteID, testResults)
+			uploadResults, err = client.UpdateTestResults(context.Background(), suiteID, testResults, true)
 		})
 
 		It("updates the timings file", func() {

--- a/internal/backend/remote/update_test_results_test.go
+++ b/internal/backend/remote/update_test_results_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("registers, uploads, and updates the test result in sequence", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))
@@ -132,7 +132,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("registers, uploads, and updates the test result in sequence", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))
@@ -148,7 +148,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("returns an error to the user", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
 			Expect(uploadResults).To(BeNil())
 			Expect(err).ToNot(Succeed())
 		})
@@ -188,7 +188,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("updates the upload status as failed", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(false))
@@ -225,7 +225,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("does not return an error to the user", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -11,7 +11,7 @@ import (
 type Client interface {
 	GetRunConfiguration(ctx context.Context, testSuiteIdentifier string) (RunConfiguration, error)
 	GetTestTimingManifest(context.Context, string) ([]testing.TestFileTiming, error)
-	UpdateTestResults(context.Context, string, v1.TestResults) ([]TestResultsUploadResult, error)
+	UpdateTestResults(context.Context, string, v1.TestResults, bool) ([]TestResultsUploadResult, error)
 }
 
 type QuarantinedTest struct {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -843,7 +843,7 @@ func (s Service) reportTestResults(
 		return nil, nil
 	}
 
-	result, err := s.API.UpdateTestResults(ctx, cfg.SuiteID, newlyExecutedTestResults)
+	result, err := s.API.UpdateTestResults(ctx, cfg.SuiteID, newlyExecutedTestResults, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update test results")
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -195,6 +195,7 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				_ v1.TestResults,
+				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 				return []backend.TestResultsUploadResult{{OriginalPaths: []string{testResultsFilePath}, Uploaded: true}}, nil
@@ -556,6 +557,7 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				testResults v1.TestResults,
+				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 
@@ -1032,6 +1034,7 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				_ v1.TestResults,
+				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 
@@ -1159,6 +1162,7 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				testResults v1.TestResults,
+				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -162,7 +162,7 @@ func (s Service) UpdateTestResults(
 		return nil, errors.WithStack(err)
 	}
 
-	result, err := s.API.UpdateTestResults(ctx, testSuiteID, *parsedResults)
+	result, err := s.API.UpdateTestResults(ctx, testSuiteID, *parsedResults, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update test results")
 	}

--- a/internal/mocks/backend.go
+++ b/internal/mocks/backend.go
@@ -13,7 +13,7 @@ import (
 type API struct {
 	MockGetRunConfiguration   func(context.Context, string) (backend.RunConfiguration, error)
 	MockGetTestTimingManifest func(context.Context, string) ([]testing.TestFileTiming, error)
-	MockUpdateTestResults     func(context.Context, string, v1.TestResults) (
+	MockUpdateTestResults     func(context.Context, string, v1.TestResults, bool) (
 		[]backend.TestResultsUploadResult, error,
 	)
 }
@@ -47,9 +47,10 @@ func (a *API) UpdateTestResults(
 	ctx context.Context,
 	testSuiteID string,
 	testResults v1.TestResults,
+	_ bool,
 ) ([]backend.TestResultsUploadResult, error) {
 	if a.MockUpdateTestResults != nil {
-		return a.MockUpdateTestResults(ctx, testSuiteID, testResults)
+		return a.MockUpdateTestResults(ctx, testSuiteID, testResults, true)
 	}
 
 	return nil, errors.NewInternalError("MockUpdateTestResults was not configured")


### PR DESCRIPTION
When test results are >= 5MB, we'll clear our derivedFrom since this is just ancillary data used for debugging.