### PR TITLE
Allow passing through additional args even when partitioning

### DIFF
--- a/internal/cli/run_command.go
+++ b/internal/cli/run_command.go
@@ -73,7 +73,7 @@ func (s Service) makeRunCommand(ctx context.Context, cfg RunConfig) (RunCommand,
 	}
 	partitionCommand := compiledPartitionTemplate.Substitute(substitutionValueLookup)
 
-	commandArgs, err := commandArgs(partitionCommand, nil)
+	commandArgs, err := commandArgs(partitionCommand, cfg.Args)
 	if err != nil {
 		return RunCommand{}, err
 	}


### PR DESCRIPTION
You might want to pass through additional flags like `--debug` or `--runInBand` even when using your partition command. This adds support for that.