### PR TITLE
Load balance the test file timings across N workers instead of applying a bin packing algorithm

### DIFF
--- a/.mint/buildkite.yml
+++ b/.mint/buildkite.yml
@@ -1,6 +1,6 @@
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: code

--- a/.mint/buildkite.yml
+++ b/.mint/buildkite.yml
@@ -1,3 +1,7 @@
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: code
     call: mint/git-clone 1.6.1

--- a/.mint/ci.yml
+++ b/.mint/ci.yml
@@ -12,6 +12,10 @@ concurrency-pools:
     capacity: 1
     on-overflow: cancel-running
 
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: test
     call: ${{ run.mint-dir }}/test.yml

--- a/.mint/ci.yml
+++ b/.mint/ci.yml
@@ -14,7 +14,7 @@ concurrency-pools:
 
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: test

--- a/.mint/generate-backwards-compatibility-tests.yml
+++ b/.mint/generate-backwards-compatibility-tests.yml
@@ -1,6 +1,6 @@
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: code

--- a/.mint/generate-backwards-compatibility-tests.yml
+++ b/.mint/generate-backwards-compatibility-tests.yml
@@ -1,3 +1,7 @@
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: code
     call: mint/git-clone 1.6.1

--- a/.mint/lint.yml
+++ b/.mint/lint.yml
@@ -1,6 +1,6 @@
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: code

--- a/.mint/lint.yml
+++ b/.mint/lint.yml
@@ -1,3 +1,7 @@
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: code
     call: mint/git-clone 1.6.1

--- a/.mint/publish.yml
+++ b/.mint/publish.yml
@@ -1,3 +1,7 @@
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: github-cli
     call: github/install-cli 1.0.1

--- a/.mint/publish.yml
+++ b/.mint/publish.yml
@@ -1,6 +1,6 @@
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: github-cli

--- a/.mint/release.yml
+++ b/.mint/release.yml
@@ -5,7 +5,7 @@ concurrency-pools:
 
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: verify-kind

--- a/.mint/release.yml
+++ b/.mint/release.yml
@@ -3,6 +3,10 @@ concurrency-pools:
     capacity: 1
     on-overflow: queue
 
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: verify-kind
     if: ${{ init.kind == 'production' || init.kind == 'unstable' || init.kind == 'testing' }}

--- a/.mint/test-backwards-compatibility.yml
+++ b/.mint/test-backwards-compatibility.yml
@@ -5,7 +5,7 @@ concurrency-pools:
 
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: new-code

--- a/.mint/test-backwards-compatibility.yml
+++ b/.mint/test-backwards-compatibility.yml
@@ -3,6 +3,10 @@ concurrency-pools:
     capacity: 2
     on-overflow: queue
 
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: new-code
     call: mint/git-clone 1.6.1

--- a/.mint/test.yml
+++ b/.mint/test.yml
@@ -5,6 +5,10 @@ on:
       init:
         commit-sha: ${{ event.git.sha }}
 
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: code
     call: mint/git-clone 1.6.1

--- a/.mint/test.yml
+++ b/.mint/test.yml
@@ -7,7 +7,7 @@ on:
 
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: code

--- a/.mint/upload.yml
+++ b/.mint/upload.yml
@@ -1,6 +1,6 @@
 base:
   os: ubuntu 24.04
-  tag: 1.0
+  tag: 1.1
 
 tasks:
   - key: code

--- a/.mint/upload.yml
+++ b/.mint/upload.yml
@@ -1,3 +1,7 @@
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
 tasks:
   - key: code
     call: mint/git-clone 1.6.1

