### PR TITLE
Strip backtraces from test attempt data if results file is too large

### DIFF
--- a/internal/backend/local/client.go
+++ b/internal/backend/local/client.go
@@ -161,7 +161,6 @@ func (c Client) UpdateTestResults(
 	_ context.Context,
 	_ string,
 	testResults v1.TestResults,
-	_ bool,
 ) ([]backend.TestResultsUploadResult, error) {
 	if c.Timings == nil {
 		c.Timings = make(map[string]time.Duration)

--- a/internal/backend/local/client_test.go
+++ b/internal/backend/local/client_test.go
@@ -103,7 +103,7 @@ var _ = Describe("local backend client", func() {
 		})
 
 		JustBeforeEach(func() {
-			uploadResults, err = client.UpdateTestResults(context.Background(), suiteID, testResults, true)
+			uploadResults, err = client.UpdateTestResults(context.Background(), suiteID, testResults)
 		})
 
 		It("updates the timings file", func() {

--- a/internal/backend/remote/update_test_results_test.go
+++ b/internal/backend/remote/update_test_results_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 
@@ -30,6 +31,7 @@ var _ = Describe("Uploading Test Results", func() {
 	)
 
 	BeforeEach(func() {
+		testResults = v1.TestResults{}
 		mockUUID = uuid.MustParse("fff24366-af1d-43cc-ab32-8c9ed137cf09")
 		mockNewUUID = func() (uuid.UUID, error) {
 			return mockUUID, nil
@@ -136,6 +138,223 @@ var _ = Describe("Uploading Test Results", func() {
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))
+		})
+	})
+
+	Context("with large contents in `derivedFrom`", func() {
+		var err error
+
+		BeforeEach(func() {
+			err = nil
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				switch mockRoundTripCalls {
+				case 0: // registering the test results file
+					Expect(req.Method).To(Equal(http.MethodPost))
+					Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/bulk_test_results"))
+					Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+					resp.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(
+						"{\"test_results_uploads\":[{\"id\": %q, \"external_identifier\":%q,\"upload_url\":\"%d\"}]}",
+						"some-captain-identifier", mockUUID, GinkgoRandomSeed(),
+					)))
+				case 1: // upload to `upload_url`
+					Expect(req.Method).To(Equal(http.MethodPut))
+					Expect(req.URL.String()).To(ContainSubstring(fmt.Sprintf("%d", GinkgoRandomSeed())))
+
+					body, err := io.ReadAll(req.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(body)).To(ContainSubstring("\"contents\":\"PHRydW5jYXRlZCBkdWUgdG8gdGVzdCByZXN1bHRzIHNpemU+\""))
+
+					resp.Body = io.NopCloser(strings.NewReader(""))
+				case 2: // update status
+					Expect(req.Method).To(Equal(http.MethodPut))
+					Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/bulk_test_results"))
+					body, err := io.ReadAll(req.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(body)).To(ContainSubstring(fmt.Sprintf(
+						"%q,\"upload_status\":\"uploaded\"",
+						"some-captain-identifier",
+					)))
+					resp.Body = io.NopCloser(strings.NewReader(""))
+				default:
+					Fail("too many HTTP calls")
+				}
+
+				mockRoundTripCalls++
+
+				return &resp, nil
+			}
+		})
+
+		JustBeforeEach(func() {
+			tooMuchData := make([]byte, 26*1024*1024)
+			_, _ = rand.NewChaCha8([32]byte{}).Read(tooMuchData)
+
+			testResults = v1.TestResults{
+				DerivedFrom: []v1.OriginalTestResults{{
+					Contents: string(tooMuchData),
+				}},
+			}
+			_, err = apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+		})
+
+		It("strips the `derivedFrom` content from the test results", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with large backtraces in previous attempts", func() {
+		var err error
+
+		BeforeEach(func() {
+			err = nil
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				switch mockRoundTripCalls {
+				case 0: // registering the test results file
+					Expect(req.Method).To(Equal(http.MethodPost))
+					Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/bulk_test_results"))
+					Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+					resp.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(
+						"{\"test_results_uploads\":[{\"id\": %q, \"external_identifier\":%q,\"upload_url\":\"%d\"}]}",
+						"some-captain-identifier", mockUUID, GinkgoRandomSeed(),
+					)))
+				case 1: // upload to `upload_url`
+					Expect(req.Method).To(Equal(http.MethodPut))
+					Expect(req.URL.String()).To(ContainSubstring(fmt.Sprintf("%d", GinkgoRandomSeed())))
+
+					body, err := io.ReadAll(req.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(body)).To(ContainSubstring("\"contents\":\"PHRydW5jYXRlZCBkdWUgdG8gdGVzdCByZXN1bHRzIHNpemU+\""))
+					Expect(string(body)).To(ContainSubstring("\"backtrace\":[\"\\u003ctruncated due to test results size\\u003e\"]"))
+					Expect(string(body)).To(ContainSubstring("\"backtrace\":[\"won't be touched\"]"))
+
+					resp.Body = io.NopCloser(strings.NewReader(""))
+				case 2: // update status
+					Expect(req.Method).To(Equal(http.MethodPut))
+					Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/bulk_test_results"))
+					body, err := io.ReadAll(req.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(body)).To(ContainSubstring(fmt.Sprintf(
+						"%q,\"upload_status\":\"uploaded\"",
+						"some-captain-identifier",
+					)))
+					resp.Body = io.NopCloser(strings.NewReader(""))
+				default:
+					Fail("too many HTTP calls")
+				}
+
+				mockRoundTripCalls++
+
+				return &resp, nil
+			}
+		})
+
+		JustBeforeEach(func() {
+			tooMuchData := make([]byte, 26*1024*1024)
+			_, _ = rand.NewChaCha8([32]byte{}).Read(tooMuchData)
+
+			testResults = v1.TestResults{
+				Tests: []v1.Test{{
+					PastAttempts: []v1.TestAttempt{{
+						Status: v1.TestStatus{
+							Backtrace: []string{string(tooMuchData)},
+						},
+					}},
+					Attempt: v1.TestAttempt{
+						Status: v1.TestStatus{
+							Backtrace: []string{"won't be touched"},
+						},
+					},
+				}},
+				DerivedFrom: []v1.OriginalTestResults{{
+					Contents: "will be stripped regardless",
+				}},
+			}
+			_, err = apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+		})
+
+		It("strips the `derivedFrom` content from the test results", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with large backtraces in current attempt", func() {
+		var err error
+
+		BeforeEach(func() {
+			err = nil
+			mockRoundTripper = func(req *http.Request) (*http.Response, error) {
+				var resp http.Response
+
+				switch mockRoundTripCalls {
+				case 0: // registering the test results file
+					Expect(req.Method).To(Equal(http.MethodPost))
+					Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/bulk_test_results"))
+					Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+					resp.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(
+						"{\"test_results_uploads\":[{\"id\": %q, \"external_identifier\":%q,\"upload_url\":\"%d\"}]}",
+						"some-captain-identifier", mockUUID, GinkgoRandomSeed(),
+					)))
+				case 1: // upload to `upload_url`
+					Expect(req.Method).To(Equal(http.MethodPut))
+					Expect(req.URL.String()).To(ContainSubstring(fmt.Sprintf("%d", GinkgoRandomSeed())))
+
+					body, err := io.ReadAll(req.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(body)).To(ContainSubstring("\"contents\":\"PHRydW5jYXRlZCBkdWUgdG8gdGVzdCByZXN1bHRzIHNpemU+\""))
+					Expect(string(body)).To(ContainSubstring("\"backtrace\":[\"\\u003ctruncated due to test results size\\u003e\"]"))
+					Expect(string(body)).NotTo(ContainSubstring("\"backtrace\":[\"will be stripped regardless\"]"))
+
+					resp.Body = io.NopCloser(strings.NewReader(""))
+				case 2: // update status
+					Expect(req.Method).To(Equal(http.MethodPut))
+					Expect(req.URL.Path).To(HaveSuffix("/api/test_suites/bulk_test_results"))
+					body, err := io.ReadAll(req.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(body)).To(ContainSubstring(fmt.Sprintf(
+						"%q,\"upload_status\":\"uploaded\"",
+						"some-captain-identifier",
+					)))
+					resp.Body = io.NopCloser(strings.NewReader(""))
+				default:
+					Fail("too many HTTP calls")
+				}
+
+				mockRoundTripCalls++
+
+				return &resp, nil
+			}
+		})
+
+		JustBeforeEach(func() {
+			tooMuchData := make([]byte, 26*1024*1024)
+			_, _ = rand.NewChaCha8([32]byte{}).Read(tooMuchData)
+
+			testResults = v1.TestResults{
+				Tests: []v1.Test{{
+					PastAttempts: []v1.TestAttempt{{
+						Status: v1.TestStatus{
+							Backtrace: []string{"will be stripped regardless"},
+						},
+					}},
+					Attempt: v1.TestAttempt{
+						Status: v1.TestStatus{
+							Backtrace: []string{string(tooMuchData)},
+						},
+					},
+				}},
+				DerivedFrom: []v1.OriginalTestResults{{
+					Contents: "will be stripped regardless",
+				}},
+			}
+			_, err = apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
+		})
+
+		It("strips the `derivedFrom` content from the test results", func() {
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/internal/backend/remote/update_test_results_test.go
+++ b/internal/backend/remote/update_test_results_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("registers, uploads, and updates the test result in sequence", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))
@@ -132,7 +132,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("registers, uploads, and updates the test result in sequence", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))
@@ -148,7 +148,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("returns an error to the user", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
 			Expect(uploadResults).To(BeNil())
 			Expect(err).ToNot(Succeed())
 		})
