### PR TITLE
Don't swallow error messages when failing due to duplicate test IDs

### DIFF
--- a/cmd/captain/parse.go
+++ b/cmd/captain/parse.go
@@ -23,7 +23,12 @@ func configureParseCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 			if err != nil {
 				return errors.WithStack(err)
 			}
+
 			err = captain.Parse(cmd.Context(), artifacts)
+			if _, ok := errors.AsConfigurationError(err); !ok {
+				cmd.SilenceUsage = true
+			}
+
 			return errors.WithStack(err)
 		},
 	}

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -50,6 +50,10 @@ func (s Service) parse(filepaths []string, group int) (*v1.TestResults, error) {
 
 		results, err := parsing.Parse(fd, group, s.ParseConfig)
 		if err != nil {
+			if _, ok := errors.AsDuplicateTestIDError(err); ok {
+				return nil, errors.WithStack(err)
+			}
+
 			return nil, errors.NewInputError("Unable to parse %q with the available parsers", testResultsFilePath)
 		}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -171,3 +171,24 @@ func AsCacheError(err error) (CacheError, bool) {
 	ok := As(err, &e)
 	return e, ok
 }
+
+// DuplicateTestIDError is an error caused by duplicate test IDs
+type DuplicateTestIDError struct {
+	E error
+}
+
+func (e DuplicateTestIDError) Error() string {
+	return e.E.Error()
+}
+
+// DuplicateTestIDError returns a new DuplicateTestIDError
+func NewDuplicateTestIDError(msg string, a ...any) error {
+	return WithStack(DuplicateTestIDError{errors.Errorf(msg, a...)})
+}
+
+// AsDuplicateTestIDError checks whether the error is a duplicate test ID error
+func AsDuplicateTestIDError(err error) (DuplicateTestIDError, bool) {
+	var e DuplicateTestIDError
+	ok := As(err, &e)
+	return e, ok
+}

--- a/internal/parsing/parse.go
+++ b/internal/parsing/parse.go
@@ -153,7 +153,7 @@ func parseWith(file fs.File, parsers []Parser, groupNumber int, cfg Config) (*v1
 			"Please make sure test identifiers are unique.",
 		)
 		if cfg.FailOnDuplicateTestID {
-			return nil, errors.NewInputError("%s", duplicateTestIDWarningMsg)
+			return nil, errors.NewDuplicateTestIDError("%s", duplicateTestIDWarningMsg)
 		}
 		cfg.Logger.Warn(duplicateTestIDWarningMsg)
 	}


### PR DESCRIPTION
h/t @TAGraves 