### PR TITLE
Update to aws/assume-role 2.0.0

### DIFF
--- a/.mint/publish.yml
+++ b/.mint/publish.yml
@@ -55,7 +55,7 @@ tasks:
 
   - key: configure-aws
     use: aws-cli
-    call: aws/assume-role 1.1.4
+    call: aws/assume-role 2.0.0
     with:
       region: us-east-1
       role-to-assume: arn:aws:iam::152560469324:role/captain-cli-cd-through-mint


### PR DESCRIPTION
This failed during the last release. It looks like the work was done to update to 2.0.0 but we did not in fact update to 2.0.0