### PR TITLE
Add missed base configuration in dynamic embedded runs

### DIFF
--- a/.mint/release.yml
+++ b/.mint/release.yml
@@ -20,6 +20,10 @@ tasks:
     run: |
       if [[ "${{ init.kind }}" == "production" ]]; then
         cat << EOF | tee extract-version-details.yml
+          base:
+            os: ubuntu 24.04
+            tag: 1.1
+
           tasks:
             - key: extract-version-details
               run: |
@@ -30,6 +34,10 @@ tasks:
       fi
       if [[ "${{ init.kind }}" == "unstable" ]]; then
         cat << EOF | tee extract-version-details.yml
+          base:
+            os: ubuntu 24.04
+            tag: 1.1
+
           tasks:
             - key: extract-version-details
               run: |
@@ -39,6 +47,10 @@ tasks:
       fi
       if [[ "${{ init.kind }}" == "testing" ]]; then
         cat << EOF | tee extract-version-details.yml
+          base:
+            os: ubuntu 24.04
+            tag: 1.1
+
           tasks:
             - key: extract-version-details
               run: |


### PR DESCRIPTION
I missed these since they don't run on pull requests