--- a/internal/cli/partition.go
+++ b/internal/cli/partition.go
@@ -124,15 +124,20 @@ func (s Service) calculatePartition(ctx context.Context, cfg PartitionConfig) (P
 }
 
 func partitionWithLeastRuntime(partitions []testing.TestPartition) testing.TestPartition {
-	partition := partitions[0]
+	selected := partitions[0]
 
-	for _, p := range partitions {
-		if p.Runtime < partition.Runtime {
-			partition = p
+	for _, candidate := range partitions {
+		if candidate.Runtime < selected.Runtime {
+			selected = candidate
+			continue
+		}
+
+		if candidate.Runtime == selected.Runtime && len(candidate.TestFilePaths) < len(selected.TestFilePaths) {
+			selected = candidate
 		}
 	}
 
-	return partition
+	return selected
 }
 
 func utilizedPartitionCount(partitions []testing.TestPartition) int {

--- a/internal/cli/partition.go
+++ b/internal/cli/partition.go
@@ -88,36 +88,27 @@ func (s Service) calculatePartition(ctx context.Context, cfg PartitionConfig) (P
 	}
 
 	partitions := make([]testing.TestPartition, 0)
-	var totalCapacity time.Duration
+	var totalRuntime time.Duration
 	for _, fileTimingMatch := range fileTimingMatches {
-		totalCapacity += fileTimingMatch.Duration()
+		totalRuntime += fileTimingMatch.Duration()
 	}
-	partitionCapacity := totalCapacity / time.Duration(cfg.PartitionNodes.Total)
+	partitionRuntime := totalRuntime / time.Duration(cfg.PartitionNodes.Total)
 
-	s.Log.Debugf("Total Capacity: %s", totalCapacity)
-	s.Log.Debugf("Target Partition Capacity: %s", partitionCapacity)
+	s.Log.Debugf("Total Runtime: %s", totalRuntime)
+	s.Log.Debugf("Target Partition Runtime: %s", partitionRuntime)
 
 	for i := 0; i < cfg.PartitionNodes.Total; i++ {
 		partitions = append(partitions, testing.TestPartition{
-			Index:             i,
-			TestFilePaths:     make([]string, 0),
-			RemainingCapacity: partitionCapacity,
-			TotalCapacity:     partitionCapacity,
+			Index:         i,
+			TestFilePaths: make([]string, 0),
+			Runtime:       time.Duration(0),
 		})
 	}
 
 	for _, fileTimingMatch := range fileTimingMatches {
-		fits, partition := partitionWithFirstFit(partitions, fileTimingMatch)
-		if fits {
-			partition = partition.Add(fileTimingMatch)
-			partitions[partition.Index] = partition
-			s.Log.Debugf("%s: Assigned %s using first fit strategy", partition, fileTimingMatch)
-			continue
-		}
-		partition = partitionWithMostRemainingCapacity(partitions)
-		partition = partition.Add(fileTimingMatch)
+		partition := partitionWithLeastRuntime(partitions).Add(fileTimingMatch)
 		partitions[partition.Index] = partition
-		s.Log.Debugf("%s: Assigned %s using most remaining capacity strategy", partition, fileTimingMatch)
+		s.Log.Debugf("%s: Assigned %s using least runtime strategy", partition, fileTimingMatch)
 	}
 
 	for i, testFilepath := range unmatchedFilepaths {
@@ -132,27 +123,16 @@ func (s Service) calculatePartition(ctx context.Context, cfg PartitionConfig) (P
 	}, nil
 }
 
-func partitionWithFirstFit(
-	partitions []testing.TestPartition,
-	fileTimingMatch testing.FileTimingMatch,
-) (fit bool, result testing.TestPartition) {
-	for _, p := range partitions {
-		if p.RemainingCapacity >= fileTimingMatch.Duration() {
-			return true, p
-		}
-	}
-	return false, result
-}
+func partitionWithLeastRuntime(partitions []testing.TestPartition) testing.TestPartition {
+	partition := partitions[0]
 
-func partitionWithMostRemainingCapacity(partitions []testing.TestPartition) testing.TestPartition {
-	result := partitions[0]
-	for i := 1; i < len(partitions); i++ {
-		p := partitions[i]
-		if p.RemainingCapacity > result.RemainingCapacity {
-			result = p
+	for _, p := range partitions {
+		if p.Runtime < partition.Runtime {
+			partition = p
 		}
 	}
-	return result
+
+	return partition
 }
 
 func utilizedPartitionCount(partitions []testing.TestPartition) int {

--- a/internal/cli/partition_test.go
+++ b/internal/cli/partition_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Partition", func() {
 			Expect(fetchedTimingManifest).To(BeTrue())
 		})
 
-		It("uses first fit strategy", func() {
+		It("uses least runtime strategy", func() {
 			_ = service.Partition(ctx, cfgWithGlob(1, 2, "*.test"))
 
 			assignments := make([]string, 0)
@@ -148,12 +148,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements([]string{
-				"Total Capacity: 10ns",
-				"Target Partition Capacity: 5ns",
-				"[PART 0 (80.00)]: Assigned 'a.test' (4ns) using first fit strategy",
-				"[PART 1 (60.00)]: Assigned 'b.test' (3ns) using first fit strategy",
-				"[PART 1 (100.00)]: Assigned 'c.test' (2ns) using first fit strategy",
-				"[PART 0 (100.00)]: Assigned 'd.test' (1ns) using first fit strategy",
+				"Total Runtime: 10ns",
+				"Target Partition Runtime: 5ns",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (3ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'c.test' (2ns) using least runtime strategy",
+				"[PART 0 (0.00s)]: Assigned 'd.test' (1ns) using least runtime strategy",
 			}))
 		})
 
@@ -197,12 +197,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(Equal([]string{
-				"Total Capacity: 0s",
-				"Target Partition Capacity: 0s",
-				"[PART 0 (NaN)]: Assigned 'a.test' using round robin strategy",
-				"[PART 1 (NaN)]: Assigned 'b.test' using round robin strategy",
-				"[PART 0 (NaN)]: Assigned 'c.test' using round robin strategy",
-				"[PART 1 (NaN)]: Assigned 'd.test' using round robin strategy",
+				"Total Runtime: 0s",
+				"Target Partition Runtime: 0s",
+				"[PART 0 (0.00s)]: Assigned 'a.test' using round robin strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' using round robin strategy",
+				"[PART 0 (0.00s)]: Assigned 'c.test' using round robin strategy",
+				"[PART 1 (0.00s)]: Assigned 'd.test' using round robin strategy",
 			}))
 		})
 
@@ -263,12 +263,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(Equal([]string{
-				"Total Capacity: 0s",
-				"Target Partition Capacity: 0s",
-				"[PART 0 (NaN)]: Assigned 'a.test' using round robin strategy",
-				"[PART 1 (NaN)]: Assigned 'b.test' using round robin strategy",
-				"[PART 0 (NaN)]: Assigned 'c.test' using round robin strategy",
-				"[PART 1 (NaN)]: Assigned 'd.test' using round robin strategy",
+				"Total Runtime: 0s",
+				"Target Partition Runtime: 0s",
+				"[PART 0 (0.00s)]: Assigned 'a.test' using round robin strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' using round robin strategy",
+				"[PART 0 (0.00s)]: Assigned 'c.test' using round robin strategy",
+				"[PART 1 (0.00s)]: Assigned 'd.test' using round robin strategy",
 			}))
 		})
 
@@ -324,7 +324,7 @@ var _ = Describe("Partition", func() {
 			Expect(fetchedTimingManifest).To(BeTrue())
 		})
 
-		It("uses first fit strategy, falling back to most remaining when it can't fit", func() {
+		It("uses least runtime strategy, falling back to most remaining when it can't fit", func() {
 			_ = service.Partition(ctx, cfgWithGlob(1, 2, "*.test"))
 
 			assignments := make([]string, 0)
@@ -332,12 +332,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements([]string{
-				"Total Capacity: 13ns",
-				"Target Partition Capacity: 6ns",
-				"[PART 0 (83.33)]: Assigned 'a.test' (5ns) using first fit strategy",
-				"[PART 1 (66.67)]: Assigned 'b.test' (4ns) using first fit strategy",
-				"[PART 1 (116.67)]: Assigned 'c.test' (3ns) using most remaining capacity strategy",
-				"[PART 0 (100.00)]: Assigned 'd.test' (1ns) using first fit strategy",
+				"Total Runtime: 13ns",
+				"Target Partition Runtime: 6ns",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (5ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'c.test' (3ns) using least runtime strategy",
+				"[PART 0 (0.00s)]: Assigned 'd.test' (1ns) using least runtime strategy",
 			}))
 		})
 
@@ -398,12 +398,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements([]string{
-				"Total Capacity: 13ns",
-				"Target Partition Capacity: 6ns",
-				"[PART 0 (100.00)]: Assigned 'a.test' (6ns) using first fit strategy",
-				"[PART 1 (66.67)]: Assigned 'b.test' (4ns) using first fit strategy",
-				"[PART 1 (116.67)]: Assigned 'c.test' (3ns) using most remaining capacity strategy",
-				"[PART 0 (100.00)]: Assigned 'd.test' using round robin strategy",
+				"Total Runtime: 13ns",
+				"Target Partition Runtime: 6ns",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (6ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'c.test' (3ns) using least runtime strategy",
+				"[PART 0 (0.00s)]: Assigned 'd.test' using round robin strategy",
 			}))
 		})
 
@@ -455,12 +455,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements([]string{
-				"Total Capacity: 10ns",
-				"Target Partition Capacity: 5ns",
-				"[PART 0 (80.00)]: Assigned 'd.test' (4ns) using first fit strategy",
-				"[PART 1 (60.00)]: Assigned 'c.test' (3ns) using first fit strategy",
-				"[PART 1 (100.00)]: Assigned 'b.test' (2ns) using first fit strategy",
-				"[PART 0 (100.00)]: Assigned 'a.test' (1ns) using first fit strategy",
+				"Total Runtime: 10ns",
+				"Target Partition Runtime: 5ns",
+				"[PART 0 (0.00s)]: Assigned 'd.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'c.test' (3ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (2ns) using least runtime strategy",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (1ns) using least runtime strategy",
 			}))
 		})
 	})
