### PR TITLE
Emit absolute paths for preserved attachments

### DIFF
--- a/internal/cli/attachment_preservation.go
+++ b/internal/cli/attachment_preservation.go
@@ -110,7 +110,10 @@ func (s Service) preserveAttemptAttachments(attempt *v1.TestAttempt, scope strin
 			return errors.WithStack(err)
 		}
 
-		attachments[i].Path = destRel
+		// Emit an absolute path. The RWX agent resolves these paths, and Captain's working
+		// directory is not necessarily the agent's workspace root (e.g. a monorepo subdirectory),
+		// so a relative path can't be resolved unambiguously on that side.
+		attachments[i].Path = destAbs
 		changed = true
 	}
 

--- a/internal/cli/attachment_preservation_internal_test.go
+++ b/internal/cli/attachment_preservation_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/rwx-research/captain-cli/internal/fs"
@@ -78,15 +77,17 @@ func TestPreserveAttachmentsRewritesPaths(t *testing.T) {
 		t.Fatalf("expected 1 attachment, got %d", len(attachments))
 	}
 
-	wantPrefix := filepath.Join(preservedAttachmentsDir, "retry-1", "command-1")
-	if !strings.HasPrefix(attachments[0].Path, wantPrefix) {
-		t.Fatalf("expected rewritten path under %q, got %q", wantPrefix, attachments[0].Path)
+	// The rewritten path is absolute so the RWX agent can resolve it regardless of Captain's
+	// working directory.
+	wantPath := filepath.Join(tmp, preservedAttachmentsDir, "retry-1", "command-1", traceRel)
+	if attachments[0].Path != wantPath {
+		t.Fatalf("expected rewritten path %q, got %q", wantPath, attachments[0].Path)
 	}
-	if attachments[0].Path == traceRel {
-		t.Fatal("expected attachment path to be rewritten, but it was unchanged")
+	if !filepath.IsAbs(attachments[0].Path) {
+		t.Fatalf("expected an absolute rewritten path, got %q", attachments[0].Path)
 	}
 
-	contents, err := os.ReadFile(filepath.Join(tmp, attachments[0].Path))
+	contents, err := os.ReadFile(attachments[0].Path)
 	if err != nil {
 		t.Fatalf("preserved attachment missing: %v", err)
 	}
@@ -97,6 +98,52 @@ func TestPreserveAttachmentsRewritesPaths(t *testing.T) {
 	// Original must remain (copied, not moved) so e.g. the Playwright HTML report link stays valid.
 	if _, err := os.Stat(filepath.Join(tmp, traceRel)); err != nil {
 		t.Fatalf("original attachment should remain after preservation: %v", err)
+	}
+}
+
+// TestPreserveAttachmentsEmitsAbsolutePathFromSubdirectory confirms the rewritten path is rooted at
+// Captain's working directory even when that directory is a subdirectory (e.g. a monorepo package),
+// so the RWX agent can resolve it without knowing where Captain ran.
+func TestPreserveAttachmentsEmitsAbsolutePathFromSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workingDir := filepath.Join(root, "packages", "app")
+
+	traceRel := filepath.Join("test-results", "example-chromium", "trace.zip")
+	if err := os.MkdirAll(filepath.Join(workingDir, filepath.Dir(traceRel)), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workingDir, traceRel), []byte("trace-contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	results := &v1.TestResults{
+		Tests: []v1.Test{
+			{
+				Name: "example",
+				Attempt: v1.TestAttempt{
+					Meta: map[string]any{
+						"fileAttachments": []fileAttachment{{Name: "trace", Path: traceRel}},
+					},
+				},
+			},
+		},
+	}
+
+	service := Service{FileSystem: fixedWorkingDirFS{workingDir: workingDir}}
+	if err := service.preserveAttachments(results, "original-attempt"); err != nil {
+		t.Fatalf("preserveAttachments: %v", err)
+	}
+
+	attachments := decodeAttachments(t, results.Tests[0].Attempt.Meta["fileAttachments"])
+	wantPath := filepath.Join(workingDir, preservedAttachmentsDir, "original-attempt", traceRel)
+	if attachments[0].Path != wantPath {
+		t.Fatalf("expected rewritten path %q rooted at the working directory, got %q", wantPath, attachments[0].Path)
+	}
+
+	if _, err := os.Stat(attachments[0].Path); err != nil {
+		t.Fatalf("preserved attachment missing at rewritten path: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Background

- Linear: RWX-1181
- Companion to the agent-side change in [rwx-cloud/mint#4544](https://github.com/rwx-cloud/mint/pull/4544). A customer reported Playwright traces no longer showing in the RWX UI for failed tests, with the agent logging "Trace file is missing".

### Problem

Per-attempt attachment preservation rewrites each attachment's path relative to Captain's working directory (`preserveAttemptAttachments` sets `attachments[i].Path = destRel`). Before preservation, the results carried the absolute paths Playwright wrote.

On RWX, the agent resolves these paths but does not know Captain's working directory. That directory is not necessarily the agent's workspace root — for a monorepo suite that runs Captain from a subdirectory, a workspace-relative interpretation drops the subdirectory and the file isn't found. A relative path can't be resolved unambiguously without knowing where Captain ran.

### Solution

- Emit an absolute path for preserved attachments. Captain knows its own working directory, so the absolute path resolves correctly on the agent regardless of where Captain runs, and it matches the format Playwright produced before preservation.
- Tests: the rewritten path is now absolute, plus a new test that runs preservation with a subdirectory working directory and confirms the path is rooted there.

#### Further confirmation needed

- [ ] Confirm a run whose suite invokes Captain from a subdirectory renders traces (the agent-side change alone does not cover that case).
