### PR TITLE
Track the name of other errors in jest and vitest as the file location

### DIFF
--- a/internal/parsing/javascript_jest_parser.go
+++ b/internal/parsing/javascript_jest_parser.go
@@ -210,7 +210,14 @@ func (p JavaScriptJestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 		}
 
 		if !sawFailedTest && testResult.Status == "failed" {
-			otherErrors = append(otherErrors, v1.OtherError{Message: testResult.Message})
+			if len(testResult.Name) > 0 {
+				otherErrors = append(otherErrors, v1.OtherError{
+					Message:  testResult.Message,
+					Location: &v1.Location{File: testResult.Name},
+				})
+			} else {
+				otherErrors = append(otherErrors, v1.OtherError{Message: testResult.Message})
+			}
 		}
 	}
 

--- a/internal/parsing/javascript_jest_parser_test.go
+++ b/internal/parsing/javascript_jest_parser_test.go
@@ -408,7 +408,12 @@ var _ = Describe("JavaScriptJestParser", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testResults).NotTo(BeNil())
-			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Location: &v1.Location{File: "/some/path/to/name/of/file.js"}, Message: "the reason it failed"}))
+			Expect(testResults.OtherErrors[0]).To(Equal(
+				v1.OtherError{
+					Location: &v1.Location{File: "/some/path/to/name/of/file.js"},
+					Message:  "the reason it failed",
+				},
+			))
 			Expect(testResults.OtherErrors[1]).To(Equal(v1.OtherError{Message: "no name"}))
 			Expect(testResults.Tests[0]).NotTo(BeNil())
 		})

--- a/internal/parsing/javascript_jest_parser_test.go
+++ b/internal/parsing/javascript_jest_parser_test.go
@@ -388,6 +388,17 @@ var _ = Describe("JavaScriptJestParser", func() {
 							},
 						},
 					},
+					{
+						Name:    "",
+						Status:  "failed",
+						Message: "no name",
+						AssertionResults: []parsing.JavaScriptJestAssertionResult{
+							{
+								Status: "passed",
+								Title:  "title",
+							},
+						},
+					},
 				},
 			}
 			data, err := json.Marshal(jestResults)
@@ -397,7 +408,8 @@ var _ = Describe("JavaScriptJestParser", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testResults).NotTo(BeNil())
-			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Message: "the reason it failed"}))
+			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Location: &v1.Location{File: "/some/path/to/name/of/file.js"}, Message: "the reason it failed"}))
+			Expect(testResults.OtherErrors[1]).To(Equal(v1.OtherError{Message: "no name"}))
 			Expect(testResults.Tests[0]).NotTo(BeNil())
 		})
 

--- a/internal/parsing/javascript_vitest_parser.go
+++ b/internal/parsing/javascript_vitest_parser.go
@@ -165,7 +165,14 @@ func (p JavaScriptVitestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 		}
 
 		if !sawFailedTest && testResult.Status == "failed" {
-			otherErrors = append(otherErrors, v1.OtherError{Message: testResult.Message})
+			if len(testResult.Name) > 0 {
+				otherErrors = append(otherErrors, v1.OtherError{
+					Message:  testResult.Message,
+					Location: &v1.Location{File: testResult.Name},
+				})
+			} else {
+				otherErrors = append(otherErrors, v1.OtherError{Message: testResult.Message})
+			}
 		}
 	}
 

--- a/internal/parsing/javascript_vitest_parser_test.go
+++ b/internal/parsing/javascript_vitest_parser_test.go
@@ -315,7 +315,12 @@ var _ = Describe("JavaScriptVitestParser", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testResults).NotTo(BeNil())
-			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Location: &v1.Location{File: "/some/path/to/name/of/file.js"}, Message: "the reason it failed"}))
+			Expect(testResults.OtherErrors[0]).To(Equal(
+				v1.OtherError{
+					Location: &v1.Location{File: "/some/path/to/name/of/file.js"},
+					Message:  "the reason it failed",
+				},
+			))
 			Expect(testResults.OtherErrors[1]).To(Equal(v1.OtherError{Message: "no name"}))
 			Expect(testResults.Tests[0]).NotTo(BeNil())
 		})

--- a/internal/parsing/javascript_vitest_parser_test.go
+++ b/internal/parsing/javascript_vitest_parser_test.go
@@ -295,6 +295,17 @@ var _ = Describe("JavaScriptVitestParser", func() {
 							},
 						},
 					},
+					{
+						Name:    "",
+						Status:  "failed",
+						Message: "no name",
+						AssertionResults: []parsing.JavaScriptVitestAssertionResult{
+							{
+								Status: "passed",
+								Title:  "title",
+							},
+						},
+					},
 				},
 			}
 			data, err := json.Marshal(jestResults)
@@ -304,7 +315,8 @@ var _ = Describe("JavaScriptVitestParser", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testResults).NotTo(BeNil())
-			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Message: "the reason it failed"}))
+			Expect(testResults.OtherErrors[0]).To(Equal(v1.OtherError{Location: &v1.Location{File: "/some/path/to/name/of/file.js"}, Message: "the reason it failed"}))
+			Expect(testResults.OtherErrors[1]).To(Equal(v1.OtherError{Message: "no name"}))
 			Expect(testResults.Tests[0]).NotTo(BeNil())
 		})
 


### PR DESCRIPTION
We found that other errors had a pretty disappointing DX since it simply says something like "Test suite had no tests" without any information about which suite (_unless_ we grab this field)