### PR TITLE
Support minitest-junit output in the Ruby minitest parser

### DIFF
--- a/internal/parsing/.snapshots/RubyMinitestParser Parse parses minitest-junit output
+++ b/internal/parsing/.snapshots/RubyMinitestParser Parse parses minitest-junit output
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rwx-research/test-results-schema/main/v1.json",
+  "framework": {
+    "language": "Ruby",
+    "kind": "minitest"
+  },
+  "summary": {
+    "status": {
+      "kind": "failed"
+    },
+    "tests": 3,
+    "flaky": 0,
+    "otherErrors": 0,
+    "retries": 0,
+    "canceled": 0,
+    "failed": 2,
+    "pended": 0,
+    "quarantined": 0,
+    "skipped": 0,
+    "successful": 1,
+    "timedOut": 0,
+    "todo": 0
+  },
+  "tests": [
+    {
+      "name": "ExampleTest#test_fails",
+      "lineage": [
+        "ExampleTest",
+        "test_fails"
+      ],
+      "location": {
+        "file": "test/example_test.rb",
+        "line": 8
+      },
+      "attempt": {
+        "durationInNanoseconds": 25000,
+        "meta": {
+          "assertions": 1
+        },
+        "status": {
+          "kind": "failed",
+          "message": "intentional failure",
+          "backtrace": [
+            "test/example_test.rb:9:in `test_fails'"
+          ]
+        }
+      }
+    },
+    {
+      "name": "ExampleTest#test_passes",
+      "lineage": [
+        "ExampleTest",
+        "test_passes"
+      ],
+      "location": {
+        "file": "test/example_test.rb",
+        "line": 4
+      },
+      "attempt": {
+        "durationInNanoseconds": 8000,
+        "meta": {
+          "assertions": 1
+        },
+        "status": {
+          "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "ExampleTest#test_raises",
+      "lineage": [
+        "ExampleTest",
+        "test_raises"
+      ],
+      "location": {
+        "file": "test/example_test.rb",
+        "line": 12
+      },
+      "attempt": {
+        "durationInNanoseconds": 211000,
+        "meta": {
+          "assertions": 0
+        },
+        "status": {
+          "kind": "failed",
+          "message": "RuntimeError: uh oh",
+          "backtrace": [
+            "test/example_test.rb:13:in `test_raises'"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/parsing/.snapshots/RubyMinitestParser Parse parses minitest-junit output
+++ b/internal/parsing/.snapshots/RubyMinitestParser Parse parses minitest-junit output
@@ -8,7 +8,7 @@
     "status": {
       "kind": "failed"
     },
-    "tests": 3,
+    "tests": 4,
     "flaky": 0,
     "otherErrors": 0,
     "retries": 0,
@@ -16,36 +16,12 @@
     "failed": 2,
     "pended": 0,
     "quarantined": 0,
-    "skipped": 0,
+    "skipped": 1,
     "successful": 1,
     "timedOut": 0,
     "todo": 0
   },
   "tests": [
-    {
-      "name": "ExampleTest#test_fails",
-      "lineage": [
-        "ExampleTest",
-        "test_fails"
-      ],
-      "location": {
-        "file": "test/example_test.rb",
-        "line": 8
-      },
-      "attempt": {
-        "durationInNanoseconds": 25000,
-        "meta": {
-          "assertions": 1
-        },
-        "status": {
-          "kind": "failed",
-          "message": "intentional failure",
-          "backtrace": [
-            "test/example_test.rb:9:in `test_fails'"
-          ]
-        }
-      }
-    },
     {
       "name": "ExampleTest#test_passes",
       "lineage": [
@@ -57,12 +33,36 @@
         "line": 4
       },
       "attempt": {
-        "durationInNanoseconds": 8000,
+        "durationInNanoseconds": 6000,
         "meta": {
           "assertions": 1
         },
         "status": {
           "kind": "successful"
+        }
+      }
+    },
+    {
+      "name": "ExampleTest#test_fails",
+      "lineage": [
+        "ExampleTest",
+        "test_fails"
+      ],
+      "location": {
+        "file": "test/example_test.rb",
+        "line": 8
+      },
+      "attempt": {
+        "durationInNanoseconds": 5000,
+        "meta": {
+          "assertions": 1
+        },
+        "status": {
+          "kind": "failed",
+          "message": "intentional failure",
+          "backtrace": [
+            "test/example_test.rb:9:in `test_fails'"
+          ]
         }
       }
     },
@@ -77,7 +77,7 @@
         "line": 12
       },
       "attempt": {
-        "durationInNanoseconds": 211000,
+        "durationInNanoseconds": 120000,
         "meta": {
           "assertions": 0
         },
@@ -87,6 +87,26 @@
           "backtrace": [
             "test/example_test.rb:13:in `test_raises'"
           ]
+        }
+      }
+    },
+    {
+      "name": "ExampleTest#test_skips",
+      "lineage": [
+        "ExampleTest",
+        "test_skips"
+      ],
+      "location": {
+        "file": "test/example_test.rb",
+        "line": 16
+      },
+      "attempt": {
+        "durationInNanoseconds": 8000,
+        "meta": {
+          "assertions": 0
+        },
+        "status": {
+          "kind": "skipped"
         }
       }
     }

--- a/internal/parsing/ruby_minitest_parser.go
+++ b/internal/parsing/ruby_minitest_parser.go
@@ -13,7 +13,9 @@ import (
 	v1 "github.com/rwx-research/captain-cli/internal/testingschema/v1"
 )
 
-// Parses https://github.com/minitest-reporters/minitest-reporters/blob/73eea31b1e8b6af88c87f969cfa464d917f00cbb/lib/minitest/reporters/junit_reporter.rb#L16
+// Parses the JUnit XML emitted by either minitest reporter:
+//   - minitest-reporters: https://github.com/minitest-reporters/minitest-reporters/blob/73eea31b1e8b6af88c87f969cfa464d917f00cbb/lib/minitest/reporters/junit_reporter.rb#L16
+//   - minitest-junit:     https://github.com/aespinosa/minitest-junit
 type RubyMinitestParser struct{}
 
 type RubyMinitestFailure struct {
@@ -30,6 +32,7 @@ type RubyMinitestTestCase struct {
 	Error      *RubyMinitestFailure `xml:"error"`
 	Failure    *RubyMinitestFailure `xml:"failure"`
 	File       string               `xml:"file,attr"`
+	Line       int                  `xml:"line,attr"`
 	Lineno     int                  `xml:"lineno,attr"`
 	Name       string               `xml:"name,attr"`
 	Skipped    *RubyMinitestSkipped `xml:"skipped"`
@@ -86,7 +89,11 @@ func (p RubyMinitestParser) Parse(data io.Reader) (*v1.TestResults, error) {
 				status = v1.NewSuccessfulTestStatus()
 			}
 
+			// minitest-reporters emits the line number as `lineno`, minitest-junit as `line`.
 			line := testCase.Lineno
+			if line == 0 {
+				line = testCase.Line
+			}
 			location := v1.Location{File: testCase.File, Line: &line}
 
 			tests = append(
@@ -118,38 +125,66 @@ var (
 )
 
 func (p RubyMinitestParser) NewFailedTestStatus(failure RubyMinitestFailure) v1.TestStatus {
-	failureMessage := failure.Message
-	failureException := failure.Type
+	message := failure.Message
+	var backtrace []string
 
-	if failure.Contents == nil {
-		return v1.NewFailedTestStatus(failureMessage, failureException, nil)
-	}
-
-	lines := rubyMinitestNewlineRegexp.Split(strings.TrimSpace(*failure.Contents), -1)[2:]
-
-	var failureBacktrace []string
-
-	if len(lines) > 0 {
-		failureMessageComponents := make([]string, 0)
-
-		for _, line := range lines {
-			if rubyMinitestBacktraceRegexp.Match([]byte(line)) {
-				failureBacktrace = append(failureBacktrace, strings.TrimSpace(line))
-			} else {
-				failureMessageComponents = append(failureMessageComponents, line)
+	if failure.Contents != nil && rubyMinitestFailureLocationRegexp.MatchString(*failure.Contents) {
+		// minitest-reporters: the detail block and backtrace both live in the body.
+		if m, b := p.parseMinitestDetailBlock(*failure.Contents); m != nil {
+			message, backtrace = m, b
+		}
+		if backtrace == nil {
+			if loc := rubyMinitestFailureLocationRegexp.FindStringSubmatch(*failure.Contents); len(loc) >= 2 {
+				backtrace = []string{loc[1]}
 			}
 		}
-
-		constructedMessage := strings.Join(failureMessageComponents, "\n")
-		failureMessage = &constructedMessage
-	}
-
-	if failureBacktrace == nil {
-		location := rubyMinitestFailureLocationRegexp.FindStringSubmatch(*failure.Contents)
-		if len(location) >= 2 {
-			failureBacktrace = []string{location[1]}
+	} else {
+		// minitest-junit: the detail block is in the `message` attribute and the body is a
+		// single backtrace frame.
+		if failure.Message != nil {
+			if m, _ := p.parseMinitestDetailBlock(*failure.Message); m != nil {
+				message = m
+			}
+		}
+		if failure.Contents != nil {
+			if frame := strings.TrimSpace(*failure.Contents); frame != "" {
+				backtrace = []string{frame}
+			}
 		}
 	}
 
-	return v1.NewFailedTestStatus(failureMessage, failureException, failureBacktrace)
+	return v1.NewFailedTestStatus(message, failure.Type, backtrace)
+}
+
+// parseMinitestDetailBlock extracts the human-readable message and any backtrace frames from a
+// minitest failure/error detail block, formatted as:
+//
+//	Failure:                        (or "Error:")
+//	<identity> [<file>:<line>]:
+//	<message line(s)>
+//	<optional indented backtrace frame(s)>
+//
+// The two leading label/location lines are dropped so the stored message matches across the
+// minitest-reporters and minitest-junit layouts. Returns a nil message when the block is too
+// short to contain one, leaving the caller's fallback in place.
+func (p RubyMinitestParser) parseMinitestDetailBlock(block string) (*string, []string) {
+	lines := rubyMinitestNewlineRegexp.Split(strings.TrimSpace(block), -1)
+	if len(lines) <= 2 {
+		return nil, nil
+	}
+	lines = lines[2:]
+
+	var failureBacktrace []string
+	failureMessageComponents := make([]string, 0)
+
+	for _, line := range lines {
+		if rubyMinitestBacktraceRegexp.Match([]byte(line)) {
+			failureBacktrace = append(failureBacktrace, strings.TrimSpace(line))
+		} else {
+			failureMessageComponents = append(failureMessageComponents, line)
+		}
+	}
+
+	constructedMessage := strings.Join(failureMessageComponents, "\n")
+	return &constructedMessage, failureBacktrace
 }

--- a/internal/parsing/ruby_minitest_parser_test.go
+++ b/internal/parsing/ruby_minitest_parser_test.go
@@ -34,7 +34,7 @@ var _ = Describe("RubyMinitestParser", func() {
 			testResults, err := parsing.RubyMinitestParser{}.Parse(fixture)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(testResults.Tests).To(HaveLen(3))
+			Expect(testResults.Tests).To(HaveLen(4))
 
 			byName := map[string]v1.Test{}
 			for _, test := range testResults.Tests {
@@ -46,6 +46,11 @@ var _ = Describe("RubyMinitestParser", func() {
 			Expect(*passed.Location.Line).To(Equal(4))
 			Expect(passed.Attempt.Status.Kind).To(Equal(v1.TestStatusSuccessful))
 			Expect(passed.Attempt.Meta["assertions"]).To(Equal(1))
+
+			skipped := byName["ExampleTest#test_skips"]
+			Expect(skipped.Location.File).To(Equal("test/example_test.rb"))
+			Expect(*skipped.Location.Line).To(Equal(16))
+			Expect(skipped.Attempt.Status.Kind).To(Equal(v1.TestStatusSkipped))
 
 			failed := byName["ExampleTest#test_fails"]
 			Expect(failed.Location.File).To(Equal("test/example_test.rb"))

--- a/internal/parsing/ruby_minitest_parser_test.go
+++ b/internal/parsing/ruby_minitest_parser_test.go
@@ -27,6 +27,45 @@ var _ = Describe("RubyMinitestParser", func() {
 			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
 		})
 
+		It("parses minitest-junit output", func() {
+			fixture, err := os.Open("../../test/fixtures/minitest_junit.xml")
+			Expect(err).ToNot(HaveOccurred())
+
+			testResults, err := parsing.RubyMinitestParser{}.Parse(fixture)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testResults.Tests).To(HaveLen(3))
+
+			byName := map[string]v1.Test{}
+			for _, test := range testResults.Tests {
+				byName[test.Name] = test
+			}
+
+			passed := byName["ExampleTest#test_passes"]
+			Expect(passed.Location.File).To(Equal("test/example_test.rb"))
+			Expect(*passed.Location.Line).To(Equal(4))
+			Expect(passed.Attempt.Status.Kind).To(Equal(v1.TestStatusSuccessful))
+			Expect(passed.Attempt.Meta["assertions"]).To(Equal(1))
+
+			failed := byName["ExampleTest#test_fails"]
+			Expect(failed.Location.File).To(Equal("test/example_test.rb"))
+			Expect(*failed.Location.Line).To(Equal(8))
+			Expect(failed.Attempt.Status.Kind).To(Equal(v1.TestStatusFailed))
+			Expect(*failed.Attempt.Status.Message).To(Equal("intentional failure"))
+			Expect(failed.Attempt.Status.Backtrace).To(Equal([]string{"test/example_test.rb:9:in `test_fails'"}))
+
+			errored := byName["ExampleTest#test_raises"]
+			Expect(errored.Location.File).To(Equal("test/example_test.rb"))
+			Expect(*errored.Location.Line).To(Equal(12))
+			Expect(errored.Attempt.Status.Kind).To(Equal(v1.TestStatusFailed))
+			Expect(*errored.Attempt.Status.Message).To(Equal("RuntimeError: uh oh"))
+			Expect(errored.Attempt.Status.Backtrace).To(Equal([]string{"test/example_test.rb:13:in `test_raises'"}))
+
+			rwxJSON, err := json.MarshalIndent(testResults, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+			cupaloy.SnapshotT(GinkgoT(), rwxJSON)
+		})
+
 		It("parses empty files", func() {
 			testResults, err := parsing.RubyMinitestParser{}.Parse(strings.NewReader(`<testsuites></testsuites>`))
 			Expect(err).ToNot(HaveOccurred())

--- a/test/fixtures/minitest_junit.xml
+++ b/test/fixtures/minitest_junit.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="minitest" timestamp="2026-07-16T00:00:00+00:00" hostname="ci" tests="3" skipped="0" failures="1" errors="1" time="0.000244">
-    <testcase classname="ExampleTest" name="test_fails" time="0.000025" file="test/example_test.rb" line="8" assertions="1">
+  <testsuite name="minitest" timestamp="2026-07-16T00:00:00+00:00" hostname="ci" tests="4" skipped="1" failures="2" errors="1" time="0.000139">
+    <testcase classname="ExampleTest" name="test_passes" time="0.000006" file="test/example_test.rb" line="4" assertions="1"/>
+    <testcase classname="ExampleTest" name="test_fails" time="0.000005" file="test/example_test.rb" line="8" assertions="1">
       <failure message="Failure:
 ExampleTest#test_fails [test/example_test.rb:9]:
 intentional failure
 ">test/example_test.rb:9:in `test_fails'</failure>
     </testcase>
-    <testcase classname="ExampleTest" name="test_passes" time="0.000008" file="test/example_test.rb" line="4" assertions="1"/>
-    <testcase classname="ExampleTest" name="test_raises" time="0.000211" file="test/example_test.rb" line="12" assertions="0">
+    <testcase classname="ExampleTest" name="test_raises" time="0.000120" file="test/example_test.rb" line="12" assertions="0">
       <error message="Error:
 ExampleTest#test_raises:
 RuntimeError: uh oh
     test/example_test.rb:13:in `test_raises'
 ">test/example_test.rb:13:in `test_raises'</error>
+    </testcase>
+    <testcase classname="ExampleTest" name="test_skips" time="0.000008" file="test/example_test.rb" line="16" assertions="0">
+      <skipped message="Skipped:
+ExampleTest#test_skips [test/example_test.rb:17]:
+not ready
+"></skipped>
     </testcase>
   </testsuite>
 </testsuites>

--- a/test/fixtures/minitest_junit.xml
+++ b/test/fixtures/minitest_junit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="minitest" timestamp="2026-07-16T00:00:00+00:00" hostname="ci" tests="3" skipped="0" failures="1" errors="1" time="0.000244">
+    <testcase classname="ExampleTest" name="test_fails" time="0.000025" file="test/example_test.rb" line="8" assertions="1">
+      <failure message="Failure:
+ExampleTest#test_fails [test/example_test.rb:9]:
+intentional failure
+">test/example_test.rb:9:in `test_fails'</failure>
+    </testcase>
+    <testcase classname="ExampleTest" name="test_passes" time="0.000008" file="test/example_test.rb" line="4" assertions="1"/>
+    <testcase classname="ExampleTest" name="test_raises" time="0.000211" file="test/example_test.rb" line="12" assertions="0">
+      <error message="Error:
+ExampleTest#test_raises:
+RuntimeError: uh oh
+    test/example_test.rb:13:in `test_raises'
+">test/example_test.rb:13:in `test_raises'</error>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## What & why

Captain's Ruby `minitest` parser only understood **minitest-reporters'** JUnit output. That forces Ruby users to give up `bin/rails test --fail-fast` locally, because minitest-reporters registers a plugin that hijacks the reporter chain and displaces Rails' fail-fast reporter. The better-behaved **minitest-junit** gem only *appends* a reporter, so `--fail-fast` keeps working.

The two formats describe identical suites; the differences are purely presentational (`line` vs `lineno`, and where the failure detail lives). Captain now accepts either as a first-class minitest results format, with no regression to minitest-reporters.

## Changes

- Read the line number from `line` (minitest-junit) as well as `lineno` (minitest-reporters), so retries resolve a real `file:line` target instead of `file:0`.
- Handle minitest-junit's failure shape — full detail in the `message` attribute, a single backtrace frame in the body — without panicking on the single-line body, while preserving minitest-reporters parsing exactly (its snapshot is unchanged).

## Testing

- New parser spec + snapshot driven by a fixture captured from **real** `minitest-junit` output. A throwaway project run under both gems confirmed the two produce semantically identical results.
- The fixture covers all four status kinds minitest-junit emits (successful, failed, errored, skipped).
- Full unit suite green; minitest-reporters snapshot byte-identical (no regression); lint clean.
- End-to-end: `captain parse results --language Ruby --framework minitest test/fixtures/minitest_junit.xml` produces correct results with real line numbers and no panic.

## Out of scope

Docs (noting both reporters are supported + the `--fail-fast` trade-off) are tracked separately.

Closes RWX-1321.