@@ -494,12 +494,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements([]string{
-				"Total Capacity: 10ns",
-				"Target Partition Capacity: 3ns",
-				"[PART 0 (133.33)]: Assigned 'a.test' (4ns) using most remaining capacity strategy",
-				"[PART 1 (100.00)]: Assigned 'b.test' (3ns) using first fit strategy",
-				"[PART 2 (66.67)]: Assigned 'c.test' (2ns) using first fit strategy",
-				"[PART 2 (100.00)]: Assigned 'd.test' (1ns) using first fit strategy",
+				"Total Runtime: 10ns",
+				"Target Partition Runtime: 3ns",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (3ns) using least runtime strategy",
+				"[PART 2 (0.00s)]: Assigned 'c.test' (2ns) using least runtime strategy",
+				"[PART 2 (0.00s)]: Assigned 'd.test' (1ns) using least runtime strategy",
 			}))
 		})
 	})
@@ -533,12 +533,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements([]string{
-				"Total Capacity: 10ns",
-				"Target Partition Capacity: 5ns",
-				"[PART 0 (80.00)]: Assigned 'a.test' (4ns) using first fit strategy",
-				"[PART 1 (60.00)]: Assigned 'b.test' (3ns) using first fit strategy",
-				"[PART 1 (100.00)]: Assigned 'c.test' (2ns) using first fit strategy",
-				"[PART 0 (100.00)]: Assigned 'd.test' (1ns) using first fit strategy",
+				"Total Runtime: 10ns",
+				"Target Partition Runtime: 5ns",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (3ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'c.test' (2ns) using least runtime strategy",
+				"[PART 0 (0.00s)]: Assigned 'd.test' (1ns) using least runtime strategy",
 			}))
 		})
 	})
