### PR TITLE
Only output counts for tests with non-failure status.

### DIFF
--- a/internal/reporting/text.go
+++ b/internal/reporting/text.go
@@ -2,16 +2,100 @@ package reporting
 
 import (
 	"fmt"
-	"unicode"
+	"io"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/rwx-research/captain-cli/internal/errors"
-	"github.com/rwx-research/captain-cli/internal/fs"
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
-func WriteTextSummary(file fs.File, testResults v1.TestResults, _ Configuration) error {
-	statuses := make(map[v1.TestStatusKind][]string)
+var detailedTestStatusKinds = []v1.TestStatusKind{
+	v1.TestStatusFailed,
+	v1.TestStatusTimedOut,
+	v1.TestStatusCanceled,
+}
+
+var orderedTestStatusKinds = []v1.TestStatusKind{
+	v1.TestStatusSuccessful,
+	v1.TestStatusFailed,
+	v1.TestStatusTimedOut,
+	v1.TestStatusCanceled,
+	v1.TestStatusQuarantined,
+	v1.TestStatusSkipped,
+	v1.TestStatusPended,
+	v1.TestStatusTodo,
+}
+
+var titleCaser = cases.Title(language.AmericanEnglish)
+
+func WriteTextSummary(w io.Writer, testResults v1.TestResults, _ Configuration) error {
+	statuses := summarizeTestsByStatus(testResults)
 	totalTests := testResults.Summary.Tests
+
+	for _, kind := range detailedTestStatusKinds {
+		tests, ok := statuses[kind]
+		if !ok {
+			continue
+		}
+
+		statusName := titleCaser.String(testStatusKindToString(kind))
+		_, err := fmt.Fprintf(w, "\n%s (%d):\n", statusName, len(statuses[kind]))
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		for _, testName := range tests {
+			_, err := fmt.Fprintf(w, "- %s\n", testName)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+
+	totalCountParts := make([]string, 0, len(orderedTestStatusKinds))
+	if testResults.Summary.Successful > 0 {
+		totalCountParts = append(totalCountParts, fmt.Sprintf("%d %s", testResults.Summary.Successful, "successful"))
+	}
+
+	for _, kind := range orderedTestStatusKinds {
+		tests, ok := statuses[kind]
+		if !ok || len(tests) == 0 {
+			continue
+		}
+
+		totalCountParts = append(totalCountParts, fmt.Sprintf("%d %s", len(tests), testStatusKindToString(kind)))
+	}
+
+	pluralizeTests := "tests"
+	if totalTests == 1 {
+		pluralizeTests = "test"
+	}
+
+	_, err := fmt.Fprintf(w, "\n%d total %s", totalTests, pluralizeTests)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if len(totalCountParts) > 0 {
+		_, err = fmt.Fprintf(w, ": %s\n", strings.Join(totalCountParts, ", "))
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	} else {
+		_, err = fmt.Fprint(w, "\n")
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+func summarizeTestsByStatus(testResults v1.TestResults) map[v1.TestStatusKind][]string {
+	statuses := make(map[v1.TestStatusKind][]string)
 
 	for _, test := range testResults.Tests {
 		if test.Attempt.Status.Kind == v1.TestStatusSuccessful {
@@ -20,39 +104,22 @@ func WriteTextSummary(file fs.File, testResults v1.TestResults, _ Configuration)
 
 		tests, ok := statuses[test.Attempt.Status.Kind]
 		if !ok {
-			tests = make([]string, 0)
+			tests = []string{test.Name}
+		} else {
+			tests = append(tests, test.Name)
 		}
 
-		tests = append(tests, test.Name)
 		statuses[test.Attempt.Status.Kind] = tests
 	}
 
-	pluralizeTests := "tests"
-	if totalTests == 1 {
-		pluralizeTests = "test"
+	return statuses
+}
+
+func testStatusKindToString(kind v1.TestStatusKind) string {
+	switch kind { //nolint:exhaustive
+	case v1.TestStatusTimedOut:
+		return "timed out"
+	default:
+		return string(kind)
 	}
-
-	_, err := file.Write([]byte(fmt.Sprintf("Captain detected a total of %d %s.\n", totalTests, pluralizeTests)))
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	for status, tests := range statuses {
-		statusName := []rune(status)
-		statusName[0] = unicode.ToUpper(statusName[0])
-
-		_, err := file.Write([]byte(fmt.Sprintf("\n%s (%d):\n", string(statusName), len(tests))))
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		for _, testName := range tests {
-			_, err := file.Write([]byte(fmt.Sprintf("- %s\n", testName)))
-			if err != nil {
-				return errors.WithStack(err)
-			}
-		}
-	}
-
-	return nil
 }

--- a/internal/reporting/text_test.go
+++ b/internal/reporting/text_test.go
@@ -67,9 +67,9 @@ var _ = Describe("Text Report", func() {
 		Expect(reporting.WriteTextSummary(mockFile, testResults, reporting.Configuration{})).To(Succeed())
 		summary := mockFile.Builder.String()
 
-		Expect(summary).To(ContainSubstring("total of 4 tests"))
-		Expect(summary).To(ContainSubstring("Failed (1)"))
-		Expect(summary).To(ContainSubstring("Skipped (1)"))
-		Expect(summary).To(ContainSubstring("TimedOut (1)"))
+		Expect(summary).To(ContainSubstring("Failed (1):"))
+		Expect(summary).To(ContainSubstring("Timed Out (1):"))
+		Expect(summary).NotTo(ContainSubstring("Skipped (1):"))
+		Expect(summary).To(ContainSubstring("4 total tests: 1 successful, 1 failed, 1 timed out, 1 skipped"))
 	})
 })

--- a/test/.snapshots/OSS mode Integration Tests captain merge parses and merges provided results
+++ b/test/.snapshots/OSS mode Integration Tests captain merge parses and merges provided results
@@ -1,4 +1,3 @@
-Captain detected a total of 72 tests.
 
 Failed (36):
 - Tests::Case within a context behaves like shared examples has top-level aggregated failing tests
@@ -38,28 +37,4 @@ Failed (36):
 - Tests::Case within a context has passing pended tests
 - Tests::Case within a context behaves like shared examples has top-level failing tests
 
-Pended (24):
-- Tests::Case within a context behaves like shared examples has top-level skipped tests
-- Tests::Case within a context behaves like shared examples has top-level failing pended tests
-- Tests::Case within a context behaves like shared examples within a context has skipped tests
-- Tests::Case within a context behaves like shared examples within a context has failing pended tests
-- some string has top-level skipped tests
-- some string has top-level failing pended tests
-- some string behaves like shared examples has top-level skipped tests
-- some string behaves like shared examples has top-level failing pended tests
-- some string behaves like shared examples within a context has skipped tests
-- some string behaves like shared examples within a context has failing pended tests
-- some string within a context has skipped tests
-- some string within a context has failing pended tests
-- some string within a context behaves like shared examples has top-level skipped tests
-- some string within a context behaves like shared examples has top-level failing pended tests
-- some string within a context behaves like shared examples within a context has skipped tests
-- some string within a context behaves like shared examples within a context has failing pended tests
-- Tests::Case has top-level skipped tests
-- Tests::Case has top-level failing pended tests
-- Tests::Case behaves like shared examples has top-level skipped tests
-- Tests::Case behaves like shared examples has top-level failing pended tests
-- Tests::Case behaves like shared examples within a context has skipped tests
-- Tests::Case behaves like shared examples within a context has failing pended tests
-- Tests::Case within a context has skipped tests
-- Tests::Case within a context has failing pended tests
+72 total tests: 12 successful, 36 failed, 24 pended

--- a/test/.snapshots/OSS mode Integration Tests captain merge supports globs
+++ b/test/.snapshots/OSS mode Integration Tests captain merge supports globs
@@ -1,4 +1,3 @@
-Captain detected a total of 72 tests.
 
 Failed (36):
 - Tests::Case within a context behaves like shared examples has top-level aggregated failing tests
@@ -38,28 +37,4 @@ Failed (36):
 - Tests::Case within a context has passing pended tests
 - Tests::Case within a context behaves like shared examples has top-level failing tests
 
-Pended (24):
-- Tests::Case within a context behaves like shared examples has top-level skipped tests
-- Tests::Case within a context behaves like shared examples has top-level failing pended tests
-- Tests::Case within a context behaves like shared examples within a context has skipped tests
-- Tests::Case within a context behaves like shared examples within a context has failing pended tests
-- some string has top-level skipped tests
-- some string has top-level failing pended tests
-- some string behaves like shared examples has top-level skipped tests
-- some string behaves like shared examples has top-level failing pended tests
-- some string behaves like shared examples within a context has skipped tests
-- some string behaves like shared examples within a context has failing pended tests
-- some string within a context has skipped tests
-- some string within a context has failing pended tests
-- some string within a context behaves like shared examples has top-level skipped tests
-- some string within a context behaves like shared examples has top-level failing pended tests
-- some string within a context behaves like shared examples within a context has skipped tests
-- some string within a context behaves like shared examples within a context has failing pended tests
-- Tests::Case has top-level skipped tests
-- Tests::Case has top-level failing pended tests
-- Tests::Case behaves like shared examples has top-level skipped tests
-- Tests::Case behaves like shared examples has top-level failing pended tests
-- Tests::Case behaves like shared examples within a context has skipped tests
-- Tests::Case behaves like shared examples within a context has failing pended tests
-- Tests::Case within a context has skipped tests
-- Tests::Case within a context has failing pended tests
+72 total tests: 12 successful, 36 failed, 24 pended


### PR DESCRIPTION
Failed, timed out, and canceled tests are output as a list of test names, one per line. Other tests are included only in the counts at the end of the output.