### PR TITLE
Allow messages, exceptions, and backtraces for timed out tests in Playwright

### DIFF
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Run", func() {
 							Name:     secondFailedTestDescription,
 							Location: &v1.Location{File: "/other/path/to/file.test"},
 							Attempt: v1.TestAttempt{
-								Status: v1.NewTimedOutTestStatus(),
+								Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 							},
 						},
 					},
@@ -778,7 +778,7 @@ var _ = Describe("Run", func() {
 							Name:     secondFailedTestDescription,
 							Location: &v1.Location{File: "/other/path/to/file.test"},
 							Attempt: v1.TestAttempt{
-								Status: v1.NewTimedOutTestStatus(),
+								Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 							},
 						},
 					},

--- a/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file
+++ b/internal/parsing/.snapshots/JavaScriptPlaywrightParser Parse parses the sample file
@@ -862,7 +862,8 @@
           "tags": []
         },
         "status": {
-          "kind": "timedOut"
+          "kind": "timedOut",
+          "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
         },
         "stderr": "",
         "stdout": "",
@@ -877,7 +878,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -897,7 +899,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -1447,7 +1450,8 @@
           "tags": []
         },
         "status": {
-          "kind": "timedOut"
+          "kind": "timedOut",
+          "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
         },
         "stderr": "",
         "stdout": "",
@@ -1462,7 +1466,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -1482,7 +1487,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -2006,7 +2012,8 @@
           "tags": []
         },
         "status": {
-          "kind": "timedOut"
+          "kind": "timedOut",
+          "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
         },
         "stderr": "",
         "stdout": "",
@@ -2021,7 +2028,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -2041,7 +2049,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -2455,7 +2464,8 @@
           "tags": []
         },
         "status": {
-          "kind": "timedOut"
+          "kind": "timedOut",
+          "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
         },
         "stderr": "",
         "stdout": "",
@@ -2470,7 +2480,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",
@@ -2490,7 +2501,8 @@
             "tags": []
           },
           "status": {
-            "kind": "timedOut"
+            "kind": "timedOut",
+            "message": "\u001b[31mTest timeout of 1000ms exceeded.\u001b[39m"
           },
           "stderr": "",
           "stdout": "",

--- a/internal/parsing/go_ginkgo_parser.go
+++ b/internal/parsing/go_ginkgo_parser.go
@@ -71,7 +71,7 @@ func (p GoGinkgoParser) Parse(data io.Reader) (*v1.TestResults, error) {
 			case ginkgo.SpecStateInterrupted:
 				status = v1.NewCanceledTestStatus()
 			case ginkgo.SpecStateTimedout:
-				status = v1.NewTimedOutTestStatus()
+				status = v1.NewTimedOutTestStatus(nil, nil, nil)
 			default:
 				return nil, errors.NewInputError("Unknown spec state: %v", specReport.State)
 			}