@@ -576,12 +576,12 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements(
-				"Total Capacity: 10ns",
-				"Target Partition Capacity: 5ns",
-				"[PART 0 (80.00)]: Assigned 'a.test' (4ns) using first fit strategy",
-				"[PART 1 (60.00)]: Assigned 'b.test' (3ns) using first fit strategy",
-				"[PART 1 (100.00)]: Assigned 'c.test' (2ns) using first fit strategy",
-				"[PART 0 (100.00)]: Assigned 'd.test' (1ns) using first fit strategy",
+				"Total Runtime: 10ns",
+				"Target Partition Runtime: 5ns",
+				"[PART 0 (0.00s)]: Assigned 'a.test' (4ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'b.test' (3ns) using least runtime strategy",
+				"[PART 1 (0.00s)]: Assigned 'c.test' (2ns) using least runtime strategy",
+				"[PART 0 (0.00s)]: Assigned 'd.test' (1ns) using least runtime strategy",
 			))
 		})
 

--- a/internal/testing/test_partition.go
+++ b/internal/testing/test_partition.go
@@ -6,15 +6,14 @@ import (
 )
 
 type TestPartition struct {
-	RemainingCapacity time.Duration
-	Index             int
-	TestFilePaths     []string
-	TotalCapacity     time.Duration
+	Index         int
+	Runtime       time.Duration
+	TestFilePaths []string
 }
 
 func (p TestPartition) Add(matchedTiming FileTimingMatch) TestPartition {
 	p = p.AddFilePath(matchedTiming.ClientFilepath)
-	p.RemainingCapacity -= matchedTiming.Duration()
+	p.Runtime += matchedTiming.Duration()
 	return p
 }
 
