### PR TITLE
Preserve the Scope field in RWX test results

### DIFF
--- a/internal/cli/.snapshots/Merge when given multiple globs globs each pattern and merges the results
+++ b/internal/cli/.snapshots/Merge when given multiple globs globs each pattern and merges the results
@@ -16,9 +16,9 @@
   },
   Tests: ([]v1.Test) (len=4) {
     (v1.Test) {
-      Scope: (*string)(<nil>),
       ID: (*string)((len=7) "test-id"),
       Name: (string) (len=9) "test-name",
+      Scope: (*string)(<nil>),
       Lineage: ([]string) {
       },
       Location: (*v1.Location)(test-file),
@@ -41,9 +41,9 @@
       }
     },
     (v1.Test) {
-      Scope: (*string)(<nil>),
       ID: (*string)((len=7) "test-id"),
       Name: (string) (len=9) "test-name",
+      Scope: (*string)(<nil>),
       Lineage: ([]string) {
       },
       Location: (*v1.Location)(test-file),
@@ -66,9 +66,9 @@
       }
     },
     (v1.Test) {
-      Scope: (*string)(<nil>),
       ID: (*string)((len=7) "test-id"),
       Name: (string) (len=9) "test-name",
+      Scope: (*string)(<nil>),
       Lineage: ([]string) {
       },
       Location: (*v1.Location)(test-file),
@@ -91,9 +91,9 @@
       }
     },
     (v1.Test) {
-      Scope: (*string)(<nil>),
       ID: (*string)((len=7) "test-id"),
       Name: (string) (len=9) "test-name",
+      Scope: (*string)(<nil>),
       Lineage: ([]string) {
       },
       Location: (*v1.Location)(test-file),

--- a/internal/parsing/.snapshots/DotNetxUnitParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/DotNetxUnitParser Parse parses the sample file
@@ -23,6 +23,7 @@
   "tests": [
     {
       "name": "NullAssertsTests+Null.Success",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 6370900,
         "meta": {
@@ -38,6 +39,7 @@
     },
     {
       "name": "NullAssertsTests+Null.Failure",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 11433500,
         "meta": {
@@ -53,6 +55,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.DoubleNotWithinRange",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 2485800,
         "meta": {
@@ -68,6 +71,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.IntValueWithinRange",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 559500,
         "meta": {
@@ -83,6 +87,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.DoubleValueWithinRange",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 104400,
         "meta": {
@@ -98,6 +103,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.IntNotWithinRangeWithZeroMinimum",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 307700,
         "meta": {
@@ -114,6 +120,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.IntNotWithinRangeWithZeroActual",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 299900,
         "meta": {
@@ -129,6 +136,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.StringNotWithinRange",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 1059900,
         "meta": {
@@ -144,6 +152,7 @@
     },
     {
       "name": "RangeAssertsTests+InRange.StringValueWithinRange",
+      "scope": "test.xunit.assert.dll",
       "attempt": {
         "durationInNanoseconds": 129800,
         "meta": {
@@ -159,6 +168,7 @@
     },
     {
       "name": "CommandLineTests+MethodArgument.MultipleValidMethodArguments",
+      "scope": "test.xunit.console.dll",
       "attempt": {
         "durationInNanoseconds": 11454300,
         "meta": {
@@ -174,6 +184,7 @@
     },
     {
       "name": "CommandLineTests+MethodArgument.MethodArgumentNotPassed",
+      "scope": "test.xunit.console.dll",
       "attempt": {
         "durationInNanoseconds": 323400,
         "meta": {
@@ -194,6 +205,7 @@
     },
     {
       "name": "CommandLineTests+MethodArgument.SingleValidMethodArgument",
+      "scope": "test.xunit.console.dll",
       "attempt": {
         "durationInNanoseconds": 425700,
         "meta": {
@@ -209,6 +221,7 @@
     },
     {
       "name": "CommandLineTests+MethodArgument.MissingOptionValue",
+      "scope": "test.xunit.console.dll",
       "attempt": {
         "durationInNanoseconds": 2254700,
         "meta": {
@@ -224,6 +237,7 @@
     },
     {
       "name": "CommandLineTests+SerializeOption.SerializeSetSerializeIsTrue",
+      "scope": "test.xunit.console.dll",
       "attempt": {
         "durationInNanoseconds": 288600,
         "meta": {
@@ -239,6 +253,7 @@
     },
     {
       "name": "CommandLineTests+SerializeOption.SerializeNotSetSerializeIsFalse",
+      "scope": "test.xunit.console.dll",
       "attempt": {
         "durationInNanoseconds": 403900,
         "meta": {

--- a/internal/parsing/.snapshots/GoTestParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/GoTestParser Parse parses the sample file
@@ -23,6 +23,7 @@
   "tests": [
     {
       "name": "FuzzHex",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -36,6 +37,7 @@
     },
     {
       "name": "FuzzHex/seed#0",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -49,6 +51,7 @@
     },
     {
       "name": "FuzzHex/seed#1",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -62,6 +65,7 @@
     },
     {
       "name": "FuzzHex/seed#2",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -75,6 +79,7 @@
     },
     {
       "name": "FuzzHex/seed#3",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -88,6 +93,7 @@
     },
     {
       "name": "FuzzHex/seed#4",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -101,6 +107,7 @@
     },
     {
       "name": "FuzzHex/seed#5",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -114,6 +121,7 @@
     },
     {
       "name": "TestBar",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -127,6 +135,7 @@
     },
     {
       "name": "TestBarFailing",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -140,6 +149,7 @@
     },
     {
       "name": "TestFoo",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -153,6 +163,7 @@
     },
     {
       "name": "TestFoo",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -166,6 +177,7 @@
     },
     {
       "name": "TestFooFailing",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -179,6 +191,7 @@
     },
     {
       "name": "TestFooParallelTable",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -192,6 +205,7 @@
     },
     {
       "name": "TestFooParallelTable/0",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -205,6 +219,7 @@
     },
     {
       "name": "TestFooParallelTable/1",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -218,6 +233,7 @@
     },
     {
       "name": "TestFooParallelTable/2",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -231,6 +247,7 @@
     },
     {
       "name": "TestFooParallelTable/3",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -244,6 +261,7 @@
     },
     {
       "name": "TestFooParallelTable/4",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -257,6 +275,7 @@
     },
     {
       "name": "TestFooTable",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -270,6 +289,7 @@
     },
     {
       "name": "TestFooTable/0",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -283,6 +303,7 @@
     },
     {
       "name": "TestFooTable/1",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -296,6 +317,7 @@
     },
     {
       "name": "TestFooTable/2",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -309,6 +331,7 @@
     },
     {
       "name": "TestFooTable/3",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -322,6 +345,7 @@
     },
     {
       "name": "TestFooTable/4",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -335,6 +359,7 @@
     },
     {
       "name": "TestSkipNoReason",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -348,6 +373,7 @@
     },
     {
       "name": "TestSkipReason",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -361,6 +387,7 @@
     },
     {
       "name": "TestSlow",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 1500000000,
         "meta": {
@@ -374,6 +401,7 @@
     },
     {
       "name": "TestTableFailing",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -387,6 +415,7 @@
     },
     {
       "name": "TestTableFailing/0",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -400,6 +429,7 @@
     },
     {
       "name": "TestTableFailing/1",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -413,6 +443,7 @@
     },
     {
       "name": "TestTableFailing/2",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -426,6 +457,7 @@
     },
     {
       "name": "TestTableFailing/3",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -439,6 +471,7 @@
     },
     {
       "name": "TestTableFailing/4",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg1",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -452,6 +485,7 @@
     },
     {
       "name": "TestWhatever",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {
@@ -465,6 +499,7 @@
     },
     {
       "name": "TestWhateverFailing",
+      "scope": "github.com/captain-examples/go-testing/internal/pkg2",
       "attempt": {
         "durationInNanoseconds": 0,
         "meta": {

--- a/internal/parsing/.snapshots/JavaScriptKarmaParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptKarmaParser Parse parses the sample file
@@ -24,6 +24,7 @@
     {
       "id": "spec3",
       "name": "Some test context is a contextual passing test",
+      "scope": "Chrome macOS",
       "lineage": [
         "Some test",
         "context",
@@ -44,6 +45,7 @@
     {
       "id": "spec0",
       "name": "Some test is a passing test",
+      "scope": "Chrome macOS",
       "lineage": [
         "Some test",
         "is a passing test"
@@ -63,6 +65,7 @@
     {
       "id": "spec1",
       "name": "Some test is a skipped test",
+      "scope": "Chrome macOS",
       "lineage": [
         "Some test",
         "is a skipped test"
@@ -82,6 +85,7 @@
     {
       "id": "spec2",
       "name": "Some test is a failing test",
+      "scope": "Chrome macOS",
       "lineage": [
         "Some test",
         "is a failing test"

--- a/internal/parsing/.snapshots/JavaScriptKarmaParser Parse puts a generic other error in place when there are no errors but the suite failed
+++ b/internal/parsing/.snapshots/JavaScriptKarmaParser Parse puts a generic other error in place when there are no errors but the suite failed
@@ -24,6 +24,7 @@
     {
       "id": "spec3",
       "name": "Some test context is a contextual passing test",
+      "scope": "Mozilla/5.0 ",
       "lineage": [
         "Some test",
         "context",

--- a/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file
@@ -23,6 +23,7 @@
   "tests": [
     {
       "name": "New Todo should allow me to add todo items",
+      "scope": "chromium",
       "lineage": [
         "New Todo",
         "should allow me to add todo items"
@@ -49,6 +50,7 @@
     },
     {
       "name": "New Todo should clear text input field when an item is added",
+      "scope": "chromium",
       "lineage": [
         "New Todo",
         "should clear text input field when an item is added"
@@ -75,6 +77,7 @@
     },
     {
       "name": "New Todo should append new items to the bottom of the list",
+      "scope": "chromium",
       "lineage": [
         "New Todo",
         "should append new items to the bottom of the list"
@@ -101,6 +104,7 @@
     },
     {
       "name": "New Todo should allow me to add todo items",
+      "scope": "firefox",
       "lineage": [
         "New Todo",
         "should allow me to add todo items"
@@ -127,6 +131,7 @@
     },
     {
       "name": "New Todo should clear text input field when an item is added",
+      "scope": "firefox",
       "lineage": [
         "New Todo",
         "should clear text input field when an item is added"
@@ -153,6 +158,7 @@
     },
     {
       "name": "New Todo should append new items to the bottom of the list",
+      "scope": "firefox",
       "lineage": [
         "New Todo",
         "should append new items to the bottom of the list"
@@ -179,6 +185,7 @@
     },
     {
       "name": "Mark all as completed should allow me to mark all items as completed",
+      "scope": "chromium",
       "lineage": [
         "Mark all as completed",
         "should allow me to mark all items as completed"
@@ -205,6 +212,7 @@
     },
     {
       "name": "Mark all as completed should allow me to clear the complete state of all items",
+      "scope": "chromium",
       "lineage": [
         "Mark all as completed",
         "should allow me to clear the complete state of all items"
@@ -231,6 +239,7 @@
     },
     {
       "name": "Mark all as completed complete all checkbox should update state when items are completed / cleared",
+      "scope": "chromium",
       "lineage": [
         "Mark all as completed",
         "complete all checkbox should update state when items are completed / cleared"
@@ -257,6 +266,7 @@
     },
     {
       "name": "Mark all as completed should allow me to mark all items as completed",
+      "scope": "firefox",
       "lineage": [
         "Mark all as completed",
         "should allow me to mark all items as completed"
@@ -283,6 +293,7 @@
     },
     {
       "name": "Mark all as completed should allow me to clear the complete state of all items",
+      "scope": "firefox",
       "lineage": [
         "Mark all as completed",
         "should allow me to clear the complete state of all items"
@@ -309,6 +320,7 @@
     },
     {
       "name": "Mark all as completed complete all checkbox should update state when items are completed / cleared",
+      "scope": "firefox",
       "lineage": [
         "Mark all as completed",
         "complete all checkbox should update state when items are completed / cleared"
@@ -335,6 +347,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "chromium",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -360,6 +373,7 @@
     },
     {
       "name": "skipped test",
+      "scope": "chromium",
       "lineage": [
         "skipped test"
       ],
@@ -389,6 +403,7 @@
     },
     {
       "name": "fixme test",
+      "scope": "chromium",
       "lineage": [
         "fixme test"
       ],
@@ -418,6 +433,7 @@
     },
     {
       "name": "failing test",
+      "scope": "chromium",
       "lineage": [
         "failing test"
       ],
@@ -491,6 +507,7 @@
     },
     {
       "name": "throw error test",
+      "scope": "chromium",
       "lineage": [
         "throw error test"
       ],
@@ -564,6 +581,7 @@
     },
     {
       "name": "throw string",
+      "scope": "chromium",
       "lineage": [
         "throw string"
       ],
@@ -625,6 +643,7 @@
     },
     {
       "name": "passing test",
+      "scope": "chromium",
       "lineage": [
         "passing test"
       ],
@@ -650,6 +669,7 @@
     },
     {
       "name": "failing w/ fail annotation",
+      "scope": "chromium",
       "lineage": [
         "failing w/ fail annotation"
       ],
@@ -679,6 +699,7 @@
     },
     {
       "name": "passing w/ fail annotation",
+      "scope": "chromium",
       "lineage": [
         "passing w/ fail annotation"
       ],
@@ -753,6 +774,7 @@
     },
     {
       "name": "fails then passes",
+      "scope": "chromium",
       "lineage": [
         "fails then passes"
       ],
@@ -822,6 +844,7 @@
     },
     {
       "name": "times out",
+      "scope": "chromium",
       "lineage": [
         "times out"
       ],
@@ -883,6 +906,7 @@
     },
     {
       "name": "slow",
+      "scope": "chromium",
       "lineage": [
         "slow"
       ],
@@ -908,6 +932,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "firefox",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -933,6 +958,7 @@
     },
     {
       "name": "skipped test",
+      "scope": "firefox",
       "lineage": [
         "skipped test"
       ],
@@ -962,6 +988,7 @@
     },
     {
       "name": "fixme test",
+      "scope": "firefox",
       "lineage": [
         "fixme test"
       ],
@@ -991,6 +1018,7 @@
     },
     {
       "name": "failing test",
+      "scope": "firefox",
       "lineage": [
         "failing test"
       ],
@@ -1064,6 +1092,7 @@
     },
     {
       "name": "throw error test",
+      "scope": "firefox",
       "lineage": [
         "throw error test"
       ],
@@ -1137,6 +1166,7 @@
     },
     {
       "name": "throw string",
+      "scope": "firefox",
       "lineage": [
         "throw string"
       ],
@@ -1198,6 +1228,7 @@
     },
     {
       "name": "passing test",
+      "scope": "firefox",
       "lineage": [
         "passing test"
       ],
@@ -1223,6 +1254,7 @@
     },
     {
       "name": "failing w/ fail annotation",
+      "scope": "firefox",
       "lineage": [
         "failing w/ fail annotation"
       ],
@@ -1252,6 +1284,7 @@
     },
     {
       "name": "passing w/ fail annotation",
+      "scope": "firefox",
       "lineage": [
         "passing w/ fail annotation"
       ],
@@ -1326,6 +1359,7 @@
     },
     {
       "name": "fails then passes",
+      "scope": "firefox",
       "lineage": [
         "fails then passes"
       ],
@@ -1395,6 +1429,7 @@
     },
     {
       "name": "times out",
+      "scope": "firefox",
       "lineage": [
         "times out"
       ],
@@ -1456,6 +1491,7 @@
     },
     {
       "name": "slow",
+      "scope": "firefox",
       "lineage": [
         "slow"
       ],
@@ -1481,6 +1517,7 @@
     },
     {
       "name": "first level passing test",
+      "scope": "chromium",
       "lineage": [
         "first level",
         "passing test"
@@ -1507,6 +1544,7 @@
     },
     {
       "name": "first level passing test",
+      "scope": "firefox",
       "lineage": [
         "first level",
         "passing test"
@@ -1533,6 +1571,7 @@
     },
     {
       "name": "first level second level passing test",
+      "scope": "chromium",
       "lineage": [
         "first level",
         "second level",
@@ -1560,6 +1599,7 @@
     },
     {
       "name": "first level second level passing test",
+      "scope": "firefox",
       "lineage": [
         "first level",
         "second level",
@@ -1587,6 +1627,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "chromium",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -1612,6 +1653,7 @@
     },
     {
       "name": "skipped test",
+      "scope": "chromium",
       "lineage": [
         "skipped test"
       ],
@@ -1641,6 +1683,7 @@
     },
     {
       "name": "fixme test",
+      "scope": "chromium",
       "lineage": [
         "fixme test"
       ],
@@ -1670,6 +1713,7 @@
     },
     {
       "name": "failing test",
+      "scope": "chromium",
       "lineage": [
         "failing test"
       ],
@@ -1743,6 +1787,7 @@
     },
     {
       "name": "passing test",
+      "scope": "chromium",
       "lineage": [
         "passing test"
       ],
@@ -1768,6 +1813,7 @@
     },
     {
       "name": "failing w/ fail annotation",
+      "scope": "chromium",
       "lineage": [
         "failing w/ fail annotation"
       ],
@@ -1797,6 +1843,7 @@
     },
     {
       "name": "passing w/ fail annotation",
+      "scope": "chromium",
       "lineage": [
         "passing w/ fail annotation"
       ],
@@ -1871,6 +1918,7 @@
     },
     {
       "name": "fails then passes",
+      "scope": "chromium",
       "lineage": [
         "fails then passes"
       ],
@@ -1940,6 +1988,7 @@
     },
     {
       "name": "times out",
+      "scope": "chromium",
       "lineage": [
         "times out"
       ],
@@ -2001,6 +2050,7 @@
     },
     {
       "name": "slow",
+      "scope": "chromium",
       "lineage": [
         "slow"
       ],
@@ -2026,6 +2076,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "firefox",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -2051,6 +2102,7 @@
     },
     {
       "name": "skipped test",
+      "scope": "firefox",
       "lineage": [
         "skipped test"
       ],
@@ -2080,6 +2132,7 @@
     },
     {
       "name": "fixme test",
+      "scope": "firefox",
       "lineage": [
         "fixme test"
       ],
@@ -2109,6 +2162,7 @@
     },
     {
       "name": "failing test",
+      "scope": "firefox",
       "lineage": [
         "failing test"
       ],
@@ -2182,6 +2236,7 @@
     },
     {
       "name": "passing test",
+      "scope": "firefox",
       "lineage": [
         "passing test"
       ],
@@ -2207,6 +2262,7 @@
     },
     {
       "name": "failing w/ fail annotation",
+      "scope": "firefox",
       "lineage": [
         "failing w/ fail annotation"
       ],
@@ -2236,6 +2292,7 @@
     },
     {
       "name": "passing w/ fail annotation",
+      "scope": "firefox",
       "lineage": [
         "passing w/ fail annotation"
       ],
@@ -2310,6 +2367,7 @@
     },
     {
       "name": "fails then passes",
+      "scope": "firefox",
       "lineage": [
         "fails then passes"
       ],
@@ -2379,6 +2437,7 @@
     },
     {
       "name": "times out",
+      "scope": "firefox",
       "lineage": [
         "times out"
       ],
@@ -2440,6 +2499,7 @@
     },
     {
       "name": "slow",
+      "scope": "firefox",
       "lineage": [
         "slow"
       ],
@@ -2465,6 +2525,7 @@
     },
     {
       "name": "first level passing test",
+      "scope": "chromium",
       "lineage": [
         "first level",
         "passing test"
@@ -2491,6 +2552,7 @@
     },
     {
       "name": "first level passing test",
+      "scope": "firefox",
       "lineage": [
         "first level",
         "passing test"
@@ -2517,6 +2579,7 @@
     },
     {
       "name": "first level second level passing test",
+      "scope": "chromium",
       "lineage": [
         "first level",
         "second level",
@@ -2544,6 +2607,7 @@
     },
     {
       "name": "first level second level passing test",
+      "scope": "firefox",
       "lineage": [
         "first level",
         "second level",

--- a/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file with an error in global setup
+++ b/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file with an error in global setup
@@ -23,6 +23,7 @@
   "tests": [
     {
       "name": "Auth Flow You can signup and login with GitHub",
+      "scope": "chromium",
       "lineage": [
         "Auth Flow",
         "You can signup and login with GitHub"
@@ -46,6 +47,7 @@
     },
     {
       "name": "Deep links work across domains when choosing an organization",
+      "scope": "chromium",
       "lineage": [
         "Deep links",
         "work across domains when choosing an organization"
@@ -69,6 +71,7 @@
     },
     {
       "name": "Feedback submission functionality Allows the submission of feedback to the support email address",
+      "scope": "chromium",
       "lineage": [
         "Feedback submission functionality",
         "Allows the submission of feedback to the support email address"
@@ -92,6 +95,7 @@
     },
     {
       "name": "Forgot Password Flow You can sign up with email, forget your password, ask to reset it, reset it, and sign in with the new password",
+      "scope": "chromium",
       "lineage": [
         "Forgot Password Flow",
         "You can sign up with email, forget your password, ask to reset it, reset it, and sign in with the new password"
@@ -115,6 +119,7 @@
     },
     {
       "name": "Login Flow When you are logged out and visit an authenticated path, you are redirected to the authenticated path after login",
+      "scope": "chromium",
       "lineage": [
         "Login Flow",
         "When you are logged out and visit an authenticated path, you are redirected to the authenticated path after login"
@@ -138,6 +143,7 @@
     },
     {
       "name": "Login Flow When you are logged out and visit an authenticated path, you are redirected to the authenticated path after signup",
+      "scope": "chromium",
       "lineage": [
         "Login Flow",
         "When you are logged out and visit an authenticated path, you are redirected to the authenticated path after signup"
@@ -161,6 +167,7 @@
     },
     {
       "name": "Onboarding Flow You can sign up to captain with email, create an organization, invite someone to that organization, and then they can signup with the invite code and automatically be added to the organization.",
+      "scope": "chromium",
       "lineage": [
         "Onboarding Flow",
         "You can sign up to captain with email, create an organization, invite someone to that organization, and then they can signup with the invite code and automatically be added to the organization."
@@ -184,6 +191,7 @@
     },
     {
       "name": "Onboarding Flow You can sign up to captain with email, create an organization, invite someone who already has an account to that organization, and then they can be deeplink logged in and added to the organization.",
+      "scope": "chromium",
       "lineage": [
         "Onboarding Flow",
         "You can sign up to captain with email, create an organization, invite someone who already has an account to that organization, and then they can be deeplink logged in and added to the organization."
@@ -207,6 +215,7 @@
     },
     {
       "name": "Onboarding Flow You can sign up for abq with email and create an organization.",
+      "scope": "chromium",
       "lineage": [
         "Onboarding Flow",
         "You can sign up for abq with email and create an organization."
@@ -230,6 +239,7 @@
     },
     {
       "name": "One Click Onboarding Flow You can sign up with Github through the one click flow",
+      "scope": "chromium",
       "lineage": [
         "One Click Onboarding Flow",
         "You can sign up with Github through the one click flow"
@@ -253,6 +263,7 @@
     },
     {
       "name": "One Click Onboarding Flow You can see the unsupported message and form for non-Github selections in the one click flow",
+      "scope": "chromium",
       "lineage": [
         "One Click Onboarding Flow",
         "You can see the unsupported message and form for non-Github selections in the one click flow"
@@ -276,6 +287,7 @@
     },
     {
       "name": "One Click Onboarding Flow You can see the unsupported message and form for not-listed selections in the one click flow",
+      "scope": "chromium",
       "lineage": [
         "One Click Onboarding Flow",
         "You can see the unsupported message and form for not-listed selections in the one click flow"
@@ -299,6 +311,7 @@
     },
     {
       "name": "Telemetry functionality Telemetry is enabled by default but can be opted out of",
+      "scope": "chromium",
       "lineage": [
         "Telemetry functionality",
         "Telemetry is enabled by default but can be opted out of"
@@ -322,6 +335,7 @@
     },
     {
       "name": "Automatic time zone detection Initially sets user's time zones to the browser's and lets them change it",
+      "scope": "chromium",
       "lineage": [
         "Automatic time zone detection",
         "Initially sets user's time zones to the browser's and lets them change it"

--- a/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file with other errors
+++ b/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file with other errors
@@ -23,6 +23,7 @@
   "tests": [
     {
       "name": "homepage has title and links to intro page",
+      "scope": "chromium",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -45,6 +46,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "firefox",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -67,6 +69,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "webkit",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -89,6 +92,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "Mobile Chrome",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -111,6 +115,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "Mobile Safari",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -133,6 +138,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "Microsoft Edge",
       "lineage": [
         "homepage has title and links to intro page"
       ],
@@ -155,6 +161,7 @@
     },
     {
       "name": "homepage has title and links to intro page",
+      "scope": "Google Chrome",
       "lineage": [
         "homepage has title and links to intro page"
       ],

--- a/internal/testingschema/v1/test.go
+++ b/internal/testingschema/v1/test.go
@@ -102,14 +102,9 @@ type TestAttempt struct {
 }
 
 type Test struct {
-	// Used to disambiguate tests during the merge process, this should align
-	// with any fields that are used for test identity, but are not top-level
-	// fields (i.e. any identity components that come from the attempt meta).
-	// Not included in the JSON output nor the schema.
-	Scope *string `json:"-"`
-
 	ID           *string       `json:"id,omitempty"`
 	Name         string        `json:"name"`
+	Scope        *string       `json:"scope,omitempty"`
 	Lineage      []string      `json:"lineage,omitempty"`
 	Location     *Location     `json:"location,omitempty"`
 	Attempt      TestAttempt   `json:"attempt"`


### PR DESCRIPTION
See https://github.com/rwx-research/captain/pull/98; this is needed to ensure test matching can work correctly when retrying failed tests onto a new node.