### PR TITLE
Update cloud integration tests to new staging host

### DIFF
--- a/test/cloud_integration_test.go
+++ b/test/cloud_integration_test.go
@@ -19,7 +19,7 @@ var _ = Describe(versionedPrefixForQuarantining()+"Cloud Mode Integration Tests"
 	withAndWithoutInheritedEnv(func(getEnv envGenerator, prefix string) {
 		getEnvWithAccessToken := func() map[string]string {
 			env := getEnv()
-			env["CAPTAIN_HOST"] = "staging.cloud.rwx.com"
+			env["CAPTAIN_HOST"] = "cloud.rwxstaging.com"
 			env["RWX_ACCESS_TOKEN"] = os.Getenv("RWX_ACCESS_TOKEN_STAGING")
 			return env
 		}


### PR DESCRIPTION
### Problem

The staging host moved from `staging.cloud.rwx.com` to `cloud.rwxstaging.com`. The Cloud Mode integration tests hardcoded the old host via `CAPTAIN_HOST`, so every Cloud Mode integration test (across all providers) began failing on `main` once the host changed.

### Solution

- Updated the hardcoded `CAPTAIN_HOST` in `test/cloud_integration_test.go` to `cloud.rwxstaging.com`. This was the only reference to the old host in the repo.

#### Further confirmation needed

- [x] Cloud Mode integration tests pass against the new staging host (verified via RWX run: https://cloud.rwx.com/mint/rwx/runs/50a2dc9e40504609a64eb4b55d957ad1)