### PR TITLE
Make the Mocha error parser more generous

### DIFF
--- a/internal/parsing/javascript_mocha_parser.go
+++ b/internal/parsing/javascript_mocha_parser.go
@@ -26,9 +26,7 @@ type JavaScriptMochaStats struct {
 }
 
 type JavaScriptMochaError struct {
-	Actual           *string `json:"actual,omitempty"`
 	Code             *string `json:"code,omitempty"`
-	Expected         *string `json:"expected,omitempty"`
 	GeneratedMessage *bool   `json:"generatedMessage,omitempty"`
 	Message          string  `json:"message"`
 	Name             *string `json:"name,omitempty"`


### PR DESCRIPTION
These fields can be more than just a string. Since we don't actually use them, I chose to remove them from the parser.