@@ -24,6 +23,5 @@ func (p TestPartition) AddFilePath(filepath string) TestPartition {
 }
 
 func (p TestPartition) String() string {
-	percent := 100 - (float64(p.RemainingCapacity) / float64(p.TotalCapacity) * 100)
-	return fmt.Sprintf("[PART %d (%0.2f)]", p.Index, percent)
+	return fmt.Sprintf("[PART %d (%0.2fs)]", p.Index, p.Runtime.Seconds())
 }

--- a/internal/testing/test_partition_test.go
+++ b/internal/testing/test_partition_test.go
@@ -10,12 +10,11 @@ import (
 )
 
 var _ = Describe("TestPartition.Add", func() {
-	It("appends matching test file path and updates remaining capacity", func() {
+	It("appends matching test file path and updates the runtime", func() {
 		partition := testing.TestPartition{
-			RemainingCapacity: time.Duration(10),
-			Index:             0,
-			TestFilePaths:     []string{},
-			TotalCapacity:     time.Duration(100),
+			Index:         0,
+			TestFilePaths: []string{},
+			Runtime:       time.Duration(10),
 		}
 		testFileTiming := testing.TestFileTiming{
 			Filepath: "./spec/a_spec.rb",
@@ -27,24 +26,22 @@ var _ = Describe("TestPartition.Add", func() {
 		}
 		partition = partition.Add(fileTimingMatch)
 
-		Expect(partition.RemainingCapacity).To(Equal(time.Duration(8)))
+		Expect(partition.Runtime).To(Equal(time.Duration(12)))
 		Expect(partition.TestFilePaths).To(Equal([]string{"spec/a_spec.rb"}))
 	})
 })
 
 var _ = Describe("TestPartition.AddFilePath", func() {
-	It("appends filepath to the but doesn't update remaining capacity", func() {
-		remainingCapacity := time.Duration(10)
+	It("appends filepath to the but doesn't update the runtime", func() {
 		clientTestFilepath := "spec/a_spec.rb"
 		partition := testing.TestPartition{
-			RemainingCapacity: remainingCapacity,
-			Index:             0,
-			TestFilePaths:     []string{},
-			TotalCapacity:     time.Duration(100),
+			Index:         0,
+			TestFilePaths: []string{},
+			Runtime:       time.Duration(10),
 		}
 		partition = partition.AddFilePath(clientTestFilepath)
 
-		Expect(partition.RemainingCapacity).To(Equal(remainingCapacity))
+		Expect(partition.Runtime).To(Equal(time.Duration(10)))
 		Expect(partition.TestFilePaths).To(Equal([]string{clientTestFilepath}))
 	})
 })


### PR DESCRIPTION
Targeting total runtime / partitions for bin capacity can lead to many scenarios where you have empty bins. This is not ideal for test partitioning because we want to distribute the tests across a specified number of workers as evenly as possible. Notably, we _don't_ want to try to fill bins as full as possible leaving any empty. 

Instead of bin packing, this problem more closely relates to load balancing. A simple "shortest queue first" approach works very well and ensures all partitions get tests (so long as there are more files than partitions). In this case, queue depth is the total runtime we've added so far.