### PR TITLE
Preserve per-attempt attachments and full attempt history across retries

### DIFF
--- a/internal/cli/attachment_preservation.go
+++ b/internal/cli/attachment_preservation.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rwx-research/captain-cli/internal/errors"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+)
+
+// preservedAttachmentsDir is the working-directory-relative root under which Captain copies test
+// attachment files (e.g. Playwright traces). Frameworks write attachments to deterministic per-retry
+// paths; when Captain re-invokes the test command for a targeted retry, those files are overwritten
+// in place. Without preserving them, only the final invocation's attachment survives on disk, and it
+// ends up associated with whichever attempt the merged results happen to reference that path from.
+const preservedAttachmentsDir = "captain-attempts"
+
+// fileAttachment mirrors the shape Captain stores under an attempt's meta["fileAttachments"]. We
+// round-trip through JSON rather than depend on a framework-specific type, so the reporter emits the
+// same {name, path} shape it otherwise would.
+type fileAttachment struct {
+	Name string `json:"name"`
+	Path string `json:"path,omitempty"`
+}
+
+// shouldPreserveAttachments reports whether Captain is running in an RWX context, where the RWX agent
+// resolves and uploads attachment paths from the emitted results. Gating on this keeps local
+// `captain run` users from getting rewritten paths or extra files in their working tree.
+func shouldPreserveAttachments() bool {
+	return os.Getenv("RWX_TEST_RESULTS") != ""
+}
+
+// preserveAttachments copies every attempt's attachment files into a unique, invocation-scoped
+// location and rewrites the in-memory attachment paths to point at the copies. It must be called
+// after an invocation's results are parsed but before the next invocation overwrites the files.
+func (s Service) preserveAttachments(results *v1.TestResults, scope string) error {
+	if results == nil {
+		return nil
+	}
+
+	workingDir, err := s.FileSystem.Getwd()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for ti := range results.Tests {
+		test := &results.Tests[ti]
+
+		if err := s.preserveAttemptAttachments(&test.Attempt, scope, workingDir); err != nil {
+			return err
+		}
+
+		for ai := range test.PastAttempts {
+			if err := s.preserveAttemptAttachments(&test.PastAttempts[ai], scope, workingDir); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s Service) preserveAttemptAttachments(attempt *v1.TestAttempt, scope string, workingDir string) error {
+	if attempt.Meta == nil {
+		return nil
+	}
+
+	raw, ok := attempt.Meta["fileAttachments"]
+	if !ok {
+		return nil
+	}
+
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	var attachments []fileAttachment
+	if err := json.Unmarshal(encoded, &attachments); err != nil {
+		// Not a recognized attachment shape; leave it untouched.
+		return nil //nolint:nilerr
+	}
+
+	changed := false
+	for i := range attachments {
+		srcPath := attachments[i].Path
+		if srcPath == "" {
+			continue
+		}
+
+		srcAbs := srcPath
+		if !filepath.IsAbs(srcAbs) {
+			srcAbs = filepath.Join(workingDir, srcPath)
+		}
+
+		// The file may already have been overwritten or removed by a later invocation; skip if missing.
+		if _, err := s.FileSystem.Stat(srcAbs); err != nil {
+			continue
+		}
+
+		destRel := filepath.Join(preservedAttachmentsDir, scope, relativeAttachmentPath(srcPath, srcAbs, workingDir))
+		destAbs := filepath.Join(workingDir, destRel)
+
+		if err := s.FileSystem.MkdirAll(filepath.Dir(destAbs), 0o750); err != nil {
+			return errors.WithStack(err)
+		}
+		if err := copyFile(s.FileSystem, srcAbs, destAbs); err != nil {
+			return errors.WithStack(err)
+		}
+
+		attachments[i].Path = destRel
+		changed = true
+	}
+
+	if changed {
+		attempt.Meta["fileAttachments"] = attachments
+	}
+
+	return nil
+}
+
+// relativeAttachmentPath derives a working-directory-relative path to mirror the source attachment
+// under, so the preserved copy resolves the same way the original did.
+func relativeAttachmentPath(srcPath, srcAbs, workingDir string) string {
+	if !filepath.IsAbs(srcPath) {
+		return srcPath
+	}
+
+	if rel, err := filepath.Rel(workingDir, srcAbs); err == nil && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+
+	return strings.TrimPrefix(srcAbs, string(filepath.Separator))
+}

--- a/internal/cli/attachment_preservation_internal_test.go
+++ b/internal/cli/attachment_preservation_internal_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rwx-research/captain-cli/internal/fs"
+	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
+)
+
+// fixedWorkingDirFS is a real filesystem whose Getwd is pinned to a fixed directory, so tests can
+// exercise attachment preservation against a temp dir without mutating the process's working
+// directory (which would make them unsafe to run in parallel).
+type fixedWorkingDirFS struct {
+	fs.Local
+	workingDir string
+}
+
+func (f fixedWorkingDirFS) Getwd() (string, error) {
+	return f.workingDir, nil
+}
+
+func decodeAttachments(t *testing.T, raw any) []fileAttachment {
+	t.Helper()
+
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal attachments: %v", err)
+	}
+
+	var attachments []fileAttachment
+	if err := json.Unmarshal(encoded, &attachments); err != nil {
+		t.Fatalf("unmarshal attachments: %v", err)
+	}
+
+	return attachments
+}
+
+// TestPreserveAttachmentsRewritesPaths confirms that an attempt's attachment is copied to a unique,
+// invocation-scoped location and its path is rewritten, while the original is left in place.
+func TestPreserveAttachmentsRewritesPaths(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	// A framework writes a trace to a deterministic per-retry path; a re-invocation would reuse it.
+	traceRel := filepath.Join("test-results", "example-retry1", "trace.zip")
+	if err := os.MkdirAll(filepath.Join(tmp, filepath.Dir(traceRel)), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, traceRel), []byte("trace-contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	results := &v1.TestResults{
+		Tests: []v1.Test{
+			{
+				Name: "example",
+				Attempt: v1.TestAttempt{
+					Meta: map[string]any{
+						"fileAttachments": []fileAttachment{{Name: "trace", Path: traceRel}},
+					},
+				},
+			},
+		},
+	}
+
+	service := Service{FileSystem: fixedWorkingDirFS{workingDir: tmp}}
+	if err := service.preserveAttachments(results, filepath.Join("retry-1", "command-1")); err != nil {
+		t.Fatalf("preserveAttachments: %v", err)
+	}
+
+	attachments := decodeAttachments(t, results.Tests[0].Attempt.Meta["fileAttachments"])
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+
+	wantPrefix := filepath.Join(preservedAttachmentsDir, "retry-1", "command-1")
+	if !strings.HasPrefix(attachments[0].Path, wantPrefix) {
+		t.Fatalf("expected rewritten path under %q, got %q", wantPrefix, attachments[0].Path)
+	}
+	if attachments[0].Path == traceRel {
+		t.Fatal("expected attachment path to be rewritten, but it was unchanged")
+	}
+
+	contents, err := os.ReadFile(filepath.Join(tmp, attachments[0].Path))
+	if err != nil {
+		t.Fatalf("preserved attachment missing: %v", err)
+	}
+	if string(contents) != "trace-contents" {
+		t.Fatalf("preserved contents mismatch: %q", contents)
+	}
+
+	// Original must remain (copied, not moved) so e.g. the Playwright HTML report link stays valid.
+	if _, err := os.Stat(filepath.Join(tmp, traceRel)); err != nil {
+		t.Fatalf("original attachment should remain after preservation: %v", err)
+	}
+}
+
+// TestPreserveAttachmentsSkipsMissingFiles confirms a missing source (already overwritten/removed) is
+// left untouched rather than erroring.
+func TestPreserveAttachmentsSkipsMissingFiles(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	missingRel := filepath.Join("test-results", "gone-retry1", "trace.zip")
+	results := &v1.TestResults{
+		Tests: []v1.Test{
+			{
+				Name: "example",
+				Attempt: v1.TestAttempt{
+					Meta: map[string]any{
+						"fileAttachments": []fileAttachment{{Name: "trace", Path: missingRel}},
+					},
+				},
+			},
+		},
+	}
+
+	service := Service{FileSystem: fixedWorkingDirFS{workingDir: tmp}}
+	if err := service.preserveAttachments(results, "original-attempt"); err != nil {
+		t.Fatalf("preserveAttachments should not error on missing files: %v", err)
+	}
+
+	attachments := decodeAttachments(t, results.Tests[0].Attempt.Meta["fileAttachments"])
+	if attachments[0].Path != missingRel {
+		t.Fatalf("expected missing attachment path to be left unchanged, got %q", attachments[0].Path)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -176,6 +176,13 @@ func (s Service) RunSuite(ctx context.Context, cfg RunConfig) (finalErr error) {
 			return err
 		}
 
+		// Preserve this attempt's attachments before any retry re-invocation overwrites them in place.
+		if shouldPreserveAttachments() {
+			if err := s.preserveAttachments(testResults, originalAttemptID); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		if testResults != nil {
 			tests := make([]v1.Test, len(testResults.Tests))
 			copy(tests, testResults.Tests)
@@ -675,6 +682,13 @@ func (s Service) attemptRetries(
 			newTestResults, newTestResultsFiles, _, err := s.handleCommandOutcome(cfg, cmdErr, retryID)
 			if err != nil {
 				return flattenedTestResults, flattenedNewlyExecutedTestResults, retryID, err
+			}
+
+			// Preserve this invocation's attachments before the next invocation overwrites them in place.
+			if shouldPreserveAttachments() {
+				if err := s.preserveAttachments(newTestResults, ias.attemptScope()); err != nil {
+					return flattenedTestResults, flattenedNewlyExecutedTestResults, retryID, errors.WithStack(err)
+				}
 			}
 
 			if newTestResults != nil {

--- a/internal/cli/utils.go
+++ b/internal/cli/utils.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rwx-research/captain-cli/internal/fs"
 )
 
+const originalAttemptID = "original-attempt"
+
 type IntermediateArtifactStorage struct {
 	basePath   string
 	commandID  string
@@ -29,7 +31,7 @@ func (s Service) NewIntermediateArtifactStorage(path string) (*IntermediateArtif
 		basePath:   path,
 		fs:         s.FileSystem,
 		workingDir: wd,
-		retryID:    "original-attempt",
+		retryID:    originalAttemptID,
 	}
 
 	if path == "" {
@@ -153,12 +155,23 @@ func (ias *IntermediateArtifactStorage) moveFile(srcPath, dstPath string) error 
 		return nil
 	}
 
-	srcFile, err := ias.fs.Open(srcPath)
+	if err := copyFile(ias.fs, srcPath, dstPath); err != nil {
+		return err
+	}
+
+	return errors.WithStack(ias.fs.Remove(srcPath))
+}
+
+func copyFile(fileSystem fs.FileSystem, srcPath, dstPath string) error {
+	srcFile, err := fileSystem.Open(srcPath)
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	defer func() {
+		_ = srcFile.Close()
+	}()
 
-	dstFile, err := ias.fs.Create(dstPath)
+	dstFile, err := fileSystem.Create(dstPath)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -167,24 +180,10 @@ func (ias *IntermediateArtifactStorage) moveFile(srcPath, dstPath string) error 
 	}()
 
 	if _, err = io.Copy(dstFile, srcFile); err != nil {
-		_ = srcFile.Close()
 		return errors.WithStack(err)
 	}
 
-	if err = dstFile.Sync(); err != nil {
-		_ = srcFile.Close()
-		return errors.WithStack(err)
-	}
-
-	if err = srcFile.Close(); err != nil {
-		return errors.WithStack(err)
-	}
-
-	if err = ias.fs.Remove(srcPath); err != nil {
-		return errors.WithStack(err)
-	}
-
-	return nil
+	return errors.WithStack(dstFile.Sync())
 }
 
 func (ias *IntermediateArtifactStorage) delete() error {
@@ -197,4 +196,14 @@ func (ias *IntermediateArtifactStorage) SetCommandID(n int) {
 
 func (ias *IntermediateArtifactStorage) SetRetryID(n int) {
 	ias.retryID = fmt.Sprintf("retry-%d", n)
+}
+
+// attemptScope is a unique-per-invocation path segment used to namespace preserved attachments so
+// re-invocations writing to the same framework paths don't clobber each other.
+func (ias *IntermediateArtifactStorage) attemptScope() string {
+	if ias.commandID != "" {
+		return filepath.Join(ias.retryID, ias.commandID)
+	}
+
+	return ias.retryID
 }

--- a/internal/testingschema/v1/merge.go
+++ b/internal/testingschema/v1/merge.go
@@ -53,13 +53,26 @@ func flatten(unionedTestResults []TestResults) TestResults {
 					// do not flatten skipped statuses into existing tests because they didn't actually run again
 					break
 				}
+				swapped := false
 				if newAttempt.Status.ImpliesFailure() && !newPastAttempt.Status.ImpliesFailure() {
 					newAttempt, newPastAttempt = newPastAttempt, newAttempt
+					swapped = true
 				}
 
-				pastAttempts := make([]TestAttempt, len(baseTest.PastAttempts)+1)
-				copy(pastAttempts, baseTest.PastAttempts)
-				pastAttempts[len(pastAttempts)-1] = newPastAttempt
+				// Preserve the complete attempt history from both sides. The incoming test may carry its
+				// own PastAttempts (e.g. a framework's in-process retries within a single Captain
+				// invocation); dropping them loses attempts and their distinct attachments (traces).
+				pastAttempts := make([]TestAttempt, 0, len(baseTest.PastAttempts)+len(incomingTest.PastAttempts)+1)
+				pastAttempts = append(pastAttempts, baseTest.PastAttempts...)
+				if swapped {
+					// headline stayed on baseTest.Attempt; incomingTest.Attempt becomes the latest past attempt
+					pastAttempts = append(pastAttempts, incomingTest.PastAttempts...)
+					pastAttempts = append(pastAttempts, newPastAttempt)
+				} else {
+					// headline moved to incomingTest.Attempt; baseTest.Attempt precedes incoming's past attempts
+					pastAttempts = append(pastAttempts, newPastAttempt)
+					pastAttempts = append(pastAttempts, incomingTest.PastAttempts...)
+				}
 
 				flattened.Tests[i] = Test{
 					Scope:        baseTest.Scope,

--- a/internal/testingschema/v1/merge_test.go
+++ b/internal/testingschema/v1/merge_test.go
@@ -676,4 +676,126 @@ var _ = Describe("Merge", func() {
 			},
 		))
 	})
+
+	It("preserves the incoming test's own past attempts across batches", func() {
+		int1 := 1
+		id1 := "id1"
+		name1 := "name1"
+		lineage1 := []string{"name", "1"}
+		location1 := v1.Location{File: "file1.rb", Line: &int1}
+
+		baseP0 := "base-p0"
+		baseP1 := "base-p1"
+		baseHeadline := "base-headline"
+		incP0 := "inc-p0"
+		incP1 := "inc-p1"
+		incHeadline := "inc-headline"
+
+		// First invocation: an attempt with its own in-process retries (e.g. a framework retrying).
+		results1 := v1.TestResults{
+			Framework: v1.JavaScriptPlaywrightFramework,
+			Tests: []v1.Test{
+				{
+					ID:       &id1,
+					Name:     name1,
+					Lineage:  lineage1,
+					Location: &location1,
+					Attempt:  v1.TestAttempt{Status: v1.NewFailedTestStatus(&baseHeadline, nil, nil)},
+					PastAttempts: []v1.TestAttempt{
+						{Status: v1.NewFailedTestStatus(&baseP0, nil, nil)},
+						{Status: v1.NewFailedTestStatus(&baseP1, nil, nil)},
+					},
+				},
+			},
+		}
+
+		// Second invocation (a targeted retry) with its own in-process retries.
+		results2 := v1.TestResults{
+			Framework: v1.JavaScriptPlaywrightFramework,
+			Tests: []v1.Test{
+				{
+					ID:       &id1,
+					Name:     name1,
+					Lineage:  lineage1,
+					Location: &location1,
+					Attempt:  v1.TestAttempt{Status: v1.NewFailedTestStatus(&incHeadline, nil, nil)},
+					PastAttempts: []v1.TestAttempt{
+						{Status: v1.NewFailedTestStatus(&incP0, nil, nil)},
+						{Status: v1.NewFailedTestStatus(&incP1, nil, nil)},
+					},
+				},
+			},
+		}
+
+		merged := v1.Merge([]v1.TestResults{results1}, []v1.TestResults{results2})
+
+		Expect(merged.Tests).To(HaveLen(1))
+		Expect(merged.Tests[0].Attempt).To(Equal(
+			v1.TestAttempt{Status: v1.NewFailedTestStatus(&incHeadline, nil, nil)},
+		))
+		// Full chronological history, headline excluded: base's full sequence, then incoming's past.
+		Expect(merged.Tests[0].PastAttempts).To(Equal([]v1.TestAttempt{
+			{Status: v1.NewFailedTestStatus(&baseP0, nil, nil)},
+			{Status: v1.NewFailedTestStatus(&baseP1, nil, nil)},
+			{Status: v1.NewFailedTestStatus(&baseHeadline, nil, nil)},
+			{Status: v1.NewFailedTestStatus(&incP0, nil, nil)},
+			{Status: v1.NewFailedTestStatus(&incP1, nil, nil)},
+		}))
+	})
+
+	It("keeps a passing headline while preserving both sides' past attempts", func() {
+		int1 := 1
+		id1 := "id1"
+		name1 := "name1"
+		lineage1 := []string{"name", "1"}
+		location1 := v1.Location{File: "file1.rb", Line: &int1}
+
+		baseP0 := "base-p0"
+		incP0 := "inc-p0"
+		incHeadline := "inc-headline"
+
+		// First invocation eventually passed.
+		results1 := v1.TestResults{
+			Framework: v1.JavaScriptPlaywrightFramework,
+			Tests: []v1.Test{
+				{
+					ID:       &id1,
+					Name:     name1,
+					Lineage:  lineage1,
+					Location: &location1,
+					Attempt:  v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()},
+					PastAttempts: []v1.TestAttempt{
+						{Status: v1.NewFailedTestStatus(&baseP0, nil, nil)},
+					},
+				},
+			},
+		}
+
+		// A later invocation failed; the passing attempt must remain the headline.
+		results2 := v1.TestResults{
+			Framework: v1.JavaScriptPlaywrightFramework,
+			Tests: []v1.Test{
+				{
+					ID:       &id1,
+					Name:     name1,
+					Lineage:  lineage1,
+					Location: &location1,
+					Attempt:  v1.TestAttempt{Status: v1.NewFailedTestStatus(&incHeadline, nil, nil)},
+					PastAttempts: []v1.TestAttempt{
+						{Status: v1.NewFailedTestStatus(&incP0, nil, nil)},
+					},
+				},
+			},
+		}
+
+		merged := v1.Merge([]v1.TestResults{results1}, []v1.TestResults{results2})
+
+		Expect(merged.Tests).To(HaveLen(1))
+		Expect(merged.Tests[0].Attempt).To(Equal(v1.TestAttempt{Status: v1.NewSuccessfulTestStatus()}))
+		Expect(merged.Tests[0].PastAttempts).To(Equal([]v1.TestAttempt{
+			{Status: v1.NewFailedTestStatus(&baseP0, nil, nil)},
+			{Status: v1.NewFailedTestStatus(&incP0, nil, nil)},
+			{Status: v1.NewFailedTestStatus(&incHeadline, nil, nil)},
+		}))
+	})
 })


### PR DESCRIPTION
[Slack](https://rwxhq.slack.com/archives/C083W41Q399/p1781614993137749)

This addresses two related issues with attachment (e.g. Playwright trace) handling when Captain performs targeted retries by re-invoking the test command. They're split one-per-commit.

## Fix 1 — Attachments overwritten & mis-associated across retries

**Problem.** Frameworks write attachments to deterministic per-retry paths (e.g. `…-Headless-Mode-retry1/trace.zip`). When Captain re-invokes the test command for a targeted retry, each invocation overwrites the previous one's files in place. Attachments are only collected after all retries finish, so only the **final** invocation's files survive on disk — and they get associated with whichever attempt referenced that path. The result: a trace displayed on an earlier attempt actually contains a *later* invocation's run.

**Solution** (`internal/cli/attachment_preservation.go`, wired into `internal/cli/run.go`; helper in `internal/cli/utils.go`):
- After each invocation's results are parsed — the initial attempt and every targeted retry — copy each attempt's attachment files to a unique, invocation-scoped path and rewrite the in-memory `fileAttachments` path to the copy, before the next invocation can overwrite them.
- Gated on RWX context (`RWX_TEST_RESULTS` set), the same signal that enables the `rwx-v1-json` output, so local `captain run` behavior is unchanged.
- Reuses a `copyFile` helper extracted from `IntermediateArtifactStorage.moveFile`; it **copies** rather than moves, so the framework's own report (e.g. the Playwright HTML report) keeps working links to the originals.

## Fix 2 — Merge dropped attempts (and their traces)

**Problem.** `Merge` (`flatten`) kept the base test's `PastAttempts` but carried only the headline `Attempt` from each incoming result, discarding `incomingTest.PastAttempts`. For frameworks that retry **internally** within a single invocation, this dropped real attempts — and with `on-first-retry`-style trace config, the dropped attempts were exactly the ones carrying traces.

**Solution** (`internal/testingschema/v1/merge.go`):
- `flatten` now carries `incomingTest.PastAttempts`, so the merged result holds every invocation's full attempt sequence in chronological order. Headline selection (skip / passing-attempt swap) is unchanged.

**Tradeoff worth noting:** for suites that **stack** framework-internal retries with Captain targeted retries, more attempts are now surfaced (previously only the first invocation's full history plus each later invocation's headline were kept). This is intended — those attempts genuinely executed — and the merged attempt list is what consumers render.

## Tests

- Merge: carried-forward past attempts across invocations, and passing-headline ordering.
- Preservation: copy + path rewrite, and skipping already-overwritten/missing files.

#### Further confirmation needed

- [ ] End-to-end on a real RWX run with `trace: 'on-first-retry'` + Captain `--retries`: confirm the agent resolves the rewritten relative paths and uploads each attempt's distinct trace, and the UI shows each trace on its own attempt with matching content.
- [ ] Confirm the preserved-attachment directory is resolved/collected as expected in the RWX agent environment.