@@ -188,7 +188,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("updates the upload status as failed", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(false))
@@ -225,7 +225,7 @@ var _ = Describe("Uploading Test Results", func() {
 		})
 
 		It("does not return an error to the user", func() {
-			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults, true)
+			uploadResults, err := apiClient.UpdateTestResults(context.Background(), "test suite id", testResults)
 			Expect(err).To(Succeed())
 			Expect(uploadResults).To(HaveLen(1))
 			Expect(uploadResults[0].Uploaded).To(Equal(true))

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -12,7 +12,7 @@ type Client interface {
 	GetRunConfiguration(ctx context.Context, testSuiteIdentifier string) (RunConfiguration, error)
 	GetQuarantinedTests(ctx context.Context, testSuiteIdentifier string) ([]Test, error)
 	GetTestTimingManifest(context.Context, string) ([]testing.TestFileTiming, error)
-	UpdateTestResults(context.Context, string, v1.TestResults, bool) ([]TestResultsUploadResult, error)
+	UpdateTestResults(context.Context, string, v1.TestResults) ([]TestResultsUploadResult, error)
 }
 
 type QuarantinedTest struct {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -930,7 +930,7 @@ func (s Service) reportTestResults(
 		return nil, nil
 	}
 
-	result, err := s.API.UpdateTestResults(ctx, cfg.SuiteID, newlyExecutedTestResults, true)
+	result, err := s.API.UpdateTestResults(ctx, cfg.SuiteID, newlyExecutedTestResults)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update test results")
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -186,7 +186,6 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				_ v1.TestResults,
-				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 				return []backend.TestResultsUploadResult{{OriginalPaths: []string{testResultsFilePath}, Uploaded: true}}, nil
@@ -400,7 +399,6 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				testResults v1.TestResults,
-				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 
@@ -791,7 +789,6 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				_ v1.TestResults,
-				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 
@@ -892,7 +889,6 @@ var _ = Describe("Run", func() {
 				_ context.Context,
 				_ string,
 				testResults v1.TestResults,
-				_ bool,
 			) ([]backend.TestResultsUploadResult, error) {
 				testResultsFileUploaded = true
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -162,7 +162,7 @@ func (s Service) UpdateTestResults(
 		return nil, errors.WithStack(err)
 	}
 
-	result, err := s.API.UpdateTestResults(ctx, testSuiteID, *parsedResults, true)
+	result, err := s.API.UpdateTestResults(ctx, testSuiteID, *parsedResults)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update test results")
 	}

--- a/internal/mocks/backend.go
+++ b/internal/mocks/backend.go
@@ -14,7 +14,7 @@ type API struct {
 	MockGetRunConfiguration   func(context.Context, string) (backend.RunConfiguration, error)
 	MockGetQuarantinedTests   func(context.Context, string) ([]backend.Test, error)
 	MockGetTestTimingManifest func(context.Context, string) ([]testing.TestFileTiming, error)
-	MockUpdateTestResults     func(context.Context, string, v1.TestResults, bool) (
+	MockUpdateTestResults     func(context.Context, string, v1.TestResults) (
 		[]backend.TestResultsUploadResult, error,
 	)
 }
@@ -60,10 +60,9 @@ func (a *API) UpdateTestResults(
 	ctx context.Context,
 	testSuiteID string,
 	testResults v1.TestResults,
-	_ bool,
 ) ([]backend.TestResultsUploadResult, error) {
 	if a.MockUpdateTestResults != nil {
-		return a.MockUpdateTestResults(ctx, testSuiteID, testResults, true)
+		return a.MockUpdateTestResults(ctx, testSuiteID, testResults)
 	}
 
 	return nil, errors.NewInternalError("MockUpdateTestResults was not configured")


### PR DESCRIPTION
Note this bumps the default threshold from 5 MiB to 25 MiB.