### PR TITLE
Add trim prefix to partition config

### DIFF
--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -135,7 +135,7 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		&pArgs.omitPrefix,
 		"omit-prefix",
 		"",
-		"A string prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
+		"A prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
 	)
 
 	rootCmd.AddCommand(partitionCmd)

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -15,6 +15,7 @@ type partitionArgs struct {
 	nodes      config.PartitionNodes
 	delimiter  string
 	roundRobin bool
+	omitPrefix string
 }
 
 func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
@@ -98,6 +99,7 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 				PartitionNodes: pArgs.nodes,
 				Delimiter:      pArgs.delimiter,
 				RoundRobin:     pArgs.roundRobin,
+				OmitPrefix:     pArgs.omitPrefix,
 			})
 			return errors.WithStack(err)
 		},
@@ -127,6 +129,13 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 		false,
 		"Whether to naively round robin tests across partitions. When false, historical test timing data will be used to"+
 			" evenly balance the partitions.",
+	)
+
+	partitionCmd.Flags().StringVar(
+		&pArgs.omitPrefix,
+		"omit-prefix",
+		"",
+		"A string prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
 	)
 
 	rootCmd.AddCommand(partitionCmd)

--- a/cmd/captain/partition.go
+++ b/cmd/captain/partition.go
@@ -15,7 +15,7 @@ type partitionArgs struct {
 	nodes      config.PartitionNodes
 	delimiter  string
 	roundRobin bool
-	omitPrefix string
+	trimPrefix string
 }
 
 func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
@@ -99,7 +99,7 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 				PartitionNodes: pArgs.nodes,
 				Delimiter:      pArgs.delimiter,
 				RoundRobin:     pArgs.roundRobin,
-				OmitPrefix:     pArgs.omitPrefix,
+				TrimPrefix:     pArgs.trimPrefix,
 			})
 			return errors.WithStack(err)
 		},
@@ -132,10 +132,10 @@ func configurePartitionCmd(rootCmd *cobra.Command, cliArgs *CliArgs) error {
 	)
 
 	partitionCmd.Flags().StringVar(
-		&pArgs.omitPrefix,
-		"omit-prefix",
+		&pArgs.trimPrefix,
+		"trim-prefix",
 		"",
-		"A prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
+		"A prefix to trim from the beginning of local test file paths when comparing them to historical timing data.",
 	)
 
 	rootCmd.AddCommand(partitionCmd)

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -45,7 +45,7 @@ type CliArgs struct {
 	partitionCommandTemplate  string
 	partitionGlobs            []string
 	partitionRoundRobin       bool
-	partitionOmitPrefix       string
+	partitionTrimPrefix       string
 }
 
 func createRunCmd(cliArgs *CliArgs) *cobra.Command {
@@ -153,10 +153,10 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 							},
 							Delimiter:  suiteConfig.Partition.Delimiter,
 							RoundRobin: suiteConfig.Partition.RoundRobin,
-							OmitPrefix: suiteConfig.Partition.OmitPrefix,
+							TrimPrefix: suiteConfig.Partition.TrimPrefix,
 						},
 						PartitionRoundRobin:         suiteConfig.Partition.RoundRobin,
-						PartitionOmitPrefix:         suiteConfig.Partition.OmitPrefix,
+						PartitionTrimPrefix:         suiteConfig.Partition.TrimPrefix,
 						WriteRetryFailedTestsAction: mint.IsMint(),
 						DidRetryFailedTestsInMint:   mint.DidRetryFailedTests(),
 					}
