### PR TITLE
Migrate base config from deprecated os+tag to image+config

### DIFF
--- a/.rwx/buildkite.yml
+++ b/.rwx/buildkite.yml
@@ -1,6 +1,6 @@
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: code

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -13,8 +13,8 @@ concurrency-pools:
     on-overflow: cancel-running
 
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: test

--- a/.rwx/generate-backwards-compatibility-tests.yml
+++ b/.rwx/generate-backwards-compatibility-tests.yml
@@ -1,6 +1,6 @@
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: code

--- a/.rwx/lint.yml
+++ b/.rwx/lint.yml
@@ -1,6 +1,6 @@
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: code

--- a/.rwx/publish.yml
+++ b/.rwx/publish.yml
@@ -1,6 +1,6 @@
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: github-cli

--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -21,8 +21,8 @@ concurrency-pools:
     on-overflow: queue
 
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: verify-kind
@@ -38,8 +38,8 @@ tasks:
       if [[ "${{ init.kind }}" == "production" ]]; then
         cat << EOF | tee extract-version-details.yml
           base:
-            os: ubuntu 24.04
-            tag: 1.1
+            image: ubuntu:24.04
+            config: rwx/base 1.0.0
 
           tasks:
             - key: extract-version-details
@@ -52,8 +52,8 @@ tasks:
       if [[ "${{ init.kind }}" == "unstable" ]]; then
         cat << EOF | tee extract-version-details.yml
           base:
-            os: ubuntu 24.04
-            tag: 1.1
+            image: ubuntu:24.04
+            config: rwx/base 1.0.0
 
           tasks:
             - key: extract-version-details
@@ -65,8 +65,8 @@ tasks:
       if [[ "${{ init.kind }}" == "testing" ]]; then
         cat << EOF | tee extract-version-details.yml
           base:
-            os: ubuntu 24.04
-            tag: 1.1
+            image: ubuntu:24.04
+            config: rwx/base 1.0.0
 
           tasks:
             - key: extract-version-details

--- a/.rwx/test-backwards-compatibility.yml
+++ b/.rwx/test-backwards-compatibility.yml
@@ -4,8 +4,8 @@ concurrency-pools:
     on-overflow: queue
 
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: new-code

--- a/.rwx/test.yml
+++ b/.rwx/test.yml
@@ -7,8 +7,8 @@ on:
         trigger: "cron"
 
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: code

--- a/.rwx/upload.yml
+++ b/.rwx/upload.yml
@@ -1,6 +1,6 @@
 base:
-  os: ubuntu 24.04
-  tag: 1.2
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
 
 tasks:
   - key: code


### PR DESCRIPTION
## Summary
- Migrates all `.rwx/` config files from the deprecated `os` + `tag` base syntax to the new `image` + `config` syntax
- Per https://www.rwx.com/docs/rwx/base-os-to-image-migration

## Test plan
- [ ] Verify RWX runs execute successfully with the new base config