### PR TITLE
Fix handling of Cucumber background declaration

### DIFF
--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses a skipped element
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses a skipped element
@@ -12,11 +12,11 @@
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 2,
+    "failed": 3,
     "pended": 0,
     "quarantined": 0,
     "skipped": 3,
-    "successful": 2,
+    "successful": 1,
     "timedOut": 0,
     "todo": 0
   },
@@ -182,7 +182,7 @@
         "line": 34
       },
       "attempt": {
-        "durationInNanoseconds": 282000,
+        "durationInNanoseconds": 141000,
         "meta": {
           "tags": [
             {
@@ -216,7 +216,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 49000,
+        "durationInNanoseconds": 178000,
         "meta": {
           "tags": [
             {
@@ -234,7 +234,8 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing after hook
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing after hook
@@ -6,17 +6,17 @@
   },
   "summary": {
     "status": {
-      "kind": "successful"
+      "kind": "failed"
     },
     "tests": 1,
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 0,
+    "failed": 1,
     "pended": 0,
     "quarantined": 0,
     "skipped": 0,
-    "successful": 1,
+    "successful": 0,
     "timedOut": 0,
     "todo": 0
   },
@@ -32,7 +32,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 49000,
+        "durationInNanoseconds": 178000,
         "meta": {
           "tags": [
             {
@@ -50,7 +50,8 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing before hook
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses an element with a failing before hook
@@ -32,7 +32,7 @@
         "line": 34
       },
       "attempt": {
-        "durationInNanoseconds": 282000,
+        "durationInNanoseconds": 141000,
         "meta": {
           "tags": [
             {

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file
@@ -12,11 +12,11 @@
     "otherErrors": 0,
     "retries": 0,
     "canceled": 0,
-    "failed": 2,
+    "failed": 3,
     "pended": 0,
     "quarantined": 0,
     "skipped": 3,
-    "successful": 2,
+    "successful": 1,
     "timedOut": 0,
     "todo": 0
   },
@@ -182,7 +182,7 @@
         "line": 34
       },
       "attempt": {
-        "durationInNanoseconds": 282000,
+        "durationInNanoseconds": 141000,
         "meta": {
           "tags": [
             {
@@ -216,7 +216,7 @@
         "line": 41
       },
       "attempt": {
-        "durationInNanoseconds": 49000,
+        "durationInNanoseconds": 178000,
         "meta": {
           "tags": [
             {
@@ -234,7 +234,8 @@
           ]
         },
         "status": {
-          "kind": "successful"
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `After'"
         }
       }
     }

--- a/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file that uses background
+++ b/internal/parsing/.snapshots/RubyCucumberParser Parse parses the sample file that uses background
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "Ruby",
+    "kind": "Cucumber"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 7,
+    "otherErrors": 0,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 3,
+    "pended": 0,
+    "quarantined": 0,
+    "skipped": 3,
+    "successful": 1,
+    "timedOut": 0,
+    "todo": 0
+  },
+  "tests": [
+    {
+      "name": "Background Sample \u003e A passing example",
+      "lineage": [
+        "Background Sample",
+        "A passing example"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 6
+      },
+      "attempt": {
+        "durationInNanoseconds": 584000,
+        "meta": {
+          "tags": null
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "Background Sample \u003e A failing example",
+      "lineage": [
+        "Background Sample",
+        "A failing example"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 12
+      },
+      "attempt": {
+        "durationInNanoseconds": 19087000,
+        "meta": {
+          "tags": [
+            {
+              "name": "@failing",
+              "line": 11
+            }
+          ]
+        },
+        "status": {
+          "kind": "failed",
+          "message": "\nexpected true\n     got false\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/steps.rb:17:in `\"some results should be there\"'\nfeatures/background.feature:15:in `some results should be there'"
+        }
+      }
+    },
+    {
+      "name": "Background Sample \u003e A pending example",
+      "lineage": [
+        "Background Sample",
+        "A pending example"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 17
+      },
+      "attempt": {
+        "durationInNanoseconds": 60000,
+        "meta": {
+          "tags": null
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Background Sample \u003e A skipped example",
+      "lineage": [
+        "Background Sample",
+        "A skipped example"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 22
+      },
+      "attempt": {
+        "durationInNanoseconds": 55000,
+        "meta": {
+          "tags": null
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Background Sample \u003e An undefined example",
+      "lineage": [
+        "Background Sample",
+        "An undefined example"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 27
+      },
+      "attempt": {
+        "durationInNanoseconds": 4000,
+        "meta": {
+          "tags": null
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "name": "Background Sample \u003e With a failing before hook",
+      "lineage": [
+        "Background Sample",
+        "With a failing before hook"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 33
+      },
+      "attempt": {
+        "durationInNanoseconds": 64000,
+        "meta": {
+          "tags": [
+            {
+              "name": "@failing_before_hook",
+              "line": 32
+            }
+          ]
+        },
+        "status": {
+          "kind": "failed",
+          "message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `Before'"
+        }
+      }
+    },
+    {
+      "name": "Background Sample \u003e With a failing after hook",
+      "lineage": [
+        "Background Sample",
+        "With a failing after hook"
+      ],
+      "location": {
+        "file": "features/background.feature",
+        "line": 39
+      },
+      "attempt": {
+        "durationInNanoseconds": 65000,
+        "meta": {
+          "tags": [
+            {
+              "name": "@failing_after_hook",
+              "line": 38
+            }
+          ]
+        },
+        "status": {
+          "kind": "failed",
+          "message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:33:in `After'"
+        }
+      }
+    }
+  ]
+}

--- a/internal/parsing/ruby_cucumber_parser.go
+++ b/internal/parsing/ruby_cucumber_parser.go
@@ -161,7 +161,7 @@ outer:
 				allResults = append(allResults, *step.Result)
 			}
 
-			for _, hook := range element.Before {
+			for _, hook := range element.After {
 				if hook.Result.Duration != nil {
 					duration += time.Duration(*hook.Result.Duration * int(time.Nanosecond))
 				}

--- a/internal/parsing/ruby_cucumber_parser.go
+++ b/internal/parsing/ruby_cucumber_parser.go
@@ -133,7 +133,23 @@ outer:
 	}
 
 	for _, feature := range cucumberFeatures {
-		for _, element := range feature.Elements {
+		for i := 0; i < len(feature.Elements); i++ {
+			element := feature.Elements[i]
+
+			// Merge Background into the next Scenario
+			if element.Type == "background" {
+				if i+1 >= len(feature.Elements) || feature.Elements[i+1].Type != "scenario" {
+					return nil, errors.NewInputError("Background must be followed by a Scenario in feature '%s'", feature.Name)
+				}
+
+				nextElement := &feature.Elements[i+1]
+
+				nextElement.Steps = append(element.Steps, nextElement.Steps...)
+				nextElement.Before = append(element.Before, nextElement.Before...)
+				nextElement.After = append(element.After, nextElement.After...)
+				continue
+			}
+
 			duration := time.Duration(0)
 			allResults := make([]RubyCucumberResult, 0)
 
@@ -200,7 +216,6 @@ outer:
 				}
 			}
 
-			element := element
 			location := v1.Location{File: feature.URI, Line: &element.Line}
 			attempt := v1.TestAttempt{
 				Duration: &duration,

--- a/internal/parsing/ruby_cucumber_parser_test.go
+++ b/internal/parsing/ruby_cucumber_parser_test.go
@@ -27,6 +27,17 @@ var _ = Describe("RubyCucumberParser", func() {
 			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
 		})
 
+		It("parses the sample file that uses background", func() {
+			fixture, err := os.Open("../../test/fixtures/cucumber/background_integration.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.RubyCucumberParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+			rwxJSON, err := json.MarshalIndent(testResults, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
+		})
+
 		It("parses a passing element", func() {
 			fixture, err := os.Open("../../test/fixtures/cucumber/passing.json")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/fixtures/cucumber/background_integration.json
+++ b/test/fixtures/cucumber/background_integration.json
@@ -1,0 +1,514 @@
+[
+  {
+    "id": "background-sample",
+    "uri": "features/background.feature",
+    "keyword": "Feature",
+    "name": "Background Sample",
+    "description": "",
+    "line": 1,
+    "elements": [
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 18000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;a-passing-example",
+        "keyword": "Scenario",
+        "name": "A passing example",
+        "description": "",
+        "line": 6,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this will pass",
+            "line": 7,
+            "match": {
+              "location": "features/step_definitions/steps.rb:5"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 3000
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 8,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "some results should be there",
+            "line": 9,
+            "match": {
+              "location": "features/step_definitions/steps.rb:16"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 561000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 3000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;a-failing-example",
+        "keyword": "Example",
+        "name": "A failing example",
+        "description": "",
+        "line": 12,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this will fail",
+            "line": 13,
+            "match": {
+              "location": "features/step_definitions/steps.rb:9"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 14,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "some results should be there",
+            "line": 15,
+            "match": {
+              "location": "features/step_definitions/steps.rb:16"
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "\nexpected true\n     got false\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/steps.rb:17:in `\"some results should be there\"'\nfeatures/background.feature:15:in `some results should be there'",
+              "duration": 19080000
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@failing",
+            "line": 11
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 12000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;a-pending-example",
+        "keyword": "Example",
+        "name": "A pending example",
+        "description": "",
+        "line": 17,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this is pending",
+            "line": 18,
+            "match": {
+              "location": "features/step_definitions/steps.rb:20"
+            },
+            "result": {
+              "status": "pending",
+              "error_message": "TODO (Cucumber::Pending)\n./features/step_definitions/steps.rb:21:in `\"this is pending\"'\nfeatures/background.feature:18:in `this is pending'",
+              "duration": 48000
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 19,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "nothing should happen",
+            "line": 20,
+            "match": {
+              "location": "features/background.feature:20"
+            },
+            "result": {
+              "status": "undefined"
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 5000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;a-skipped-example",
+        "keyword": "Example",
+        "name": "A skipped example",
+        "description": "",
+        "line": 22,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this is skipped",
+            "line": 23,
+            "match": {
+              "location": "features/step_definitions/steps.rb:24"
+            },
+            "result": {
+              "status": "skipped",
+              "duration": 50000
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 24,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "nothing should happen",
+            "line": 25,
+            "match": {
+              "location": "features/background.feature:25"
+            },
+            "result": {
+              "status": "undefined"
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 4000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;an-undefined-example",
+        "keyword": "Example",
+        "name": "An undefined example",
+        "description": "",
+        "line": 27,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this is undefined",
+            "line": 28,
+            "match": {
+              "location": "features/background.feature:28"
+            },
+            "result": {
+              "status": "undefined"
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 29,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "nothing should happen",
+            "line": 30,
+            "match": {
+              "location": "features/background.feature:30"
+            },
+            "result": {
+              "status": "undefined"
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ],
+        "before": [
+          {
+            "match": {
+              "location": "features/step_definitions/steps.rb:28"
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "failed in before hook (RuntimeError)\n./features/step_definitions/steps.rb:29:in `Before'",
+              "duration": 64000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;with-a-failing-before-hook",
+        "keyword": "Example",
+        "name": "With a failing before hook",
+        "description": "",
+        "line": 33,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this will pass",
+            "line": 34,
+            "match": {
+              "location": "features/step_definitions/steps.rb:5"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 35,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "some results should be there",
+            "line": 36,
+            "match": {
+              "location": "features/step_definitions/steps.rb:16"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@failing_before_hook",
+            "line": 32
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 3,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I share some background",
+            "line": 4,
+            "match": {
+              "location": "features/step_definitions/steps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 7000
+            }
+          }
+        ]
+      },
+      {
+        "id": "background-sample;with-a-failing-after-hook",
+        "keyword": "Example",
+        "name": "With a failing after hook",
+        "description": "",
+        "line": 39,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "this will pass",
+            "line": 40,
+            "match": {
+              "location": "features/step_definitions/steps.rb:5"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 3000
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I do an action",
+            "line": 41,
+            "match": {
+              "location": "features/step_definitions/steps.rb:13"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "some results should be there",
+            "line": 42,
+            "match": {
+              "location": "features/step_definitions/steps.rb:16"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 15000
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@failing_after_hook",
+            "line": 38
+          }
+        ],
+        "after": [
+          {
+            "match": {
+              "location": "features/step_definitions/steps.rb:32"
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "failed in after hook (RuntimeError)\n./features/step_definitions/steps.rb:33:in `After'",
+              "duration": 38000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
A feature can hoist up shared steps into a Background shared across all Scenarios.

From the cucumber json they are a top-level element. This results in creating duplicate rwx tests.

Instead, when we come across a Background, prepend its properties into the subsequent Scenario. This seems to indeed be how the [ruby json formatter works](https://github.com/cucumber/cucumber-ruby/blob/main/spec/cucumber/formatter/json_spec.rb#L454-L524). 

While in here noticed that we're not properly handling after hooks.

---

I took a look at the Javascript Cucumber parser to see if it had the same issue, but at least experimentally it seems to produce json with the Background already combined into the Scenario.