### PR TITLE
Refetch quarantined tests right before using them

### DIFF
--- a/internal/backend/local/client.go
+++ b/internal/backend/local/client.go
@@ -141,6 +141,22 @@ func (c Client) GetRunConfiguration(_ context.Context, _ string) (backend.RunCon
 	return makeRunConfiguration(c.Flakes, c.Quarantines, c.quarantinesTime)
 }
 
+func (c Client) GetQuarantinedTests(_ context.Context, _ string) ([]backend.Test, error) {
+	quarantinedTests := make([]backend.Test, len(c.Quarantines))
+
+	for i, quarantine := range c.Quarantines {
+		identity, strict := NewMapFromYAML(quarantine).withoutKey("strict")
+
+		quarantinedTests[i] = backend.Test{
+			CompositeIdentifier: newCompositeID(identity),
+			IdentityComponents:  identity.Order,
+			StrictIdentity:      strict == "true",
+		}
+	}
+
+	return quarantinedTests, nil
+}
+
 func (c Client) UpdateTestResults(
 	_ context.Context,
 	_ string,

--- a/internal/backend/remote/get_quarantined_tests_test.go
+++ b/internal/backend/remote/get_quarantined_tests_test.go
@@ -1,0 +1,181 @@
+package remote_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/rwx-research/captain-cli/internal/backend/remote"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetQuarantinedTests", func() {
+	var (
+		apiClient        remote.Client
+		mockRoundTripper func(*http.Request) (*http.Response, error)
+		host             string
+	)
+
+	JustBeforeEach(func() {
+		apiClientConfig := remote.ClientConfig{Log: zap.NewNop().Sugar(), Host: host}
+		apiClient = remote.Client{ClientConfig: apiClientConfig, RoundTrip: mockRoundTripper}
+	})
+
+	Context("when the response is successful against captain.build", func() {
+		BeforeEach(func() {
+			host = "captain.build"
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/quarantined_tests"))
+				Expect(req.URL.Query().Has("test_suite_identifier")).To(BeTrue())
+
+				resp.Body = io.NopCloser(strings.NewReader(`
+					{
+						"quarantined_tests": [
+							{
+								"composite_identifier": "q-1",
+								"identity_components": ["component1", "component2"],
+								"strict_identity": true
+							},
+							{
+								"composite_identifier": "q-2",
+								"identity_components": ["component3"],
+								"strict_identity": false
+							}
+						]
+					}
+				`))
+				resp.StatusCode = 200
+
+				return &resp, nil
+			}
+		})
+
+		It("returns the quarantined tests", func() {
+			quarantinedTests, err := apiClient.GetQuarantinedTests(context.Background(), "test-suite-id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(quarantinedTests).To(HaveLen(2))
+			Expect(quarantinedTests[0].CompositeIdentifier).To(Equal("q-1"))
+			Expect(quarantinedTests[0].IdentityComponents).To(Equal([]string{"component1", "component2"}))
+			Expect(quarantinedTests[0].StrictIdentity).To(BeTrue())
+			Expect(quarantinedTests[1].CompositeIdentifier).To(Equal("q-2"))
+			Expect(quarantinedTests[1].IdentityComponents).To(Equal([]string{"component3"}))
+			Expect(quarantinedTests[1].StrictIdentity).To(BeFalse())
+		})
+	})
+
+	Context("when the response is successful against cloud.rwx.com", func() {
+		BeforeEach(func() {
+			host = "cloud.rwx.com"
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.URL.Path).To(HaveSuffix("/captain/api/test_suites/quarantined_tests"))
+				Expect(req.URL.Query().Has("test_suite_identifier")).To(BeTrue())
+
+				resp.Body = io.NopCloser(strings.NewReader(`
+					{
+						"quarantined_tests": [
+							{
+								"composite_identifier": "q-1",
+								"identity_components": ["component1", "component2"],
+								"strict_identity": true
+							}
+						]
+					}
+				`))
+				resp.StatusCode = 200
+
+				return &resp, nil
+			}
+		})
+
+		It("returns the quarantined tests", func() {
+			quarantinedTests, err := apiClient.GetQuarantinedTests(context.Background(), "test-suite-id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(quarantinedTests).To(HaveLen(1))
+			Expect(quarantinedTests[0].CompositeIdentifier).To(Equal("q-1"))
+		})
+	})
+
+	Context("when the response is empty", func() {
+		BeforeEach(func() {
+			host = "cloud.rwx.com"
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.URL.Path).To(HaveSuffix("/captain/api/test_suites/quarantined_tests"))
+				Expect(req.URL.Query().Has("test_suite_identifier")).To(BeTrue())
+
+				resp.Body = io.NopCloser(strings.NewReader(`{ "quarantined_tests": [] }`))
+				resp.StatusCode = 200
+
+				return &resp, nil
+			}
+		})
+
+		It("returns an empty list", func() {
+			quarantinedTests, err := apiClient.GetQuarantinedTests(context.Background(), "test-suite-id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(quarantinedTests).To(BeEmpty())
+		})
+	})
+
+	Context("when the response is not successful", func() {
+		BeforeEach(func() {
+			host = "cloud.rwx.com"
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.URL.Path).To(HaveSuffix("quarantined_tests"))
+				Expect(req.URL.Query().Has("test_suite_identifier")).To(BeTrue())
+
+				resp.StatusCode = 400
+				resp.Body = io.NopCloser(strings.NewReader(""))
+
+				return &resp, nil
+			}
+		})
+
+		It("returns an error", func() {
+			quarantinedTests, err := apiClient.GetQuarantinedTests(context.Background(), "test-suite-id")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API backend encountered an error"))
+			Expect(quarantinedTests).To(BeNil())
+		})
+	})
+
+	Context("when the response body is invalid JSON", func() {
+		BeforeEach(func() {
+			host = "cloud.rwx.com"
+			mockRoundTripper = func(_ *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				resp.Body = io.NopCloser(strings.NewReader(`invalid json`))
+				resp.StatusCode = 200
+				resp.Header = http.Header{
+					"Content-Type": []string{"application/json"},
+				}
+
+				return &resp, nil
+			}
+		})
+
+		It("returns an error", func() {
+			quarantinedTests, err := apiClient.GetQuarantinedTests(context.Background(), "test-suite-id")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to parse the response body"))
+			Expect(quarantinedTests).To(BeNil())
+		})
+	})
+})

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -10,6 +10,7 @@ import (
 // Client is the interface of our API layer.
 type Client interface {
 	GetRunConfiguration(ctx context.Context, testSuiteIdentifier string) (RunConfiguration, error)
+	GetQuarantinedTests(ctx context.Context, testSuiteIdentifier string) ([]Test, error)
 	GetTestTimingManifest(context.Context, string) ([]testing.TestFileTiming, error)
 	UpdateTestResults(context.Context, string, v1.TestResults, bool) ([]TestResultsUploadResult, error)
 }

--- a/internal/mocks/backend.go
+++ b/internal/mocks/backend.go
@@ -12,6 +12,7 @@ import (
 // API is a mocked implementation of 'backend.Client'.
 type API struct {
 	MockGetRunConfiguration   func(context.Context, string) (backend.RunConfiguration, error)
+	MockGetQuarantinedTests   func(context.Context, string) ([]backend.Test, error)
 	MockGetTestTimingManifest func(context.Context, string) ([]testing.TestFileTiming, error)
 	MockUpdateTestResults     func(context.Context, string, v1.TestResults, bool) (
 		[]backend.TestResultsUploadResult, error,
@@ -28,6 +29,18 @@ func (a *API) GetRunConfiguration(
 	}
 
 	return backend.RunConfiguration{}, errors.NewInternalError("MockGetRunConfiguration was not configured")
+}
+
+// GetQuarantinedTests either calls the configured mock of itself or returns an error if that doesn't exist.
+func (a *API) GetQuarantinedTests(
+	ctx context.Context,
+	testSuiteIdentifier string,
+) ([]backend.Test, error) {
+	if a.MockGetQuarantinedTests != nil {
+		return a.MockGetQuarantinedTests(ctx, testSuiteIdentifier)
+	}
+
+	return nil, errors.NewInternalError("MockGetQuarantinedTests was not configured")
 }
 
 // GetTestTimingManifest either calls the configured mock of itself or returns an error if that doesn't exist.


### PR DESCRIPTION
If a failure/flake on main gets quarantined, there might be a lot of slow test suite runs started before the quarantine that will be affected by it. This pulls the quarantined tests just in time so that we use the most up to date data when quarantining tests.