### PR TITLE
Synthesize karma test id/name when karma-mocha omits them

### DIFF
--- a/internal/parsing/.snapshots/JavaScriptKarmaParser Parse synthesizes id and name from suite and description when karma-mocha leaves them empty
+++ b/internal/parsing/.snapshots/JavaScriptKarmaParser Parse synthesizes id and name from suite and description when karma-mocha leaves them empty
@@ -100,11 +100,9 @@
         },
         "status": {
           "kind": "failed",
-          "message": "Expected true to be false.",
+          "message": "AssertionError: Expected true to be false.",
           "backtrace": [
-            "at \u003cJasmine\u003e",
-            "at UserContext.\u003canonymous\u003e (http://localhost:9876/base/tests/some-test.js?0928787523d1ecf8fe8e5c6b04ef9abb48348e11:19:18)",
-            "at \u003cJasmine\u003e"
+            "at Context.\u003canonymous\u003e (http://localhost:9876/base/tests/some-test.js?0928787523d1ecf8fe8e5c6b04ef9abb48348e11:19:18)"
           ]
         }
       }

--- a/internal/parsing/.snapshots/JavaScriptKarmaParser Parse synthesizes id and name from suite and description when karma-mocha leaves them empty
+++ b/internal/parsing/.snapshots/JavaScriptKarmaParser Parse synthesizes id and name from suite and description when karma-mocha leaves them empty
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "JavaScript",
+    "kind": "Karma"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 4,
+    "flaky": 0,
+    "otherErrors": 0,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 1,
+    "pended": 0,
+    "quarantined": 0,
+    "skipped": 1,
+    "successful": 2,
+    "timedOut": 0,
+    "todo": 0
+  },
+  "tests": [
+    {
+      "id": "Some test context is a contextual passing test",
+      "name": "Some test context is a contextual passing test",
+      "scope": "Chrome macOS",
+      "lineage": [
+        "Some test",
+        "context",
+        "is a contextual passing test"
+      ],
+      "attempt": {
+        "durationInNanoseconds": 1000000,
+        "meta": {
+          "browserFullName": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+          "browserId": "87843490",
+          "browserName": "Chrome macOS"
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "Some test is a passing test",
+      "name": "Some test is a passing test",
+      "scope": "Chrome macOS",
+      "lineage": [
+        "Some test",
+        "is a passing test"
+      ],
+      "attempt": {
+        "durationInNanoseconds": 1000000,
+        "meta": {
+          "browserFullName": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+          "browserId": "87843490",
+          "browserName": "Chrome macOS"
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "id": "Some test is a skipped test",
+      "name": "Some test is a skipped test",
+      "scope": "Chrome macOS",
+      "lineage": [
+        "Some test",
+        "is a skipped test"
+      ],
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "browserFullName": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+          "browserId": "87843490",
+          "browserName": "Chrome macOS"
+        },
+        "status": {
+          "kind": "skipped"
+        }
+      }
+    },
+    {
+      "id": "Some test is a failing test",
+      "name": "Some test is a failing test",
+      "scope": "Chrome macOS",
+      "lineage": [
+        "Some test",
+        "is a failing test"
+      ],
+      "attempt": {
+        "durationInNanoseconds": 0,
+        "meta": {
+          "browserFullName": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+          "browserId": "87843490",
+          "browserName": "Chrome macOS"
+        },
+        "status": {
+          "kind": "failed",
+          "message": "Expected true to be false.",
+          "backtrace": [
+            "at \u003cJasmine\u003e",
+            "at UserContext.\u003canonymous\u003e (http://localhost:9876/base/tests/some-test.js?0928787523d1ecf8fe8e5c6b04ef9abb48348e11:19:18)",
+            "at \u003cJasmine\u003e"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/parsing/javascript_karma_parser.go
+++ b/internal/parsing/javascript_karma_parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/mileusna/useragent"
@@ -87,7 +88,24 @@ func (p JavaScriptKarmaParser) Parse(data io.Reader) (*v1.TestResults, error) {
 		}
 
 		for _, testCase := range testCases {
+			lineage := make([]string, 0, len(testCase.Suite)+1)
+			lineage = append(lineage, testCase.Suite...)
+			lineage = append(lineage, testCase.Description)
+
+			// karma-mocha's adapter hardcodes `id` to "" and does not emit a `fullName`
+			// field at all (see karma-mocha/src/adapter.js). Without a fallback, every
+			// karma-mocha test reduces to the same composite identifier and Captain
+			// reports them as duplicates. karma-jasmine populates both fields and is
+			// unaffected by this fallback.
 			id := testCase.ID
+			name := testCase.FullName
+			if name == "" {
+				name = strings.Join(lineage, " ")
+			}
+			if id == "" {
+				id = name
+			}
+
 			duration := time.Duration(testCase.Time * int(time.Millisecond))
 			var status v1.TestStatus
 			switch {
@@ -121,9 +139,9 @@ func (p JavaScriptKarmaParser) Parse(data io.Reader) (*v1.TestResults, error) {
 				tests,
 				v1.Test{
 					ID:      &id,
-					Name:    testCase.FullName,
+					Name:    name,
 					Scope:   &browserName,
-					Lineage: append(testCase.Suite, testCase.Description),
+					Lineage: lineage,
 					Attempt: v1.TestAttempt{
 						Duration: &duration,
 						Status:   status,

--- a/internal/parsing/javascript_karma_parser.go
+++ b/internal/parsing/javascript_karma_parser.go
@@ -88,10 +88,6 @@ func (p JavaScriptKarmaParser) Parse(data io.Reader) (*v1.TestResults, error) {
 		}
 
 		for _, testCase := range testCases {
-			lineage := make([]string, 0, len(testCase.Suite)+1)
-			lineage = append(lineage, testCase.Suite...)
-			lineage = append(lineage, testCase.Description)
-
 			// karma-mocha's adapter hardcodes `id` to "" and does not emit a `fullName`
 			// field at all (see karma-mocha/src/adapter.js). Without a fallback, every
 			// karma-mocha test reduces to the same composite identifier and Captain
@@ -100,7 +96,7 @@ func (p JavaScriptKarmaParser) Parse(data io.Reader) (*v1.TestResults, error) {
 			id := testCase.ID
 			name := testCase.FullName
 			if name == "" {
-				name = strings.Join(lineage, " ")
+				name = strings.Join(append(testCase.Suite, testCase.Description), " ")
 			}
 			if id == "" {
 				id = name
@@ -141,7 +137,7 @@ func (p JavaScriptKarmaParser) Parse(data io.Reader) (*v1.TestResults, error) {
 					ID:      &id,
 					Name:    name,
 					Scope:   &browserName,
-					Lineage: lineage,
+					Lineage: append(testCase.Suite, testCase.Description),
 					Attempt: v1.TestAttempt{
 						Duration: &duration,
 						Status:   status,

--- a/internal/parsing/javascript_karma_parser_test.go
+++ b/internal/parsing/javascript_karma_parser_test.go
@@ -35,6 +35,21 @@ var _ = Describe("JavaScriptKarmaParser", func() {
 			testResults, err := parsing.JavaScriptKarmaParser{}.Parse(fixture)
 			Expect(err).ToNot(HaveOccurred())
 
+			Expect(testResults.Tests).To(HaveLen(4))
+			synthesizedNames := make([]string, 0, len(testResults.Tests))
+			for _, test := range testResults.Tests {
+				Expect(test.ID).ToNot(BeNil())
+				Expect(*test.ID).ToNot(BeEmpty())
+				Expect(*test.ID).To(Equal(test.Name))
+				synthesizedNames = append(synthesizedNames, test.Name)
+			}
+			Expect(synthesizedNames).To(ConsistOf(
+				"Some test context is a contextual passing test",
+				"Some test is a passing test",
+				"Some test is a skipped test",
+				"Some test is a failing test",
+			))
+
 			rwxJSON, err := json.MarshalIndent(testResults, "", "  ")
 			Expect(err).ToNot(HaveOccurred())
 			cupaloy.SnapshotT(GinkgoT(), rwxJSON)

--- a/internal/parsing/javascript_karma_parser_test.go
+++ b/internal/parsing/javascript_karma_parser_test.go
@@ -28,6 +28,18 @@ var _ = Describe("JavaScriptKarmaParser", func() {
 			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
 		})
 
+		It("synthesizes id and name from suite and description when karma-mocha leaves them empty", func() {
+			fixture, err := os.Open("../../test/fixtures/karma_mocha.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.JavaScriptKarmaParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+
+			rwxJSON, err := json.MarshalIndent(testResults, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
+		})
+
 		It("errors on JSON that doesn't look like Karma", func() {
 			var testResults *v1.TestResults
 			var err error

--- a/test/fixtures/karma_mocha.json
+++ b/test/fixtures/karma_mocha.json
@@ -1,0 +1,115 @@
+{
+  "browsers": {
+    "87843490": {
+      "id": "87843490",
+      "fullName": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+      "name": "Chrome 109.0.0.0 (Mac OS 10.15.7)",
+      "state": "DISCONNECTED",
+      "lastResult": {
+        "startTime": 1677015045628,
+        "total": 4,
+        "success": 2,
+        "failed": 1,
+        "skipped": 1,
+        "totalTime": 6,
+        "netTime": 2,
+        "error": true,
+        "disconnected": false
+      },
+      "disconnectsCount": 0,
+      "noActivityTimeout": 30000,
+      "disconnectDelay": 2000
+    }
+  },
+  "result": {
+    "87843490": [
+      {
+        "description": "is a contextual passing test",
+        "id": "",
+        "log": [],
+        "skipped": false,
+        "disabled": false,
+        "pending": false,
+        "success": true,
+        "suite": ["Some test", "context"],
+        "time": 1,
+        "executedExpectationsCount": 1,
+        "passedExpectations": [
+          {
+            "matcherName": "toBe",
+            "message": "Passed.",
+            "stack": "",
+            "passed": true
+          }
+        ],
+        "properties": null
+      },
+      {
+        "description": "is a passing test",
+        "id": "",
+        "log": [],
+        "skipped": false,
+        "disabled": false,
+        "pending": false,
+        "success": true,
+        "suite": ["Some test"],
+        "time": 1,
+        "executedExpectationsCount": 2,
+        "passedExpectations": [
+          {
+            "matcherName": "toBe",
+            "message": "Passed.",
+            "stack": "",
+            "passed": true
+          },
+          {
+            "matcherName": "toBe",
+            "message": "Passed.",
+            "stack": "",
+            "passed": true
+          }
+        ],
+        "properties": null
+      },
+      {
+        "description": "is a skipped test",
+        "id": "",
+        "log": [],
+        "skipped": true,
+        "disabled": false,
+        "pending": true,
+        "success": true,
+        "suite": ["Some test"],
+        "time": 0,
+        "executedExpectationsCount": 0,
+        "passedExpectations": [],
+        "properties": null
+      },
+      {
+        "description": "is a failing test",
+        "id": "",
+        "log": [
+          "Expected true to be false.\n    at <Jasmine>\n    at UserContext.<anonymous> (http://localhost:9876/base/tests/some-test.js?0928787523d1ecf8fe8e5c6b04ef9abb48348e11:19:18)\n    at <Jasmine>"
+        ],
+        "skipped": false,
+        "disabled": false,
+        "pending": false,
+        "success": false,
+        "suite": ["Some test"],
+        "time": 0,
+        "executedExpectationsCount": 1,
+        "passedExpectations": [],
+        "properties": null,
+        "debug_url": "http://localhost:9876/debug.html?spec=Some%20test%20is%20a%20failing%20test"
+      }
+    ]
+  },
+  "summary": {
+    "success": 2,
+    "failed": 1,
+    "skipped": 1,
+    "error": true,
+    "disconnected": false,
+    "exitCode": 1
+  }
+}

--- a/test/fixtures/karma_mocha.json
+++ b/test/fixtures/karma_mocha.json
@@ -24,83 +24,57 @@
   "result": {
     "87843490": [
       {
+        "id": "",
         "description": "is a contextual passing test",
-        "id": "",
-        "log": [],
-        "skipped": false,
-        "disabled": false,
-        "pending": false,
-        "success": true,
         "suite": ["Some test", "context"],
+        "success": true,
+        "skipped": false,
+        "pending": false,
         "time": 1,
-        "executedExpectationsCount": 1,
-        "passedExpectations": [
-          {
-            "matcherName": "toBe",
-            "message": "Passed.",
-            "stack": "",
-            "passed": true
-          }
-        ],
-        "properties": null
+        "log": [],
+        "assertionErrors": [],
+        "startTime": 1677015045630,
+        "endTime": 1677015045631
       },
       {
+        "id": "",
         "description": "is a passing test",
-        "id": "",
-        "log": [],
-        "skipped": false,
-        "disabled": false,
-        "pending": false,
-        "success": true,
         "suite": ["Some test"],
+        "success": true,
+        "skipped": false,
+        "pending": false,
         "time": 1,
-        "executedExpectationsCount": 2,
-        "passedExpectations": [
-          {
-            "matcherName": "toBe",
-            "message": "Passed.",
-            "stack": "",
-            "passed": true
-          },
-          {
-            "matcherName": "toBe",
-            "message": "Passed.",
-            "stack": "",
-            "passed": true
-          }
-        ],
-        "properties": null
-      },
-      {
-        "description": "is a skipped test",
-        "id": "",
         "log": [],
-        "skipped": true,
-        "disabled": false,
-        "pending": true,
-        "success": true,
-        "suite": ["Some test"],
-        "time": 0,
-        "executedExpectationsCount": 0,
-        "passedExpectations": [],
-        "properties": null
+        "assertionErrors": [],
+        "startTime": 1677015045632,
+        "endTime": 1677015045633
       },
       {
-        "description": "is a failing test",
         "id": "",
-        "log": [
-          "Expected true to be false.\n    at <Jasmine>\n    at UserContext.<anonymous> (http://localhost:9876/base/tests/some-test.js?0928787523d1ecf8fe8e5c6b04ef9abb48348e11:19:18)\n    at <Jasmine>"
-        ],
-        "skipped": false,
-        "disabled": false,
-        "pending": false,
-        "success": false,
+        "description": "is a skipped test",
         "suite": ["Some test"],
+        "success": false,
+        "skipped": true,
+        "pending": true,
         "time": 0,
-        "executedExpectationsCount": 1,
-        "passedExpectations": [],
-        "properties": null,
-        "debug_url": "http://localhost:9876/debug.html?spec=Some%20test%20is%20a%20failing%20test"
+        "log": [],
+        "assertionErrors": [],
+        "endTime": 1677015045633
+      },
+      {
+        "id": "",
+        "description": "is a failing test",
+        "suite": ["Some test"],
+        "success": false,
+        "skipped": false,
+        "pending": false,
+        "time": 0,
+        "log": [
+          "AssertionError: Expected true to be false.\n    at Context.<anonymous> (http://localhost:9876/base/tests/some-test.js?0928787523d1ecf8fe8e5c6b04ef9abb48348e11:19:18)"
+        ],
+        "assertionErrors": [],
+        "startTime": 1677015045634,
+        "endTime": 1677015045634
       }
     ]
   },


### PR DESCRIPTION
## Summary
- karma-mocha's adapter hardcodes each test's `id` to `""` and never emits a `fullName` field (see [karma-mocha/src/adapter.js](https://github.com/karma-runner/karma-mocha/blob/master/src/adapter.js)). With Captain's prior logic, every karma-mocha test reduced to the same composite identifier and surfaced as duplicates.
- Fall back to `suite` joined with `description` when those fields are empty. karma-jasmine populates both and is unaffected.
- Added a `karma_mocha.json` fixture that mirrors what the karma-mocha adapter actually emits (empty `id`, no `fullName`, mocha-style stack, `assertionErrors`/`startTime`/`endTime`) and a snapshot test covering the synthesis path.

Linear: [RWX-968](https://linear.app/rwx/issue/RWX-968)

## Test plan
- [x] `go test ./internal/parsing/...` passes
- [x] CI green