### PR TITLE
Adds environment variables for stripping data from captain parse results

### DIFF
--- a/internal/testingschema/v1/strip.go
+++ b/internal/testingschema/v1/strip.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+const TruncationMessage = "<truncated due to test results size>"
+
+func StripDerivedFrom(testResults TestResults) TestResults {
+	cleanedDerivedFrom := make([]OriginalTestResults, len(testResults.DerivedFrom))
+
+	for i, originalTestResults := range testResults.DerivedFrom {
+		cleanedDerivedFrom[i] = OriginalTestResults{
+			OriginalFilePath: originalTestResults.OriginalFilePath,
+			GroupNumber:      originalTestResults.GroupNumber,
+			Contents:         base64.StdEncoding.EncodeToString([]byte(TruncationMessage)),
+		}
+	}
+
+	return TestResults{
+		Framework:   testResults.Framework,
+		Summary:     testResults.Summary,
+		Tests:       testResults.Tests,
+		OtherErrors: testResults.OtherErrors,
+		DerivedFrom: cleanedDerivedFrom,
+	}
+}
+
+func StripPreviousAttempts(testResults TestResults) TestResults {
+	for i, test := range testResults.Tests {
+		for j, attempt := range test.PastAttempts {
+			testResults.Tests[i].PastAttempts[j].Status = stripStatus(attempt.Status)
+		}
+	}
+
+	return testResults
+}
+
+func StripCurrentAttempts(testResults TestResults) TestResults {
+	for i, test := range testResults.Tests {
+		if test.Attempt.Status.Backtrace != nil {
+			testResults.Tests[i].Attempt.Status = stripStatus(test.Attempt.Status)
+		}
+	}
+
+	return testResults
+}
+
+func stripStatus(status TestStatus) TestStatus {
+	if status.Backtrace != nil {
+		status.Backtrace = []string{TruncationMessage}
+	}
+
+	if status.OriginalStatus != nil {
+		s := stripStatus(*status.OriginalStatus)
+		status.OriginalStatus = &s
+	}
+
+	return status
+}
+
+func StripToSize(testResults TestResults, fileSizeThresholdBytes int64) TestResults {
+	type stripFunc func(TestResults) TestResults
+	for _, strip := range []stripFunc{StripDerivedFrom, StripPreviousAttempts, StripCurrentAttempts} {
+		// Marshal to check current size
+		buf, err := json.Marshal(testResults)
+		if err != nil {
+			return testResults
+		}
+
+		if int64(len(buf)) <= fileSizeThresholdBytes {
+			break
+		}
+
+		testResults = strip(testResults)
+	}
+
+	return testResults
+}


### PR DESCRIPTION
Now you can set `CAPTAIN_STRIP_DERIVED_FROM` and `CAPTAIN_MAX_FILE_SIZE_IN_MEGABYTES` when running `captain parse results` to limit the size and noise of the output results.