--- a/internal/parsing/javascript_playwright_parser.go
+++ b/internal/parsing/javascript_playwright_parser.go
@@ -280,7 +280,21 @@ func (p JavaScriptPlaywrightParser) testsWithinSuite(
 
 				status = v1.NewFailedTestStatus(message, nil, backtrace)
 			case "timedOut":
-				status = v1.NewTimedOutTestStatus()
+				var message *string
+				var backtrace []string
+
+				if result.Error != nil {
+					message = result.Error.Message
+
+					if result.Error.Stack != nil {
+						stackParts := javaScriptPlaywrightBacktraceSeparatorRegexp.Split(*result.Error.Stack, -1)[1:]
+						for _, part := range stackParts {
+							backtrace = append(backtrace, fmt.Sprintf("at%s", part))
+						}
+					}
+				}
+
+				status = v1.NewTimedOutTestStatus(message, nil, backtrace)
 			case "skipped":
 				status = v1.NewSkippedTestStatus(nil)
 			case "interrupted":

--- a/internal/reporting/markdown_test.go
+++ b/internal/reporting/markdown_test.go
@@ -102,12 +102,12 @@ var _ = Describe("Markdown Report", func() {
 				{
 					ID:      &id6,
 					Name:    "timed out test",
-					Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+					Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 				},
 				{
 					ID:      &id7,
 					Name:    "quarantined test",
-					Attempt: v1.TestAttempt{Status: v1.NewQuarantinedTestStatus(v1.NewTimedOutTestStatus())},
+					Attempt: v1.TestAttempt{Status: v1.NewQuarantinedTestStatus(v1.NewTimedOutTestStatus(nil, nil, nil))},
 				},
 				{
 					ID:      &id8,

--- a/internal/targetedretries/dot_net_xunit_substitution_test.go
+++ b/internal/targetedretries/dot_net_xunit_substitution_test.go
@@ -130,7 +130,7 @@ var _ = Describe("DotNetxUnitSubstitution", func() {
 					{
 						Attempt: v1.TestAttempt{
 							Meta:   map[string]any{"type": &type3, "method": &method3},
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{
@@ -208,7 +208,7 @@ var _ = Describe("DotNetxUnitSubstitution", func() {
 					{
 						Attempt: v1.TestAttempt{
 							Meta:   map[string]any{"type": &type3, "method": &method3},
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{

--- a/internal/targetedretries/elixir_exunit_substitution_test.go
+++ b/internal/targetedretries/elixir_exunit_substitution_test.go
@@ -120,7 +120,7 @@ var _ = Describe("ElixirExUnitSubstitution", func() {
 					},
 					{
 						Location: &v1.Location{File: file1, Line: &line2},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Location: &v1.Location{File: file3, Line: &line2},
@@ -182,7 +182,7 @@ var _ = Describe("ElixirExUnitSubstitution", func() {
 					},
 					{
 						Location: &v1.Location{File: file1, Line: &line2},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Location: &v1.Location{File: file3, Line: &line2},

--- a/internal/targetedretries/go_ginkgo_substitution_test.go
+++ b/internal/targetedretries/go_ginkgo_substitution_test.go
@@ -119,7 +119,7 @@ var _ = Describe("GoGinkgoSubstitution", func() {
 					},
 					{
 						Location: &v1.Location{File: file3, Line: &line3},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Location: &v1.Location{File: file2, Line: &line3},
@@ -174,7 +174,7 @@ var _ = Describe("GoGinkgoSubstitution", func() {
 					},
 					{
 						Location: &v1.Location{File: file3, Line: &line3},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Location: &v1.Location{File: file2, Line: &line3},

--- a/internal/targetedretries/go_test_substitution_test.go
+++ b/internal/targetedretries/go_test_substitution_test.go
@@ -141,7 +141,7 @@ var _ = Describe("GoTestSubstitution", func() {
 						Name: name2,
 						Attempt: v1.TestAttempt{
 							Meta:   map[string]any{"package": package1},
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{
@@ -223,7 +223,7 @@ var _ = Describe("GoTestSubstitution", func() {
 						Name: name2,
 						Attempt: v1.TestAttempt{
 							Meta:   map[string]any{"package": package1},
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{

--- a/internal/targetedretries/javascript_cucumber_substitution_test.go
+++ b/internal/targetedretries/javascript_cucumber_substitution_test.go
@@ -124,7 +124,7 @@ var _ = Describe("JavaScriptCucumberSubstitution", func() {
 					{
 						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{
@@ -191,7 +191,7 @@ var _ = Describe("JavaScriptCucumberSubstitution", func() {
 					{
 						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{

--- a/internal/targetedretries/javascript_cypress_substitution_test.go
+++ b/internal/targetedretries/javascript_cypress_substitution_test.go
@@ -157,7 +157,7 @@ var _ = Describe("JavaScriptCypressSubstitution", func() {
 					{
 						Name:     name3,
 						Location: &v1.Location{File: spec1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Name:     name1,
@@ -229,7 +229,7 @@ var _ = Describe("JavaScriptCypressSubstitution", func() {
 					{
 						Name:     name3,
 						Location: &v1.Location{File: spec1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Name:     name1,

--- a/internal/targetedretries/javascript_jest_substitution_test.go
+++ b/internal/targetedretries/javascript_jest_substitution_test.go
@@ -146,7 +146,7 @@ var _ = Describe("JavaScriptJestSubstitution", func() {
 					{
 						Lineage:  lineage2,
 						Location: &v1.Location{File: file1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Lineage:  lineage2,
@@ -218,7 +218,7 @@ var _ = Describe("JavaScriptJestSubstitution", func() {
 					{
 						Lineage:  lineage2,
 						Location: &v1.Location{File: file1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Lineage:  lineage2,

--- a/internal/targetedretries/javascript_mocha_substitution_test.go
+++ b/internal/targetedretries/javascript_mocha_substitution_test.go
@@ -146,7 +146,7 @@ var _ = Describe("JavaScriptMochaSubstitution", func() {
 					{
 						Name:     name2,
 						Location: &v1.Location{File: file1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Name:     name2,
@@ -218,7 +218,7 @@ var _ = Describe("JavaScriptMochaSubstitution", func() {
 					{
 						Name:     name2,
 						Location: &v1.Location{File: file1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Name:     name2,

--- a/internal/targetedretries/javascript_playwright_substitution_test.go
+++ b/internal/targetedretries/javascript_playwright_substitution_test.go
@@ -247,7 +247,7 @@ var _ = Describe("JavaScriptPlaywrightSubstitution", func() {
 							Location: &v1.Location{File: file2},
 							Attempt: v1.TestAttempt{
 								Meta:   map[string]any{"project": project2},
-								Status: v1.NewTimedOutTestStatus(),
+								Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 							},
 						},
 						{
@@ -341,7 +341,7 @@ var _ = Describe("JavaScriptPlaywrightSubstitution", func() {
 							Location: &v1.Location{File: file2},
 							Attempt: v1.TestAttempt{
 								Meta:   map[string]any{"project": project2},
-								Status: v1.NewTimedOutTestStatus(),
+								Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 							},
 						},
 						{
@@ -435,7 +435,7 @@ var _ = Describe("JavaScriptPlaywrightSubstitution", func() {
 							Location: &v1.Location{File: file2, Line: &lineTen},
 							Attempt: v1.TestAttempt{
 								Meta:   map[string]any{"project": project2},
-								Status: v1.NewTimedOutTestStatus(),
+								Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 							},
 						},
 						{
@@ -530,7 +530,7 @@ var _ = Describe("JavaScriptPlaywrightSubstitution", func() {
 							Location: &v1.Location{File: file2, Line: &lineTen},
 							Attempt: v1.TestAttempt{
 								Meta:   map[string]any{"project": project2},
-								Status: v1.NewTimedOutTestStatus(),
+								Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 							},
 						},
 						{

--- a/internal/targetedretries/javascript_vitest_substitution_test.go
+++ b/internal/targetedretries/javascript_vitest_substitution_test.go
@@ -146,7 +146,7 @@ var _ = Describe("JavaScriptVitestSubstitution", func() {
 					{
 						Lineage:  lineage2,
 						Location: &v1.Location{File: file1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Lineage:  lineage2,
@@ -218,7 +218,7 @@ var _ = Describe("JavaScriptVitestSubstitution", func() {
 					{
 						Lineage:  lineage2,
 						Location: &v1.Location{File: file1},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Lineage:  lineage2,

--- a/internal/targetedretries/json_substitution_test.go
+++ b/internal/targetedretries/json_substitution_test.go
@@ -130,7 +130,7 @@ var _ = Describe("JSONSubstitution", func() {
 				Tests: []v1.Test{
 					{ID: &id1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{ID: &id2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{ID: &id4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{ID: &id5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{ID: &id6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},
@@ -174,7 +174,7 @@ var _ = Describe("JSONSubstitution", func() {
 				Tests: []v1.Test{
 					{ID: &id1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{ID: &id2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{ID: &id4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{ID: &id5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{ID: &id6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},

--- a/internal/targetedretries/phpunit_substitution_test.go
+++ b/internal/targetedretries/phpunit_substitution_test.go
@@ -150,7 +150,7 @@ var _ = Describe("PHPUnitSubstitution", func() {
 						Location: &v1.Location{File: file1},
 						Attempt: v1.TestAttempt{
 							Meta:   map[string]any{"name": name2},
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{
@@ -227,7 +227,7 @@ var _ = Describe("PHPUnitSubstitution", func() {
 						Location: &v1.Location{File: file1},
 						Attempt: v1.TestAttempt{
 							Meta:   map[string]any{"name": name2},
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{

--- a/internal/targetedretries/python_pytest_substitution_test.go
+++ b/internal/targetedretries/python_pytest_substitution_test.go
@@ -111,7 +111,7 @@ var _ = Describe("PythonPytestSubstitution", func() {
 				Tests: []v1.Test{
 					{ID: &id1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{ID: &id2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{ID: &id4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{ID: &id5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{ID: &id6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},
@@ -148,7 +148,7 @@ var _ = Describe("PythonPytestSubstitution", func() {
 				Tests: []v1.Test{
 					{ID: &id1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{ID: &id2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{ID: &id4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{ID: &id5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{ID: &id6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},

--- a/internal/targetedretries/python_unittest_substitution_test.go
+++ b/internal/targetedretries/python_unittest_substitution_test.go
@@ -111,7 +111,7 @@ var _ = Describe("PythonUnitTestSubstitution", func() {
 				Tests: []v1.Test{
 					{Name: name1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{Name: name2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{Name: name3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{Name: name3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{Name: name4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{Name: name5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{Name: name6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},
@@ -148,7 +148,7 @@ var _ = Describe("PythonUnitTestSubstitution", func() {
 				Tests: []v1.Test{
 					{Name: name1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{Name: name2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{Name: name3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{Name: name3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{Name: name4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{Name: name5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{Name: name6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},

--- a/internal/targetedretries/ruby_cucumber_substitution_test.go
+++ b/internal/targetedretries/ruby_cucumber_substitution_test.go
@@ -124,7 +124,7 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 					{
 						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{
@@ -191,7 +191,7 @@ var _ = Describe("RubyCucumberSubstitution", func() {
 					{
 						Location: &v1.Location{File: file3},
 						Attempt: v1.TestAttempt{
-							Status: v1.NewTimedOutTestStatus(),
+							Status: v1.NewTimedOutTestStatus(nil, nil, nil),
 						},
 					},
 					{

--- a/internal/targetedretries/ruby_minitest_substitution_test.go
+++ b/internal/targetedretries/ruby_minitest_substitution_test.go
@@ -181,7 +181,7 @@ var _ = Describe("RubyMinitestSubstitution", func() {
 					},
 					{
 						Location: &v1.Location{File: file3, Line: &line2},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Location: &v1.Location{File: file1, Line: &line2},
@@ -237,7 +237,7 @@ var _ = Describe("RubyMinitestSubstitution", func() {
 					},
 					{
 						Location: &v1.Location{File: file3, Line: &line2},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Location: &v1.Location{File: file1, Line: &line2},
@@ -296,7 +296,7 @@ var _ = Describe("RubyMinitestSubstitution", func() {
 					{
 						Lineage:  lineage2,
 						Location: &v1.Location{File: file3},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Lineage:  lineage2,
@@ -370,7 +370,7 @@ var _ = Describe("RubyMinitestSubstitution", func() {
 					{
 						Lineage:  lineage2,
 						Location: &v1.Location{File: file3},
-						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+						Attempt:  v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 					},
 					{
 						Lineage:  lineage2,

--- a/internal/targetedretries/ruby_rspec_substitution_test.go
+++ b/internal/targetedretries/ruby_rspec_substitution_test.go
@@ -111,7 +111,7 @@ var _ = Describe("RubyRSpecSubstitution", func() {
 				Tests: []v1.Test{
 					{ID: &id1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{ID: &id2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{ID: &id4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{ID: &id5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{ID: &id6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},
@@ -147,7 +147,7 @@ var _ = Describe("RubyRSpecSubstitution", func() {
 				Tests: []v1.Test{
 					{ID: &id1, Attempt: v1.TestAttempt{Status: v1.NewFailedTestStatus(nil, nil, nil)}},
 					{ID: &id2, Attempt: v1.TestAttempt{Status: v1.NewCanceledTestStatus()}},
-					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}},
+					{ID: &id3, Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}},
 					{ID: &id4, Attempt: v1.TestAttempt{Status: v1.NewPendedTestStatus(nil)}},
 					{ID: &id5, Attempt: v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}},
 					{ID: &id6, Attempt: v1.TestAttempt{Status: v1.NewSkippedTestStatus(nil)}},

--- a/internal/testingschema/v1/summary_test.go
+++ b/internal/testingschema/v1/summary_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Summary", func() {
 				},
 			))
 
-			test = v1.Test{Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}}
+			test = v1.Test{Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}}
 			Expect(v1.NewSummary([]v1.Test{test, test}, nil)).To(Equal(
 				v1.Summary{
 					Status:   v1.SummaryStatusFailed,

--- a/internal/testingschema/v1/test.go
+++ b/internal/testingschema/v1/test.go
@@ -67,8 +67,13 @@ func NewSuccessfulTestStatus() TestStatus {
 	return TestStatus{Kind: TestStatusSuccessful}
 }
 
-func NewTimedOutTestStatus() TestStatus {
-	return TestStatus{Kind: TestStatusTimedOut}
+func NewTimedOutTestStatus(message *string, exception *string, backtrace []string) TestStatus {
+	return TestStatus{
+		Kind:      TestStatusTimedOut,
+		Message:   message,
+		Exception: exception,
+		Backtrace: backtrace,
+	}
 }
 
 func NewTodoTestStatus(message *string) TestStatus {

--- a/internal/testingschema/v1/test_test.go
+++ b/internal/testingschema/v1/test_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Test", func() {
 
 	Describe("NewTimedOutTestStatus", func() {
 		It("produces a TimedOut test status", func() {
-			Expect(v1.NewTimedOutTestStatus()).To(Equal(
+			Expect(v1.NewTimedOutTestStatus(nil, nil, nil)).To(Equal(
 				v1.TestStatus{
 					Kind: v1.TestStatusTimedOut,
 				},
@@ -150,7 +150,7 @@ var _ = Describe("Test", func() {
 		})
 
 		It("implies failure for timed out statuses", func() {
-			Expect(v1.NewTimedOutTestStatus().ImpliesFailure()).To(Equal(true))
+			Expect(v1.NewTimedOutTestStatus(nil, nil, nil).ImpliesFailure()).To(Equal(true))
 		})
 
 		It("does not imply failure for other statuses", func() {
@@ -168,7 +168,7 @@ var _ = Describe("Test", func() {
 		})
 
 		It("is potentially flaky for timed out statuses", func() {
-			Expect(v1.NewTimedOutTestStatus().PotentiallyFlaky()).To(Equal(true))
+			Expect(v1.NewTimedOutTestStatus(nil, nil, nil).PotentiallyFlaky()).To(Equal(true))
 		})
 
 		It("is not potentially flaky for other statuses", func() {
@@ -188,7 +188,7 @@ var _ = Describe("Test", func() {
 		})
 
 		It("is false for a test that timed out", func() {
-			test := v1.Test{Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus()}}
+			test := v1.Test{Attempt: v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)}}
 			Expect(test.Flaky()).To(Equal(false))
 		})
 
@@ -215,7 +215,7 @@ var _ = Describe("Test", func() {
 
 		It("is true for a test that timed out and passed", func() {
 			test := v1.Test{
-				Attempt:      v1.TestAttempt{Status: v1.NewTimedOutTestStatus()},
+				Attempt:      v1.TestAttempt{Status: v1.NewTimedOutTestStatus(nil, nil, nil)},
 				PastAttempts: []v1.TestAttempt{{Status: v1.NewSuccessfulTestStatus()}},
 			}
 			Expect(test.Flaky()).To(Equal(true))


### PR DESCRIPTION
In Playwright, timedOut tests have messages just like failed tests.

The most interesting changes here are in `internal/parsing/javascript_playwright_parser.go` and the snapshot for that file's tests.