### PR TITLE
Produce custom mint tip informing user of missing retry command

### DIFF
--- a/internal/mint/retry_actions.go
+++ b/internal/mint/retry_actions.go
@@ -25,6 +25,23 @@ func DidRetryFailedTests() bool {
 	return os.Getenv(retryActionEnv) == "true"
 }
 
+func WriteConfigureRetryCommandTip(fs fs.FileSystem) error {
+	var err error
+
+	tipFile, err := fs.Create(filepath.Join(os.Getenv("MINT_TIPS"), "configure-captain-retry-command"))
+	if err != nil {
+		return errors.Wrap(err, "unable to create tip file")
+	}
+	defer tipFile.Close()
+
+	_, err = tipFile.Write([]byte("Configure Captain retry command to enable Mint to retry only failed tests."))
+	if err != nil {
+		return errors.Wrap(err, "unable to write to tip file")
+	}
+
+	return nil
+}
+
 func WriteRetryFailedTestsAction(fs fs.FileSystem, testResults v1.TestResults) error {
 	var err error
 


### PR DESCRIPTION
- [x] ~This PR is blocked on a mint release going out to the daily release channel.~

![image](https://github.com/user-attachments/assets/a05873f2-3bd9-4159-bbc3-3f651577ae30)

Tested in mint using a pre-release.

Also, simulated mint locally using:

```
MINT="true" MINT_ACTOR="tony" MINT_RUN_URL="fake" MINT_TASK_URL="fake" MINT_RUN_ID="fake" MINT_TASK_ID="fake" MINT_TASK_ATTEMPT_NUMBER="fake" MINT_RUN_TITLE="fake" MINT_GIT_REPOSITORY_URL="fake" MINT_GIT_REPOSITORY_NAME="fake" MINT_GIT_COMMIT_MESSAGE="fake" MINT_GIT_COMMIT_SHA="fake" MINT_GIT_REF="fake" MINT_GIT_REF_NAME="fake" MINT_RETRY_ACTIONS="./tmp/mint-retry-actions" MINT_ERRORS="./tmp/mint-errors" MINT_TIPS="./tmp/tips" captain run fake-suite
```

---

Previously we would always make a mint retry action, even if we knew we couldn't successfully retry.

This would then cause UI to show the option to retry failures even though clicking it would always fail.

Instead, have captain produce a custom tip informing the user about the feature, presenting only viable retry actions.