### PR TITLE
Adds a round-robin option when partitioning

### DIFF
--- a/cmd/captain/config.go
+++ b/cmd/captain/config.go
@@ -206,7 +206,7 @@ func InitConfig(cmd *cobra.Command, cliArgs CliArgs) (cfg Config, err error) {
 
 	cfg = bindRootCmdFlags(cfg, cliArgs.RootCliArgs)
 	cfg = bindFrameworkFlags(cfg, cliArgs.frameworkParams, cliArgs.RootCliArgs.suiteID)
-	cfg = bindRunCmdFlags(cfg, cliArgs)
+	cfg = bindRunCmdFlags(cfg, cliArgs, cmd)
 
 	if err = setConfigContext(cmd, cfg); err != nil {
 		return cfg, errors.WithStack(err)

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -12,8 +12,9 @@ import (
 )
 
 type partitionArgs struct {
-	nodes     config.PartitionNodes
-	delimiter string
+	nodes      config.PartitionNodes
+	delimiter  string
+	roundRobin bool
 }
 
 func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
@@ -96,6 +97,7 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 				TestFilePaths:  args,
 				PartitionNodes: pArgs.nodes,
 				Delimiter:      pArgs.delimiter,
+				RoundRobin:     pArgs.roundRobin,
 			})
 			return errors.WithStack(err)
 		},
@@ -118,6 +120,14 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 	partitionCmd.Flags().StringVar(&pArgs.delimiter, "delimiter", defaultDelimiter,
 		"the delimiter used to separate partitioned files.\n"+
 			"It can also be set using the env var CAPTAIN_DELIMITER.")
+
+	partitionCmd.Flags().BoolVar(
+		&pArgs.roundRobin,
+		"round-robin",
+		false,
+		"Whether to naively round robin tests across partitions. When false, historical test timing data will be used to"+
+			"evenly balance the partitions.",
+	)
 
 	rootCmd.AddCommand(partitionCmd)
 	return nil

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -38,6 +38,7 @@ type RunConfig struct {
 	UploadResults               bool
 	PartitionCommandTemplate    string
 	PartitionConfig             PartitionConfig
+	PartitionRoundRobin         bool
 	WriteRetryFailedTestsAction bool
 	DidRetryFailedTestsInMint   bool
 }
@@ -149,6 +150,7 @@ type PartitionConfig struct {
 	TestFilePaths  []string
 	Delimiter      string
 	PartitionNodes config.PartitionNodes
+	RoundRobin     bool
 }
 
 func (pc PartitionConfig) Validate() error {

--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -40,9 +40,10 @@ type SuiteConfigRetries struct {
 }
 
 type SuiteConfigPartition struct {
-	Command   string
-	Globs     []string
-	Delimiter string
+	Command    string
+	Globs      []string
+	Delimiter  string
+	RoundRobin bool `yaml:"round-robin"`
 }
 
 // SuiteConfig holds options that can be customized per suite


### PR DESCRIPTION
We've run into some cases where round robin-ing is strictly better than using timing data, due to either bad test suite timing reports or due to inherit inconsistency in test timings. This adds the option to force partitioning to round robin instead of using the timings data.