### PR TITLE
Treat package-level failures as other errors for go test

### DIFF
--- a/internal/parsing/go_test_parser.go
+++ b/internal/parsing/go_test_parser.go
@@ -27,6 +27,7 @@ type GoTestTestOutput struct {
 
 func (p GoTestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 	testsByPackage := map[string]map[string]v1.Test{}
+	failedPackages := map[string]bool{}
 	scanner := bufio.NewScanner(data)
 	for scanner.Scan() {
 		text := strings.TrimSpace(scanner.Text())
@@ -43,8 +44,10 @@ func (p GoTestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 			return nil, errors.NewInputError("Test results do not look like go test")
 		}
 
-		// We don't care about package-level stats/info
 		if testOutput.Test == nil {
+			if *testOutput.Action == "fail" {
+				failedPackages[*testOutput.Package] = true
+			}
 			continue
 		}
 
@@ -129,9 +132,34 @@ func (p GoTestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 		return tests[i].Name < tests[j].Name
 	})
 
+	// Detect package-level failures where no individual test in the package failed.
+	// This can happen when a goroutine panics, TestMain fails, or there's a build error.
+	var otherErrors []v1.OtherError
+	for pkg := range failedPackages {
+		hasFailedTest := false
+		if testsByName, ok := testsByPackage[pkg]; ok {
+			for _, test := range testsByName {
+				if test.Attempt.Status.ImpliesFailure() {
+					hasFailedTest = true
+					break
+				}
+			}
+		}
+		if !hasFailedTest {
+			otherErrors = append(otherErrors, v1.OtherError{
+				Message: "Package " + pkg + " failed with no individual test failure. Check for a panic outside the tests.",
+			})
+		}
+	}
+
+	// For determinism
+	sort.Slice(otherErrors, func(i, j int) bool {
+		return otherErrors[i].Message < otherErrors[j].Message
+	})
+
 	return v1.NewTestResults(
 		v1.GoTestFramework,
 		tests,
-		nil,
+		otherErrors,
 	), nil
 }

--- a/internal/parsing/go_test_parser_test.go
+++ b/internal/parsing/go_test_parser_test.go
@@ -67,6 +67,35 @@ var _ = Describe("GoTestParser", func() {
 			Expect(*timedOutTest.Attempt.Status.Message).To(ContainSubstring("Captain inferred that this test timed out"))
 		})
 
+		It("reports an other error when a package fails with no individual test failure", func() {
+			fixture, err := os.Open("../../test/fixtures/go_test_package_failure.jsonl")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.GoTestParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testResults.Tests).To(HaveLen(1))
+			Expect(testResults.Tests[0].Name).To(Equal("TestOne"))
+			Expect(testResults.Tests[0].Attempt.Status.Kind).To(Equal(v1.TestStatusSuccessful))
+
+			Expect(testResults.OtherErrors).To(HaveLen(1))
+			Expect(testResults.OtherErrors[0].Message).To(ContainSubstring("example.com/pkg1"))
+			Expect(testResults.OtherErrors[0].Message).To(ContainSubstring("no individual test failure"))
+
+			Expect(testResults.Summary.Status).To(Equal(v1.SummaryStatusFailed))
+			Expect(testResults.Summary.OtherErrors).To(Equal(1))
+		})
+
+		It("does not report an other error when a package fails with a failed test", func() {
+			fixture, err := os.Open("../../test/fixtures/go_test.jsonl")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.GoTestParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testResults.OtherErrors).To(HaveLen(0))
+		})
+
 		It("errors on malformed JSON with no remnants of Go Test JSON", func() {
 			testResults, err := parsing.GoTestParser{}.Parse(strings.NewReader(`asdfasdfsdf`))
 			Expect(err).To(HaveOccurred())

--- a/test/fixtures/go_test_package_failure.jsonl
+++ b/test/fixtures/go_test_package_failure.jsonl
@@ -1,0 +1,7 @@
+{"Time":"2026-04-04T18:28:33.454944538Z","Action":"start","Package":"example.com/pkg1"}
+{"Time":"2026-04-04T18:28:33.556043969Z","Action":"run","Package":"example.com/pkg1","Test":"TestOne"}
+{"Time":"2026-04-04T18:28:33.556078696Z","Action":"output","Package":"example.com/pkg1","Test":"TestOne","Output":"=== RUN   TestOne\n"}
+{"Time":"2026-04-04T18:28:33.556090549Z","Action":"output","Package":"example.com/pkg1","Test":"TestOne","Output":"--- PASS: TestOne (0.39s)\n"}
+{"Time":"2026-04-04T18:28:33.947787133Z","Action":"pass","Package":"example.com/pkg1","Test":"TestOne","Elapsed":0.39}
+{"Time":"2026-04-04T18:29:10.907551788Z","Action":"output","Package":"example.com/pkg1","Output":"FAIL\texample.com/pkg1\t37.452s\n"}
+{"Time":"2026-04-04T18:29:10.90756414Z","Action":"fail","Package":"example.com/pkg1","Elapsed":37.453}


### PR DESCRIPTION
This came up during a customer implementation.