### PR TITLE
Re-apply "Accept `yml` as possible config file extension" with added bug-fix

### DIFF
--- a/.mint/test.yaml
+++ b/.mint/test.yaml
@@ -72,3 +72,31 @@ tasks:
       RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
       RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
     run: ./captain run captain-cli-ginkgo
+
+  - key: test-alternate-filename
+    use: [build, ginkgo]
+    env: 
+      CGO_ENABLED: 0
+      LDFLAGS: -w -s -X github.com/rwx-research/captain-cli.Version=testing-${{ init.commit-sha }}
+      REPORT: true
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
+    run: |
+      mv .captain/config.yaml .captain/config.yml
+      ./captain run captain-cli-ginkgo
+
+  - key: test-without-config
+    use: [build, ginkgo]
+    env: 
+      CGO_ENABLED: 0
+      LDFLAGS: -w -s -X github.com/rwx-research/captain-cli.Version=testing-${{ init.commit-sha }}
+      REPORT: true
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN_STAGING: ${{ secrets.RWX_ACCESS_TOKEN_STAGING }} # used from within the tests against staging
+    run: |
+      rm -rf .captain
+      ./captain run \
+        --command "mage test" \
+        --fail-on-upload-error true \
+        --reporter github-step-summary \
+        --test-results report.xml

--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -156,9 +156,9 @@ func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 					)
 				}
 			}
+		} else {
+			cliArgs.RootCliArgs.configFilePath = possibleConfigFilePaths[0]
 		}
-
-		cliArgs.RootCliArgs.configFilePath = possibleConfigFilePaths[0]
 	}
 
 	if cliArgs.RootCliArgs.configFilePath != "" {

--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -61,11 +61,13 @@ func setConfigContext(cmd *cobra.Command, cfg Config) error {
 
 const (
 	captainDirectory    = ".captain"
-	configFileName      = "config.yaml"
+	configFileName      = "config"
 	flakesFileName      = "flakes.yaml"
 	quarantinesFileName = "quarantines.yaml"
 	timingsFileName     = "timings.yaml"
 )
+
+var configFileExtensions = []string{"yaml", "yml"}
 
 // findInParentDir starts at the current working directory and walk up to the root, trying
 // to find the specified fileName
@@ -114,17 +116,49 @@ func findInParentDir(fileName string) (string, error) {
 // Flags take precedence over all other options.
 func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 	if cliArgs.RootCliArgs.configFilePath == "" {
-		cliArgs.RootCliArgs.configFilePath, err = findInParentDir(filepath.Join(captainDirectory, configFileName))
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
+		possibleConfigFilePaths := make([]string, 0, 2)
+		errs := make([]error, 0, 2)
+
+		for _, extension := range configFileExtensions {
+			configFilePath, err := findInParentDir(
+				filepath.Join(captainDirectory, fmt.Sprintf("%s.%s", configFileName, extension)),
+			)
+
+			if err == nil {
+				possibleConfigFilePaths = append(possibleConfigFilePaths, configFilePath)
+			} else {
+				errs = append(errs, err)
+			}
+		}
+
+		if len(possibleConfigFilePaths) > 1 {
 			return cfg, errors.NewConfigurationError(
-				"Unable to read configuration file",
+				"Unable to identify configuration file",
 				fmt.Sprintf(
-					"The following system error occurred while attempting to read the config file at %q: %s",
-					cliArgs.RootCliArgs.configFilePath, err.Error(),
+					"Captain found multiple configuration files in your environment: %s\n",
+					strings.Join(possibleConfigFilePaths, ", "),
 				),
-				"Please make sure that Captain has the correct permissions to access the config file.",
+				"Please make sure only one config file is present in your environment or explicitly specify "+
+					"one using the '--config-file' flag.",
 			)
 		}
+
+		if len(possibleConfigFilePaths) == 0 {
+			for _, err := range errs {
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					return cfg, errors.NewConfigurationError(
+						"Unable to read configuration file",
+						fmt.Sprintf(
+							"The following system error occurred while attempting to read the config file at %q: %s",
+							cliArgs.RootCliArgs.configFilePath, err.Error(),
+						),
+						"Please make sure that Captain has the correct permissions to access the config file.",
+					)
+				}
+			}
+		}
+
+		cliArgs.RootCliArgs.configFilePath = possibleConfigFilePaths[0]
 	}
 
 	if cliArgs.RootCliArgs.configFilePath != "" {


### PR DESCRIPTION
It hadn't occurred to me that we can run captain without a config file. The previous PR (#93) introduced a panic when captain was called without one. 

I've added a test in Mint to check that we can still run Captain without the need of a config file.