### PR TITLE
Support negative globs for partition globs

### DIFF
--- a/internal/fs/local.go
+++ b/internal/fs/local.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	doublestar "github.com/bmatcuk/doublestar/v4"
 
@@ -52,14 +53,25 @@ func (l Local) Glob(pattern string) ([]string, error) {
 }
 
 func (l Local) GlobMany(patterns []string) ([]string, error) {
-	pathSet := make(map[string]struct{})
+	pathSet := make(map[string]bool)
 	for _, pattern := range patterns {
+		isNegation := false
+
+		if strings.HasPrefix(pattern, "!") {
+			isNegation = true
+			pattern = strings.TrimPrefix(pattern, "!")
+		}
+
 		expandedPaths, err := l.Glob(pattern)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		for _, filePath := range expandedPaths {
-			pathSet[filePath] = struct{}{}
+			if isNegation {
+				delete(pathSet, filePath)
+			} else {
+				pathSet[filePath] = true
+			}
 		}
 	}
 

--- a/internal/fs/local_test.go
+++ b/internal/fs/local_test.go
@@ -39,6 +39,22 @@ var _ = Describe("fs.GlobMany", func() {
 		}))
 	})
 
+	It("supports negation", func() {
+		fs := fs.Local{}
+		expandedPaths, _ := fs.GlobMany([]string{
+			"../../test/fixtures/integration-tests/partition/*_spec.rb",
+			"!../../test/fixtures/integration-tests/partition/a_spec.rb",
+			"!../../test/fixtures/integration-tests/partition/b_spec.rb",
+			"../../test/fixtures/integration-tests/partition/b_spec.rb",
+		})
+
+		Expect(expandedPaths).To(Equal([]string{
+			"../../test/fixtures/integration-tests/partition/b_spec.rb",
+			"../../test/fixtures/integration-tests/partition/c_spec.rb",
+			"../../test/fixtures/integration-tests/partition/d_spec.rb",
+		}))
+	})
+
 	It("expands multiple glob patterns only returning unique paths", func() {
 		fs := fs.Local{}
 		expandedPaths, _ := fs.GlobMany([]string{


### PR DESCRIPTION
This adds support for starting a partition glob with `!`, which will cause it to _negate_ the files matched -- i.e., if the file would otherwise be included, it is instead excluded. Globs are applied in the order they are specified, and the last matching glob wins for each particular file (i.e., if the last glob that matches is negative, the file will not be included; if the last glob is positive, it will be included).