### PR TITLE
Accept `yml` as a possible file extension for the config file

### DIFF
--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -138,7 +138,7 @@ func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 					"Captain found multiple configuration files in your environment: %s\n",
 					strings.Join(possibleConfigFilePaths, ", "),
 				),
-				"Please make sure only one config file is present in your environment or explicitly a "+
+				"Please make sure only one config file is present in your environment or explicitly specify "+
 					"one using the '--config-file' flag.",
 			)
 		}


### PR DESCRIPTION
With this change, captain will accept both `config.yaml` and `config.yml`. 

If both files are present, it will fail with the following error:
```
Error: Invalid configuration: Unable to identify configuration file

Captain found multiple configuration files in your environment:
/Users/foo/.captain/config.yaml,
/Users/foo/.captain/config.yml

Please make sure only one config file is present in your environment or
explicitly specify one using the '--config-file' flag.
```

Note that this doesn't apply to `flakes.yaml`, `quarantines.yaml`, and `timings.yaml` - we continue to expect the four-letter `yaml` extension for these files. This should be fine since they are not supplied by the user - instead these are artifacts of captain itself. 