@@ -334,10 +334,10 @@ func AddFlags(runCmd *cobra.Command, cliArgs *CliArgs) error {
 	)
 
 	runCmd.Flags().StringVar(
-		&cliArgs.partitionOmitPrefix,
-		"partition-omit-prefix",
+		&cliArgs.partitionTrimPrefix,
+		"partition-trim-prefix",
 		"",
-		"A prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
+		"A prefix to trim from the beginning of local test file paths when comparing them to historical timing data.",
 	)
 
 	runCmd.Flags().StringVar(&cliArgs.RootCliArgs.githubJobName, "github-job-name", "",
@@ -482,8 +482,8 @@ func bindRunCmdFlags(cfg Config, cliArgs CliArgs, cmd *cobra.Command) Config {
 			suiteConfig.Partition.RoundRobin = cliArgs.partitionRoundRobin
 		}
 
-		if cmd.Flags().Changed("partition-round-robin") {
-			suiteConfig.Partition.OmitPrefix = cliArgs.partitionOmitPrefix
+		if cmd.Flags().Changed("partition-trim-prefix") {
+			suiteConfig.Partition.TrimPrefix = cliArgs.partitionTrimPrefix
 		}
 
 		cfg.TestSuites[cliArgs.RootCliArgs.suiteID] = suiteConfig

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -45,6 +45,7 @@ type CliArgs struct {
 	partitionCommandTemplate  string
 	partitionGlobs            []string
 	partitionRoundRobin       bool
+	partitionOmitPrefix       string
 }
 
 func createRunCmd(cliArgs *CliArgs) *cobra.Command {
@@ -152,8 +153,10 @@ func createRunCmd(cliArgs *CliArgs) *cobra.Command {
 							},
 							Delimiter:  suiteConfig.Partition.Delimiter,
 							RoundRobin: suiteConfig.Partition.RoundRobin,
+							OmitPrefix: suiteConfig.Partition.OmitPrefix,
 						},
 						PartitionRoundRobin:         suiteConfig.Partition.RoundRobin,
+						PartitionOmitPrefix:         suiteConfig.Partition.OmitPrefix,
 						WriteRetryFailedTestsAction: mint.IsMint(),
 						DidRetryFailedTestsInMint:   mint.DidRetryFailedTests(),
 					}
@@ -330,6 +333,13 @@ func AddFlags(runCmd *cobra.Command, cliArgs *CliArgs) error {
 			" evenly balance the partitions.",
 	)
 
+	runCmd.Flags().StringVar(
+		&cliArgs.partitionOmitPrefix,
+		"partition-omit-prefix",
+		"",
+		"A string prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
+	)
+
 	runCmd.Flags().StringVar(&cliArgs.RootCliArgs.githubJobName, "github-job-name", "",
 		"the name of the current Github Job")
 	if err := runCmd.Flags().MarkDeprecated("github-job-name", "the value will be ignored"); err != nil {
@@ -470,6 +480,10 @@ func bindRunCmdFlags(cfg Config, cliArgs CliArgs, cmd *cobra.Command) Config {
 
 		if cmd.Flags().Changed("partition-round-robin") {
 			suiteConfig.Partition.RoundRobin = cliArgs.partitionRoundRobin
+		}
+
+		if cmd.Flags().Changed("partition-round-robin") {
+			suiteConfig.Partition.OmitPrefix = cliArgs.partitionOmitPrefix
 		}
 
 		cfg.TestSuites[cliArgs.RootCliArgs.suiteID] = suiteConfig

--- a/cmd/captain/run.go
+++ b/cmd/captain/run.go
@@ -337,7 +337,7 @@ func AddFlags(runCmd *cobra.Command, cliArgs *CliArgs) error {
 		&cliArgs.partitionOmitPrefix,
 		"partition-omit-prefix",
 		"",
-		"A string prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
+		"A prefix to remove from the beginning of local test file paths when comparing them to historical timing data.",
 	)
 
 	runCmd.Flags().StringVar(&cliArgs.RootCliArgs.githubJobName, "github-job-name", "",

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -39,7 +39,7 @@ type RunConfig struct {
 	PartitionCommandTemplate    string
 	PartitionConfig             PartitionConfig
 	PartitionRoundRobin         bool
-	PartitionOmitPrefix         string
+	PartitionTrimPrefix         string
 	WriteRetryFailedTestsAction bool
 	DidRetryFailedTestsInMint   bool
 }
@@ -152,7 +152,7 @@ type PartitionConfig struct {
 	Delimiter      string
 	PartitionNodes config.PartitionNodes
 	RoundRobin     bool
-	OmitPrefix     string
+	TrimPrefix     string
 }
 
 func (pc PartitionConfig) Validate() error {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -39,6 +39,7 @@ type RunConfig struct {
 	PartitionCommandTemplate    string
 	PartitionConfig             PartitionConfig
 	PartitionRoundRobin         bool
+	PartitionOmitPrefix         string
 	WriteRetryFailedTestsAction bool
 	DidRetryFailedTestsInMint   bool
 }
@@ -151,6 +152,7 @@ type PartitionConfig struct {
 	Delimiter      string
 	PartitionNodes config.PartitionNodes
 	RoundRobin     bool
+	OmitPrefix     string
 }
 
 func (pc PartitionConfig) Validate() error {

--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -44,6 +44,7 @@ type SuiteConfigPartition struct {
 	Globs      []string
 	Delimiter  string
 	RoundRobin bool `yaml:"round-robin"`
+	OmitPrefix string
 }
 
 // SuiteConfig holds options that can be customized per suite

--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -44,7 +44,7 @@ type SuiteConfigPartition struct {
 	Globs      []string
 	Delimiter  string
 	RoundRobin bool   `yaml:"round-robin"`
-	OmitPrefix string `yaml:"omit-prefix"`
+	TrimPrefix string `yaml:"trim-prefix"`
 }
 
 // SuiteConfig holds options that can be customized per suite

--- a/internal/cli/config_file.go
+++ b/internal/cli/config_file.go
@@ -43,8 +43,8 @@ type SuiteConfigPartition struct {
 	Command    string
 	Globs      []string
 	Delimiter  string
-	RoundRobin bool `yaml:"round-robin"`
-	OmitPrefix string
+	RoundRobin bool   `yaml:"round-robin"`
+	OmitPrefix string `yaml:"omit-prefix"`
 }
 
 // SuiteConfig holds options that can be customized per suite

--- a/internal/cli/partition.go
+++ b/internal/cli/partition.go
@@ -46,7 +46,13 @@ func (s Service) calculatePartition(ctx context.Context, cfg PartitionConfig) (P
 		for _, clientTestFile := range testFilePaths {
 			match := false
 			var fileTimingMatch testing.FileTimingMatch
-			clientExpandedFilepath, err := filepath.Abs(clientTestFile)
+			clientExpandedFilepath := clientTestFile
+			if cfg.OmitPrefix != "" {
+				trimmedClientExpandedFilepath := strings.TrimPrefix(clientTestFile, cfg.OmitPrefix)
+				s.Log.Debugf("Omitting prefix '%s' from '%s' resulting in '%s' for comparison", cfg.OmitPrefix, clientTestFile, trimmedClientExpandedFilepath)
+				clientExpandedFilepath = trimmedClientExpandedFilepath
+			}
+			clientExpandedFilepath, err = filepath.Abs(clientExpandedFilepath)
 			if err != nil {
 				s.Log.Warnf("failed to expand path of test file: %s", clientTestFile)
 				unmatchedFilepaths = append(unmatchedFilepaths, clientTestFile)

--- a/internal/cli/partition.go
+++ b/internal/cli/partition.go
@@ -49,7 +49,12 @@ func (s Service) calculatePartition(ctx context.Context, cfg PartitionConfig) (P
 			clientExpandedFilepath := clientTestFile
 			if cfg.OmitPrefix != "" {
 				trimmedClientExpandedFilepath := strings.TrimPrefix(clientTestFile, cfg.OmitPrefix)
-				s.Log.Debugf("Omitting prefix '%s' from '%s' resulting in '%s' for comparison", cfg.OmitPrefix, clientTestFile, trimmedClientExpandedFilepath)
+				s.Log.Debugf(
+					"Omitting prefix '%s' from '%s' resulting in '%s' for comparison",
+					cfg.OmitPrefix,
+					clientTestFile,
+					trimmedClientExpandedFilepath,
+				)
 				clientExpandedFilepath = trimmedClientExpandedFilepath
 			}
 			clientExpandedFilepath, err = filepath.Abs(clientExpandedFilepath)

--- a/internal/cli/partition.go
+++ b/internal/cli/partition.go
@@ -47,11 +47,11 @@ func (s Service) calculatePartition(ctx context.Context, cfg PartitionConfig) (P
 			match := false
 			var fileTimingMatch testing.FileTimingMatch
 			clientExpandedFilepath := clientTestFile
-			if cfg.OmitPrefix != "" {
-				trimmedClientExpandedFilepath := strings.TrimPrefix(clientTestFile, cfg.OmitPrefix)
+			if cfg.TrimPrefix != "" {
+				trimmedClientExpandedFilepath := strings.TrimPrefix(clientTestFile, cfg.TrimPrefix)
 				s.Log.Debugf(
-					"Omitting prefix '%s' from '%s' resulting in '%s' for comparison",
-					cfg.OmitPrefix,
+					"Trimming prefix '%s' from '%s' resulting in '%s' for comparison",
+					cfg.TrimPrefix,
 					clientTestFile,
 					trimmedClientExpandedFilepath,
 				)

--- a/internal/cli/partition_test.go
+++ b/internal/cli/partition_test.go
@@ -20,7 +20,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func cfgWithArgs(index int, total int, args []string, delimiter string, roundRobin bool, omitPrefix string) cli.PartitionConfig {
+func cfgWithArgs(
+	index int,
+	total int,
+	args []string,
+	delimiter string,
+	roundRobin bool,
+	omitPrefix string,
+) cli.PartitionConfig {
 	return cli.PartitionConfig{
 		TestFilePaths: args,
 		PartitionNodes: config.PartitionNodes{

--- a/internal/cli/partition_test.go
+++ b/internal/cli/partition_test.go
@@ -26,7 +26,7 @@ func cfgWithArgs(
 	args []string,
 	delimiter string,
 	roundRobin bool,
-	omitPrefix string,
+	trimPrefix string,
 ) cli.PartitionConfig {
 	return cli.PartitionConfig{
 		TestFilePaths: args,
@@ -37,7 +37,7 @@ func cfgWithArgs(
 		SuiteID:    "captain-cli-test",
 		Delimiter:  delimiter,
 		RoundRobin: roundRobin,
-		OmitPrefix: omitPrefix,
+		TrimPrefix: trimPrefix,
 	}
 }
 
@@ -693,7 +693,7 @@ var _ = Describe("Partition", func() {
 			service.FileSystem.(*mocks.FileSystem).MockGlob = mockGlob
 		})
 
-		It("still matches because it first trims the omit-prefix", func() {
+		It("still matches because it first trims the trim-prefix", func() {
 			globConfig := cfgWithArgs(1, 2, []string{"tests/*.test"}, " ", false, "test/")
 			_ = service.Partition(ctx, globConfig)
 
@@ -702,10 +702,10 @@ var _ = Describe("Partition", func() {
 				assignments = append(assignments, log.Message)
 			}
 			Expect(assignments).To(ContainElements(
-				"Omitting prefix 'test/' from 'test/a.test' resulting in 'a.test' for comparison",
-				"Omitting prefix 'test/' from 'test/b.test' resulting in 'b.test' for comparison",
-				"Omitting prefix 'test/' from 'test/c.test' resulting in 'c.test' for comparison",
-				"Omitting prefix 'test/' from 'test/d.test' resulting in 'd.test' for comparison",
+				"Trimming prefix 'test/' from 'test/a.test' resulting in 'a.test' for comparison",
+				"Trimming prefix 'test/' from 'test/b.test' resulting in 'b.test' for comparison",
+				"Trimming prefix 'test/' from 'test/c.test' resulting in 'c.test' for comparison",
+				"Trimming prefix 'test/' from 'test/d.test' resulting in 'd.test' for comparison",
 				"Total Runtime: 10ns",
 				"Target Partition Runtime: 5ns",
 				"[PART 0 (0.00s)]: Assigned 'test/a.test' (4ns) using least runtime strategy",


### PR DESCRIPTION
Playwright configures a `testDir` and reports test results relative to the test dir. As a result, Captain records test results relative to this `testDir`.

When this happens, comparison with historical timing data will fail, falling back to round-robin.

This is because the server file ends up relative to the `testDir`, whereas captain's glob is the file on disk.

Supplying this new option allows users to augment the client test file path for the sole purpose of matching in scenarios like playwright (and potentially others).


https://github.com/user-attachments/assets/f3b3fbf9-2e84-4227-89cf-7755931547c8


```
% ../../rwx/captain/captain partition trimtest --index 0 --total 2 tests/**/*
WARN	No test file timings were matched. Using naive round-robin strategy.
tests/example.spec.js

tonyrxw@tonywork ~/src/captain-examples/playwright  (main ✚1…)
% ../../rwx/captain/captain partition trimtest --index 0 --total 2 tests/**/* --trim-prefix "tests/"
tests/example.spec.js
```